### PR TITLE
Hot Patch

### DIFF
--- a/docs/v0/mlflow_mapping_v0.md
+++ b/docs/v0/mlflow_mapping_v0.md
@@ -1,11 +1,14 @@
 # MLflow-Monitor v0 MLflow Mapping Strategy
+
 Date: 2026-03-09
 Status: Draft (Planning)
 
 ## 1. Purpose
+
 This document defines how MLflow-Monitor v0 uses MLflow as both a read source and a write sink while preserving CAST domain semantics and workflow guarantees.
 
 It focuses on:
+
 1. MLflow's two distinct roles in the system.
 2. Namespace and naming strategy.
 3. Entity-to-storage strategy.
@@ -20,24 +23,29 @@ This is not a low-level field dictionary. It is an architectural mapping contrac
 MLflow plays two distinct and strictly separated roles in MLflow-Monitor:
 
 ### 2.1 Role 1: Read Source (Training Experiments)
+
 MLflow training experiments are the input data source for monitoring runs.
 
 Rules:
+
 1. Training runs are read-only. MLflow-Monitor never writes to, modifies, or appends to any training run.
 2. MLflow-Monitor reads metrics, params, tags, and artifacts from existing training runs.
 3. If a training run does not have the inputs required by the recipe, the monitoring run fails explicitly at prepare stage.
 4. No partial reads. Either the required inputs are present or monitoring cannot proceed.
 
 ### 2.2 Role 2: Write Sink (Monitoring Experiments)
+
 MLflow-Monitor owns a dedicated experiment namespace for all monitoring outputs.
 
 Rules:
+
 1. All monitoring outputs are written to system-owned experiments, never to training experiments.
 2. The monitoring experiment namespace is strictly separated from training experiments.
 3. Users never manually name or create monitoring experiments.
 4. The system derives experiment names deterministically from subject identity.
 
 ### 2.3 Why This Separation Matters
+
 1. Training runs remain sacred and untouched — teams trust their MLflow training history is never modified.
 2. Backfill is clean — multiple monitoring runs against the same training run coexist without collision or overwrite.
 3. MLflow experiment lists stay clean — no monitoring clutter mixed with training experiments.
@@ -46,6 +54,7 @@ Rules:
 ## 3. Namespace and Naming Strategy
 
 ### 3.1 Monitoring Experiment Naming Convention
+
 ```
 mlflow_monitor/{subject_id}
 
@@ -56,26 +65,32 @@ Examples:
 ```
 
 ### 3.2 Naming Principles
+
 1. System owns all monitoring experiment names. Users never type monitoring experiment names.
 2. One subject maps to exactly one monitoring experiment. No duplicates, no versioned suffixes.
 3. The `mlflow_monitor/` prefix is reserved and enforced by the gateway module.
 4. Subject IDs are the only naming decision users make — they should be stable, agreed-upon identifiers.
 
 ### 3.3 Why System-Owned Naming
+
 1. Human-managed MLflow naming breaks down at scale — conventions drift, teams diverge, experiments proliferate.
 2. Deterministic naming makes any subject's monitoring history discoverable without documentation.
 3. Grouping under `mlflow_monitor/` prefix makes monitoring experiments visually distinct in the MLflow UI.
 
 ### 3.4 Backfill Semantics
+
 Multiple monitoring runs against the same training run are valid and expected:
+
 ```
 mlflow_monitor/churn_model
   Run: monitor_abc123_2026-03-01    <- original monitoring run
   Run: monitor_abc123_2026-03-09    <- backfill run, coexists cleanly
 ```
+
 No overwrite. No collision. Each monitoring run is a separate record referencing the same source training run.
 
 ## 4. Mapping Design Principles
+
 1. Domain-first semantics: CAST meaning is primary; MLflow is representation.
 2. Training runs are sacred: never modified by MLflow-Monitor.
 3. Explicit lineage: every monitoring run is traceable to its source training run.
@@ -87,7 +102,9 @@ No overwrite. No collision. Each monitoring run is a separate record referencing
 ## 5. Conceptual Entity-to-MLflow Mapping
 
 ### 5.1 Run (Monitoring Run)
+
 Mapped as:
+
 1. A new MLflow run in the `mlflow_monitor/{subject_id}` experiment.
 2. Tag `source_run_id` pointing to the source training run.
 3. Tag `source_experiment` pointing to the source training experiment name.
@@ -97,79 +114,101 @@ Mapped as:
 The source training run is never modified.
 
 ### 5.2 Baseline
+
 Mapped as:
+
 1. A dedicated sentinel MLflow run in `mlflow_monitor/{subject_id}` with tag `role=timeline_config`.
 2. The sentinel run holds tag `baseline_source_run_id` pointing to the designated training run.
 3. A baseline metadata artifact on the sentinel run captures the snapshot context at pin time.
 
 Sentinel run rules:
+
 1. Created once when the timeline is initialized.
 2. Baseline is pinned by writing `baseline_source_run_id` to the sentinel run.
 3. Once pinned, the sentinel run's baseline reference is immutable.
 
 Reasoning:
+
 1. A stable sentinel run is the single source of truth for baseline resolution at prepare stage.
 2. Avoids scattering baseline metadata across individual monitoring runs.
 
 ### 5.3 Timeline
+
 Mapped as:
+
 1. The `mlflow_monitor/{subject_id}` experiment represents the timeline.
 2. A monotonic `sequence_index` tag on each monitoring run provides deterministic temporal ordering.
 3. Sequence index is assigned by the gateway under serialized finalization per subject.
 
 Timeline ordering rule:
+
 1. Each new monitoring run gets `sequence_index = max(existing sequence_index for subject) + 1`.
 2. Assignment is serialized per subject at gateway level. Concurrent finalization is not allowed in v0.
 3. MLflow run IDs and timestamps are never used for ordering — only `sequence_index`.
 
 Reasoning:
+
 1. MLflow run IDs are UUIDs (unordered). Timestamps can collide under concurrent triggers.
 2. Explicit sequence index gives deterministic, unambiguous ordering.
 
 ### 5.4 LKG
+
 Mapped as:
+
 1. Tag `lkg_status=active` on the currently promoted monitoring run.
 2. Tag `lkg_status=superseded` on previously promoted monitoring runs.
 
 LKG resolution rule:
+
 1. At any time there is at most one monitoring run with `lkg_status=active` per subject experiment.
 2. When a new run is promoted, the gateway atomically sets the new run to `active` and the previous LKG to `superseded`.
 3. If no run has `lkg_status=active`, LKG is absent for this timeline.
 4. LKG resolution always queries for the single run with `lkg_status=active` — no ambiguity.
 
 Reasoning:
+
 1. Single explicit active tag avoids ambiguity in LKG resolution.
 2. Superseded tag preserves full promotion history for auditability.
 
 ### 5.5 Contract
+
 Mapped as:
+
 1. Contract identity and version in run metadata tags.
 2. Full contract check outputs in artifacts.
 
 ### 5.6 Diff and Finding
+
 Mapped as:
+
 1. Structured artifacts per reference mode and summary layer.
 2. Optional summary-level metadata tags for quick filtering.
 
 Reasoning:
+
 1. Diffs and findings are potentially high-volume structured records not suited for flat metadata fields.
 
 ## 6. Input Resolution at Prepare Stage
 
 ### 6.1 Source Run Resolution
+
 At prepare stage, the gateway resolves the source training run from MLflow:
+
 1. Reads `source_experiment` and `run_selector` from the compiled recipe.
 2. Resolves the concrete training run ID (latest matching run, or specific `run_id`).
 3. Validates that all `required_metrics` and `required_artifacts` from the recipe are present on that run.
 4. If any required input is missing: monitoring run transitions to `failed` with explicit missing-input reason. No partial analysis proceeds.
 
 ### 6.2 Input Availability Principle
+
 MLflow-Monitor is only as good as what is already in MLflow. If the source training run does not have the required inputs, monitoring fails loudly at prepare — never silently or partially.
 
 ## 7. Write Path Strategy (Execution-Time Persistence)
 
 ### 7.1 Stage-Aligned Writes
+
 Writes to `mlflow_monitor/{subject_id}` reflect workflow stages:
+
 1. On prepare: `source_run_id`, `source_experiment`, `sequence_index`, `baseline_source_run_id` reference, recipe version.
 2. On check: comparability status tag + check artifacts.
 3. On analyze: diff/finding artifacts + summary artifact.
@@ -177,12 +216,15 @@ Writes to `mlflow_monitor/{subject_id}` reflect workflow stages:
 5. On promotion: `lkg_status` tag update (active/superseded).
 
 ### 7.2 Idempotency
+
 Idempotency key: `(subject_id, source_run_id, recipe_id, recipe_version)`.
+
 1. Gateway checks for existing monitoring run matching the idempotency key before creating a new one.
 2. Retry of the same monitoring intent does not create duplicate run records.
 3. Explicit backfill (different recipe version or intentional re-run) creates a new run record deliberately.
 
 ### 7.3 Partial Failure Handling
+
 1. If analysis completes but persistence partially fails, run enters `failed` terminal state.
 2. Failure details indicate which persistence phase failed.
 3. Prevents false "success" for incompletely persisted runs.
@@ -190,6 +232,7 @@ Idempotency key: `(subject_id, source_run_id, recipe_id, recipe_version)`.
 ## 8. Read Path Strategy (Query-Time Semantics)
 
 ### 8.1 Required Query Classes
+
 1. Timeline traversal: retrieve monitoring runs for a subject ordered by `sequence_index`.
 2. Resolve pinned baseline: read `baseline_source_run_id` from sentinel run in subject experiment.
 3. Resolve current active LKG: query for `lkg_status=active` in subject experiment.
@@ -198,20 +241,24 @@ Idempotency key: `(subject_id, source_run_id, recipe_id, recipe_version)`.
 6. Multi-subject query: retrieve timelines for multiple subjects for side-by-side comparison (View 2).
 
 ### 8.2 Read Visibility Rule
-1. Only `closed` monitoring runs are included in timeline traversal and anchor-window queries.
+
+1. `closed` and `failed` monitoring runs are included in timeline traversal and anchor-window queries.
 2. Runs in intermediate lifecycle states (`created`, `prepared`, `checked`, `analyzed`) are not visible in read queries.
 3. `failed` runs are visible in timeline queries with explicit failed status — never silently dropped.
 
 Reasoning:
+
 1. Prevents in-progress runs from polluting trajectory views.
 2. Failed runs remain visible for diagnostics and auditability.
 
 ### 8.3 Determinism Requirements
+
 1. Timeline ordering is always by `sequence_index` — never by timestamp or run ID.
 2. Active LKG resolution returns at most one run deterministically.
 3. Non-comparable runs remain visible in timeline queries with explicit comparability status.
 
 ### 8.4 Performance Posture (v0)
+
 1. Optimize for correctness and clarity first.
 2. Accept moderate query inefficiency in v0 if semantics remain stable.
 3. Defer specialized indexing/caching until usage patterns are clear.
@@ -219,7 +266,9 @@ Reasoning:
 ## 9. Metadata vs Artifact Partitioning
 
 ### 9.1 Metadata/Tags (for filtering and state)
+
 Use tags for:
+
 1. Lifecycle status.
 2. Comparability status.
 3. Sequence index (timeline ordering).
@@ -233,7 +282,9 @@ Use tags for:
 11. Idempotency key fields.
 
 ### 9.2 Artifacts (for structured evidence)
+
 Use artifacts for:
+
 1. Contract check details and reason set.
 2. Diff records (per reference mode).
 3. Finding records.
@@ -242,10 +293,12 @@ Use artifacts for:
 6. Baseline metadata snapshot (on sentinel run).
 
 Reasoning:
+
 1. Tags enable fast coarse retrieval and filtering.
 2. Artifacts preserve rich structured outputs without flattening complexity into flat fields.
 
 ## 10. Consistency Rules
+
 1. Every closed monitoring run must have a corresponding summary artifact.
 2. Every finding must be traceable to diff evidence artifacts.
 3. Comparability `fail` runs must not contain regular metric diff artifacts.
@@ -254,12 +307,14 @@ Reasoning:
 6. Source training run ID must be present and valid on every monitoring run.
 
 ## 11. Mapping Contract Versioning
+
 1. Introduce explicit mapping version tag (`mapping_version=v0`) on all monitoring runs.
 2. Mapping version is queryable per monitoring run.
 3. Any future schema/representation changes require a version bump.
 4. Retrieval logic branches by mapping version when needed.
 
 ## 12. Security and Data Hygiene Considerations
+
 1. Avoid storing sensitive payloads in easily exposed metadata tags.
 2. Keep sensitive detailed outputs in controlled artifacts.
 3. Minimize duplication of large payloads across runs.
@@ -268,45 +323,57 @@ Reasoning:
 ## 13. Operational Risks and Controls
 
 ### 13.1 Risk: Convention Drift
+
 If naming and representation are inconsistent, retrieval breaks.
 
 Control:
+
 1. Centralize all write/read conventions in the gateway module.
 2. `mlflow_monitor/` prefix is enforced by gateway — no writes outside this namespace are allowed.
 3. Validate required mapping elements before close.
 
 ### 13.2 Risk: Retrieval Ambiguity
+
 If sequence or LKG resolution is implicit, different clients may disagree.
 
 Control:
+
 1. Explicit `sequence_index` tag for ordering — timestamps never used for ordering.
 2. Single authoritative LKG resolution rule via `lkg_status=active` tag.
 3. Serialized finalization per subject at gateway level.
 
 ### 13.3 Risk: Artifact Inflation
+
 Large diff/finding payloads can grow quickly.
 
 Control:
+
 1. Structured compact formats for artifacts.
 2. Optional aggregation/sampling views for heavy timelines (deferred).
 
 ### 13.4 Risk: Tight Coupling to MLflow
+
 Future storage evolution becomes costly.
 
 Control:
+
 1. Keep domain and workflow logic MLflow-agnostic.
 2. Encapsulate all MLflow operations behind the gateway module.
 3. Gateway is the only layer that knows about MLflow primitives.
 
 ### 13.5 Risk: Training Run Mutation
+
 Accidental writes to training experiments would break team trust.
 
 Control:
+
 1. Gateway enforces write-only to `mlflow_monitor/` namespace.
 2. Any write attempted outside this namespace is a gateway-level error, never a silent failure.
 
 ## 14. v0 Scope for MLflow Mapping
+
 In scope:
+
 1. MLflow as read source for training run inputs (read-only).
 2. MLflow as write sink for monitoring outputs under `mlflow_monitor/{subject_id}`.
 3. System-owned deterministic experiment naming.
@@ -319,6 +386,7 @@ In scope:
 10. Anchor-window read support over persisted monitoring run outputs.
 
 Deferred:
+
 1. Multi-backend persistence abstraction runtime.
 2. Rich query acceleration subsystem.
 3. Cross-store synchronization/replication.
@@ -326,6 +394,7 @@ Deferred:
 ## 15. Acceptance Scenarios
 
 Scenario 1: Comparable monitoring run
+
 1. Source training run found in training experiment with all required inputs.
 2. Monitoring run created in `mlflow_monitor/{subject_id}` with correct tags.
 3. Run closes with comparable status.
@@ -334,6 +403,7 @@ Scenario 1: Comparable monitoring run
 6. Source training run is unmodified.
 
 Scenario 2: Non-comparable monitoring run
+
 1. Source training run found but contract check fails.
 2. Monitoring run created in `mlflow_monitor/{subject_id}`.
 3. Comparability fail tag written at check stage.
@@ -342,23 +412,27 @@ Scenario 2: Non-comparable monitoring run
 6. Source training run is unmodified.
 
 Scenario 3: LKG promotion
+
 1. Promotion metadata recorded on promoted monitoring run (`lkg_status=active`).
 2. Previous LKG run updated to `lkg_status=superseded`.
 3. Active LKG resolution returns promoted run deterministically.
 4. Subsequent monitoring runs can reference new LKG.
 
 Scenario 4: Anchor-window query
+
 1. Anchor monitoring run resolved.
 2. All later closed runs returned ordered by `sequence_index`.
 3. Mixed comparable/non-comparable runs visible with explicit status.
 
 Scenario 5: Backfill
+
 1. Two monitoring runs created against same source training run.
 2. Both coexist in `mlflow_monitor/{subject_id}` without collision.
 3. Each has a distinct `sequence_index`.
 4. Source training run is unmodified.
 
 Scenario 6: Missing required input at prepare
+
 1. Recipe specifies `required_metrics: [auc, f1]`.
 2. Source training run only has `auc` logged.
 3. Monitoring run transitions to `failed` at prepare stage.
@@ -366,17 +440,22 @@ Scenario 6: Missing required input at prepare
 5. No analysis artifacts produced.
 
 ## 16. Relationship to Other v0 Docs
+
 This mapping strategy depends on:
+
 1. `cast_v0.md` for semantics.
 2. `workflow_v0.md` for stage behavior.
 3. `recipe_v0.md` for configuration provenance and input binding.
 
 And it informs:
+
 1. `acceptance_v0.md` test plan.
 2. Implementation-level metadata/artifact conventions (separate spec).
 
 ## 17. Summary
+
 MLflow-first mapping in v0 is architecturally sound when:
+
 1. MLflow plays two explicit and separated roles: read source (training experiments) and write sink (monitoring experiments).
 2. Training runs are never modified.
 3. Monitoring experiments are system-owned under `mlflow_monitor/{subject_id}`.

--- a/docs/v0/ticket_breakdown_v0.md
+++ b/docs/v0/ticket_breakdown_v0.md
@@ -222,7 +222,7 @@
 - Ordered runs by `sequence_index`
 - Lifecycle and comparability statuses included
 - Non-comparable closed runs visible
-- Failed runs excluded from default views unless explicitly requested
+- Failed runs included from default views unless explicitly requested to be excluded
 - Dependencies: P-002, P-002a
 
 **Q-002: Anchor-window query API** (P0)
@@ -373,11 +373,11 @@
 - New promoted run supersedes prior active LKG
 - Retrieval returns only the active LKG deterministically
 
-**I. Default query views exclude failed runs**
+**I. Default query views include failed runs**
 
 - Failed runs may exist in storage
-- Default timeline / anchor-window views exclude them
-- Explicit retrieval can still request them
+- Default timeline / anchor-window views include them
+- Explicit exclusion can still remove them from views
 
 **J. Baseline remains immutable after bootstrap**
 

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -311,6 +311,7 @@ class InMemoryMonitoringGateway:
         Returns:
             The monitoring namespace for the subject.
         """
+        self._validate_namespace_prefix(self._config.namespace_prefix)
         self._validate_subject_id(subject_id)
         return f"{self._config.namespace_prefix}/{subject_id}"
 
@@ -330,6 +331,20 @@ class InMemoryMonitoringGateway:
             if key.subject_id == subject_id
         }
         return MappingProxyType(bindings)
+
+    def _validate_namespace_prefix(self, prefix: str) -> None:
+        """Validate namespace prefix can safely compose a monitoring namespace.
+
+        Args:
+            prefix: Namespace prefix to validate.
+
+        Returns:
+            None
+        """
+        if not prefix or "/" in prefix:
+            raise GatewayNamespaceViolation(
+                message=(f"namespace_prefix must be non-empty and must not contain '/': {prefix!r}")
+            )
 
     def _validate_subject_id(self, subject_id: str) -> None:
         """Validate subject id can safely compose a monitoring namespace.


### PR DESCRIPTION
* fixed empty namespace_prefix issue - might not be an issue at all, just to be safe.
* updated docs to align on this decision
* from now on, `failed` run should be included on timeline / anchor-based view by default unless explicitly requested to be excluded. the reason is that we do not want any failed run be silently dropped.