### PR TITLE
[MM-16] Define Recipe Schema

### DIFF
--- a/src/mlflow_monitor/recipe.py
+++ b/src/mlflow_monitor/recipe.py
@@ -134,12 +134,19 @@ def parse_recipe_v0_lite(raw: Mapping[str, object]) -> RecipeV0Lite:
         ValueError: If required sections are missing, unknown sections are
             present, or any section value is malformed.
     """
-    missing_sections = sorted(_REQUIRED_TOP_LEVEL_SECTIONS - set(raw.keys()))
+    if not isinstance(raw, Mapping):
+        raise ValueError("Recipe payload must be a mapping.")
+
+    raw_keys = tuple(raw.keys())
+    if any(not isinstance(key, str) for key in raw_keys):
+        raise ValueError("Top-level recipe section names must be strings.")
+
+    missing_sections = sorted(_REQUIRED_TOP_LEVEL_SECTIONS - set(raw_keys))
     if missing_sections:
         missing = ", ".join(missing_sections)
         raise ValueError(f"Missing required recipe section(s): {missing}")
 
-    unknown_sections = sorted(set(raw.keys()) - _REQUIRED_TOP_LEVEL_SECTIONS)
+    unknown_sections = sorted(set(raw_keys) - _REQUIRED_TOP_LEVEL_SECTIONS)
     if unknown_sections:
         unknown = ", ".join(unknown_sections)
         raise ValueError(f"Unknown/disallowed recipe section(s): {unknown}")

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -63,6 +63,22 @@ def test_parse_recipe_v0_lite_rejects_missing_required_top_level_section() -> No
         parse_recipe_v0_lite(raw)
 
 
+def test_parse_recipe_v0_lite_rejects_non_mapping_payload() -> None:
+    with pytest.raises(ValueError, match="Recipe payload must be a mapping."):
+        parse_recipe_v0_lite([])  # type: ignore[arg-type]
+
+
+def test_parse_recipe_v0_lite_rejects_non_string_top_level_section_name() -> None:
+    raw = make_valid_recipe()
+    raw[1] = {"unexpected": "section"}  # type: ignore[index]
+
+    with pytest.raises(
+        ValueError,
+        match="Top-level recipe section names must be strings.",
+    ):
+        parse_recipe_v0_lite(raw)
+
+
 def test_parse_recipe_v0_lite_rejects_non_string_identity_field() -> None:
     raw = make_valid_recipe()
     raw["identity"] = {"recipe_id": 123, "version": "v0"}


### PR DESCRIPTION
- defer JSON/YAML parsing to later ticket [MM-39](https://app.plane.so/five-step-snake/browse/MM-39/).
- changes are implemented in `src/mlflow_monitor/recipe.py` and see `docs/v0/recipe_v0.md` for reference.