### PR TITLE
[MM-45] Repair terminal finalization replay

### DIFF
--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -287,7 +287,7 @@ class MonitoringGateway(Protocol):
         monitoring_run_id: str,
         result: MonitorRunResult,
     ) -> None:
-        """Persist final result payloads and terminal monitoring-run state."""
+        """Ensure final result payloads and terminal monitoring-run state are persisted."""
         ...
 
 

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -601,7 +601,7 @@ class MLflowMonitoringGateway:
         monitoring_run_id: str,
         result: MonitorRunResult,
     ) -> None:
-        """Write the final result artifact and terminate the MLflow run.
+        """Ensure the final result artifact exists and the MLflow run is terminal.
 
         Args:
             monitoring_run_id: Monitoring run id being finalized.
@@ -616,15 +616,22 @@ class MLflowMonitoringGateway:
             raise ValueError(
                 "finalize_monitoring_run_result supports only CHECKED and FAILED terminal results."
             )
-        self._mlflow.log_monitoring_run_json_artifact(
-            monitoring_run_id,
-            result.to_dict(),
-            _RESULT_ARTIFACT_PATH,
+
+        expected_mlflow_status = (
+            "FINISHED" if result.lifecycle_status is LifecycleStatus.CHECKED else "FAILED"
         )
-        if result.lifecycle_status is LifecycleStatus.CHECKED:
-            self._mlflow.terminate_monitoring_run(monitoring_run_id, "FINISHED")
-            return
-        self._mlflow.terminate_monitoring_run(monitoring_run_id, "FAILED")
+        artifact_paths = self._mlflow.list_artifact_paths(monitoring_run_id)
+        if _RESULT_ARTIFACT_PATH not in artifact_paths:
+            self._mlflow.log_monitoring_run_json_artifact(
+                monitoring_run_id,
+                result.to_dict(),
+                _RESULT_ARTIFACT_PATH,
+            )
+
+        run = self._mlflow.get_run(monitoring_run_id)
+        current_status = None if run is None else run.info.status
+        if current_status != expected_mlflow_status:
+            self._mlflow.terminate_monitoring_run(monitoring_run_id, expected_mlflow_status)
 
     def build_monitoring_namespace(self, subject_id: str) -> str:
         """Build the monitoring experiment name for one subject.

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -171,7 +171,7 @@ def _short_circuit_existing_monitoring_run(
         return state
 
     if state.existing_monitoring_run.lifecycle_status is LifecycleStatus.FAILED:
-        return _build_failure_monitoring_run_result(
+        result = _build_failure_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
             stage="prepare",
@@ -181,6 +181,11 @@ def _short_circuit_existing_monitoring_run(
             ),
             gateway=gateway,
         )
+        gateway.finalize_monitoring_run_result(
+            monitoring_run_id=state.monitoring_run_id,
+            result=result,
+        )
+        return result
 
     if state.existing_monitoring_run.contract_check_result is None:
         return state
@@ -200,12 +205,17 @@ def _short_circuit_existing_monitoring_run(
             gateway=gateway,
         )
 
-    return _build_existing_checked_monitoring_run_result(
+    result = _build_existing_checked_monitoring_run_result(
         subject_id=state.subject_id,
         monitoring_run_id=state.monitoring_run_id,
         existing_monitoring_run=state.existing_monitoring_run,
         gateway=gateway,
     )
+    gateway.finalize_monitoring_run_result(
+        monitoring_run_id=state.monitoring_run_id,
+        result=result,
+    )
+    return result
 
 
 def _run_prepare_monitoring_run_slice(
@@ -275,12 +285,17 @@ def _run_check_monitoring_run_slice(
     """Run the check slice, including persistence and success replay handling."""
     existing_run = gateway.get_monitoring_run(state.subject_id, state.monitoring_run_id)
     if existing_run is not None and existing_run.contract_check_result is not None:
-        return _build_existing_checked_monitoring_run_result(
+        result = _build_existing_checked_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
             existing_monitoring_run=existing_run,
             gateway=gateway,
         )
+        gateway.finalize_monitoring_run_result(
+            monitoring_run_id=state.monitoring_run_id,
+            result=result,
+        )
+        return result
 
     try:
         contract_check_result = execute_contract_check(

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -7,13 +7,49 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import pytest
 from mlflow import MlflowClient
 
-from mlflow_monitor.contract_checker import DefaultContractChecker
-from mlflow_monitor.domain import ComparabilityStatus, LifecycleStatus, MonitoringRunReference
+from mlflow_monitor.contract_checker import (
+    ContractEvaluationContext,
+    DefaultContractChecker,
+)
+from mlflow_monitor.domain import (
+    ComparabilityStatus,
+    Contract,
+    ContractCheckResult,
+    LifecycleStatus,
+    MonitoringRunReference,
+)
 from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.orchestration import run_orchestration
+from mlflow_monitor.result_contract import MonitorRunResult
+
+
+class FailingFinalizeMLflowMonitoringGateway(MLflowMonitoringGateway):
+    """Simulate finalization failure after orchestration persists terminal tags."""
+
+    def finalize_monitoring_run_result(
+        self,
+        *,
+        monitoring_run_id: str,
+        result: MonitorRunResult,
+    ) -> None:
+        _ = (monitoring_run_id, result)
+        raise RuntimeError("simulated finalization failure")
+
+
+class ExplodingContractChecker:
+    """Fail the test if checked replay re-enters contract evaluation."""
+
+    def check(
+        self,
+        contract: Contract,
+        context: ContractEvaluationContext,
+    ) -> ContractCheckResult:
+        _ = (contract, context)
+        raise AssertionError("idempotent replay must not re-run check")
 
 
 def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(
@@ -86,6 +122,87 @@ def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(
     payload = json.loads((artifact_dir / "result.json").read_text())
     assert payload["monitoring_run_id"] == result.monitoring_run_id
     assert payload["lifecycle_status"] == "checked"
+
+
+def test_mlflow_gateway_checked_replay_repairs_incomplete_terminal_finalization(
+    tracking_uri: str,
+    artifact_root_uri: str,
+    create_training_run: Callable[..., str],
+) -> None:
+    raw = MlflowClient(tracking_uri=tracking_uri)
+    baseline_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="baseline",
+        metrics={"f1": 0.87},
+        params={"feature_columns": "age"},
+        tags={
+            "python_version": "3.12",
+            "schema.age": "int",
+            "data_scope": "validation:2026-03-01",
+        },
+    )
+    current_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="current",
+        metrics={"f1": 0.91},
+        params={"feature_columns": "age"},
+        tags={
+            "python_version": "3.12",
+            "schema.age": "int",
+            "data_scope": "validation:2026-03-01",
+        },
+    )
+    partial_gateway = FailingFinalizeMLflowMonitoringGateway(
+        GatewayConfig(),
+        tracking_uri=tracking_uri,
+        artifact_location=artifact_root_uri,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated finalization failure"):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id=current_run_id,
+            baseline_source_run_id=baseline_run_id,
+            gateway=partial_gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    experiment = raw.get_experiment_by_name("mlflow_monitor/churn_model")
+    assert experiment is not None
+    monitoring_run_id = experiment.tags[f"training.{current_run_id}.monitoring_run_id"]
+    monitoring_run_before = raw.get_run(monitoring_run_id)
+    assert monitoring_run_before.info.status == "RUNNING"
+    assert monitoring_run_before.data.tags["monitoring.lifecycle_status"] == "checked"
+    assert raw.list_artifacts(monitoring_run_id, "outputs") == []
+
+    repairing_gateway = MLflowMonitoringGateway(
+        GatewayConfig(),
+        tracking_uri=tracking_uri,
+        artifact_location=artifact_root_uri,
+    )
+    replay = run_orchestration(
+        subject_id="churn_model",
+        source_run_id=current_run_id,
+        baseline_source_run_id=None,
+        gateway=repairing_gateway,
+        contract_checker=ExplodingContractChecker(),
+    )
+
+    monitoring_run_after = raw.get_run(monitoring_run_id)
+    artifact_dir = Path(raw.download_artifacts(monitoring_run_id, "outputs"))
+    payload = json.loads((artifact_dir / "result.json").read_text())
+
+    assert replay.monitoring_run_id == monitoring_run_id
+    assert replay.lifecycle_status is LifecycleStatus.CHECKED
+    assert replay.comparability_status is ComparabilityStatus.PASS
+    assert monitoring_run_after.info.status == "FINISHED"
+    assert payload["monitoring_run_id"] == monitoring_run_id
+    assert payload["lifecycle_status"] == "checked"
+    assert payload["comparability_status"] == "pass"
 
 
 def test_mlflow_gateway_reuses_baseline_resolves_previous_and_idempotent_rerun(

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -39,6 +40,10 @@ def _make_result(
             )
         ),
     )
+
+
+def _make_mlflow_run(status: str) -> SimpleNamespace:
+    return SimpleNamespace(info=SimpleNamespace(status=status))
 
 
 def test_create_or_reuse_monitoring_run_writes_idempotency_tag_last() -> None:
@@ -146,6 +151,72 @@ def test_finalize_monitoring_run_result_persists_artifact_and_termination(
         "monitoring-run-1",
         expected_mlflow_status,
     )
+
+
+@pytest.mark.parametrize(
+    ("lifecycle_status", "expected_mlflow_status"),
+    [
+        (LifecycleStatus.CHECKED, "FINISHED"),
+        (LifecycleStatus.FAILED, "FAILED"),
+    ],
+)
+@pytest.mark.parametrize(
+    (
+        "artifact_paths",
+        "current_mlflow_status",
+        "should_log_artifact",
+        "should_terminate",
+    ),
+    [
+        (["outputs/result.json"], "EXPECTED", False, False),
+        ([], "EXPECTED", True, False),
+        (["outputs/result.json"], "RUNNING", False, True),
+        ([], "RUNNING", True, True),
+    ],
+)
+def test_finalize_monitoring_run_result_repairs_only_missing_terminal_side_effects(
+    lifecycle_status: LifecycleStatus,
+    expected_mlflow_status: str,
+    artifact_paths: list[str],
+    current_mlflow_status: str,
+    should_log_artifact: bool,
+    should_terminate: bool,
+) -> None:
+    stub_client = MagicMock()
+    stub_client.list_artifact_paths.return_value = artifact_paths
+    stub_client.get_run.return_value = _make_mlflow_run(
+        expected_mlflow_status if current_mlflow_status == "EXPECTED" else current_mlflow_status
+    )
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    result = _make_result(
+        monitoring_run_id="monitoring-run-1",
+        lifecycle_status=lifecycle_status,
+    )
+
+    gateway.finalize_monitoring_run_result(
+        monitoring_run_id="monitoring-run-1",
+        result=result,
+    )
+
+    if should_log_artifact:
+        stub_client.log_monitoring_run_json_artifact.assert_called_once_with(
+            "monitoring-run-1",
+            result.to_dict(),
+            "outputs/result.json",
+        )
+    else:
+        stub_client.log_monitoring_run_json_artifact.assert_not_called()
+
+    if should_terminate:
+        stub_client.terminate_monitoring_run.assert_called_once_with(
+            "monitoring-run-1",
+            expected_mlflow_status,
+        )
+    else:
+        stub_client.terminate_monitoring_run.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -309,7 +309,7 @@ def test_run_orchestration_finalizes_newly_checked_run_once() -> None:
     assert gateway.finalized_results[0].lifecycle_status is LifecycleStatus.CHECKED
 
 
-def test_run_orchestration_checked_rerun_does_not_finalize_again() -> None:
+def test_run_orchestration_checked_rerun_finalizes_for_repair() -> None:
     gateway = FinalizingGateway(GatewayConfig())
     for source_run_id, metrics in (
         ("train-run-baseline", {"f1": 0.87}),
@@ -344,8 +344,10 @@ def test_run_orchestration_checked_rerun_does_not_finalize_again() -> None:
 
     assert second.monitoring_run_id == first.monitoring_run_id
     assert [finalized.monitoring_run_id for finalized in gateway.finalized_results] == [
-        first.monitoring_run_id
+        first.monitoring_run_id,
+        first.monitoring_run_id,
     ]
+    assert gateway.finalized_results[1].lifecycle_status is LifecycleStatus.CHECKED
 
 
 def test_run_orchestration_finalizes_owned_failure_once() -> None:
@@ -375,6 +377,46 @@ def test_run_orchestration_finalizes_owned_failure_once() -> None:
         result.monitoring_run_id
     ]
     assert gateway.finalized_results[0].lifecycle_status is LifecycleStatus.FAILED
+
+
+def test_run_orchestration_failed_rerun_finalizes_for_repair() -> None:
+    gateway = FinalizingGateway(GatewayConfig())
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-baseline",
+        source_experiment=None,
+        metrics={"f1": 0.87},
+        artifacts=("metrics.json",),
+        environment={"python": "3.12"},
+        features=("age",),
+        schema={"age": "int"},
+        data_scope="validation:2026-03-01",
+    )
+
+    first = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-missing",
+        baseline_source_run_id="train-run-baseline",
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+    second = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-missing",
+        baseline_source_run_id="train-run-baseline",
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    assert second.monitoring_run_id == first.monitoring_run_id
+    assert second.lifecycle_status is LifecycleStatus.FAILED
+    assert second.error is not None
+    assert second.error.code == "idempotent_run_retry_failed_terminal"
+    assert [finalized.monitoring_run_id for finalized in gateway.finalized_results] == [
+        first.monitoring_run_id,
+        first.monitoring_run_id,
+    ]
+    assert gateway.finalized_results[1].lifecycle_status is LifecycleStatus.FAILED
 
 
 def test_run_orchestration_non_comparable_check_still_returns_checked_result() -> None:


### PR DESCRIPTION
## Summary
- this is a fix for issue #45 
- Repair terminal idempotent replay by finalizing reconstructed checked and failed replay results before returning.
- Make MLflow finalization idempotent so missing `outputs/result.json` and incomplete MLflow terminal status are repaired independently.
- Add orchestration, gateway unit, and real-MLflow integration coverage for the repair path.

## Root Cause
Terminal lifecycle/check state could be persisted before final MLflow side effects completed. A later idempotent replay then returned cached terminal state without retrying missing finalization work.

## Validation
- `uv run pytest tests/test_monitor.py tests/test_mlflow_gateway_unit.py tests/integration/test_mlflow_gateway.py`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format .`
- `uv build`