### PR TITLE
Recover partial allocation writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Purpose
+
+MLflow-Monitor is a baseline-aware model monitoring package for MLflow.
+
+Prefer architectural correctness, explicit behavior, and small reviewable changes over speed or breadth.
+
+## Working rules
+
+- Work ticket-by-ticket.
+- Keep diffs small and reviewable.
+- Only add code that is necessary for the current ticket.
+- Do not broaden scope beyond the requested ticket.
+- Preserve existing behavior unless the task explicitly changes it.
+- Prefer the simplest implementation that satisfies the current ticket.
+- Avoid speculative abstractions or future-facing indirection unless required by the current ticket.
+- Look for relevant local skills under `.codex/skills/` before starting implementation or review work.
+- Use the local `tdd` skill for behavior-changing work; skip it for docs-only or formatting-only edits.
+- Use the local `seeking-design-truth` skill for ticket-driven work, design questions, behavior clarification, and other tasks that need grounding in the repo's design docs before implementation or review.
+- Use the local `commit-discipline` skill for commit follow-through after green ticket slices.
+- Commit very frequently by default.
+- Do not log PII.
+
+## Review rules
+
+- Default to a code review mindset when asked to review.
+- Prioritize correctness issues, behavioral regressions, edge cases, and missing tests.
+- Treat findings as the primary output; keep summaries brief and secondary.
+- Order findings by severity and include file references when possible.
+- Call out assumptions, unclear intent, or test gaps when they affect confidence.
+- If no findings are discovered, say so explicitly and note any residual risks or coverage gaps.
+- Do not focus on style-only feedback unless it affects correctness, maintainability, or project consistency.
+
+## Documentation
+
+- Use Google-style docstrings for public runtime modules, classes, and functions under `src/mlflow_monitor/`.
+- Keep docstrings concise and focused on purpose, inputs, returns, and important failure behavior.
+
+## Validation
+
+Use Python 3.12+ and `uv`.
+
+```bash
+uv sync --extra dev
+uv run pytest
+uv run ruff check .
+uv run ruff format .
+uv build
+```
+
+## Branch naming
+
+- `MM-{number}/{ticket-number}-xxx` for ticket branches.
+- `zs/` for hotfixes, revisions, or similar work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,5 +51,17 @@ uv build
 
 ## Branch naming
 
-- `MM-{number}/{ticket-number}-xxx` for ticket branches.
-- `zs/` for hotfixes, revisions, or similar work.
+- For Plane work items with an internal ticket, use
+  `MM-<plane-work-item-number>/<ticket-id>-<short-description>`.
+- For GitHub issues, use
+  `issue/<github-issue-number>-<short-description>`.
+- For exploratory work, use `spike/<short-description>`.
+- For other work, use a concise descriptive branch name.
+- Use lowercase, hyphen-separated descriptions.
+- Continue revisions on the original branch when possible.
+
+## Commit messages
+
+- Describe the change concisely in plain language.
+- Use specialized engineering terminology only when it explains the change more precisely.
+- Do not require ticket prefixes, category labels, or Conventional Commit syntax.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,8 @@ uv build
 - Describe the change concisely in plain language.
 - Use specialized engineering terminology only when it explains the change more precisely.
 - Do not require ticket prefixes, category labels, or Conventional Commit syntax.
+
+## Plane
+
+- Use Plane only when the user explicitly requests it or identifies a Plane work item.
+- Treat Plane as read-only unless the user explicitly requests a change.

--- a/docs/site/source/architecture.md
+++ b/docs/site/source/architecture.md
@@ -20,7 +20,7 @@ flowchart LR
 
     subgraph Monitoring["Monitoring Side"]
         MonExp[("MLflow: mlflow_monitor/{subject_id}")]
-        Timeline["Timeline state\nbaseline, latest run, sequence index"]
+        Timeline["Timeline state and index\nbaseline, latest run, sequence index"]
         MonRuns["Monitoring runs\nlifecycle, comparability, result artifact"]
     end
 
@@ -57,9 +57,9 @@ MLflow-Monitor reads from those runs but does not mutate them.
 
 MLflow-Monitor creates one monitoring experiment per subject. For example, `training/fraud_model` contains source training runs, and `mlflow_monitor/fraud_model` contains monitoring runs for that subject.
 
-The monitoring experiment holds timeline-level state: the pinned baseline, the latest monitoring run id, the next sequence index, and indexed run references for timeline traversal. These exist at the experiment level because they are properties of the subject's history, not of any individual monitoring run.
+The monitoring experiment holds timeline-level state: the pinned baseline, the latest monitoring run id, the next sequence index, and indexed run references for timeline traversal. The allocation index is a repairable projection: before creating or reusing a run, the gateway validates it against the durable allocation identity stored on monitoring runs and repairs uniquely recoverable partial writes.
 
-Each monitoring run holds its own evaluation state: lifecycle status, comparability status, baseline and other references, and the final `outputs/result.json` artifact. These exist at the run level because they are specific to one evaluation event.
+Each monitoring run holds its allocation identity (source run, recipe identity, and sequence index) and its evaluation state: lifecycle status, comparability status, baseline and other references, and the final `outputs/result.json` artifact. These exist at the run level because they are specific to one evaluation event.
 
 ## Why This Split Matters
 

--- a/src/mlflow_monitor/mlflow_client.py
+++ b/src/mlflow_monitor/mlflow_client.py
@@ -225,7 +225,7 @@ class MonitorMLflowClient:
         experiment_id: str,
         tag_key: str,
     ) -> tuple[MonitoringRunTagSnapshot, ...]:
-        """Return active monitoring runs containing one tag.
+        """Return non-deleted monitoring runs containing one tag.
 
         MLflow search results are paginated and expose mutable MLflow entities.
         This adapter exhausts all result pages and returns detached snapshots so

--- a/src/mlflow_monitor/mlflow_client.py
+++ b/src/mlflow_monitor/mlflow_client.py
@@ -13,13 +13,14 @@ What belongs here:
 - Deterministic normalization of a few MLflow-specific quirks
 - Read helpers that expose plain Python values where that reduces MLflow
   leakage into later gateway code
+- Paginated tag-filtered discovery of monitoring-owned runs
 
 What does not belong here:
 --------------------------
 
 - Workflow or orchestration logic
 - Monitoring domain policy
-- Broader query functionality such as run search
+- General-purpose query functionality beyond narrow monitoring-run discovery
 - Public Python API configuration policy beyond accepting an optional tracking URI
 """
 
@@ -27,10 +28,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from mlflow import MlflowClient
-from mlflow.entities import Experiment, Run
+from mlflow.entities import Experiment, Run, ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
 
@@ -60,6 +62,23 @@ class MonitoringRunInfo:
 
     run_id: str
     run_name: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MonitoringRunTagSnapshot:
+    """Detached run identifier and immutable tag snapshot.
+
+    Attributes:
+        run_id: MLflow run identifier.
+        tags: Immutable copy of the run's tags.
+    """
+
+    run_id: str
+    tags: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        """Defensively copy and freeze the supplied tag mapping."""
+        object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
 
 
 class MonitorMLflowClient:
@@ -200,6 +219,42 @@ class MonitorMLflowClient:
         """
         run = self._client.create_run(experiment_id, tags=dict(tags), run_name=source_run_name)
         return MonitoringRunInfo(run_id=run.info.run_id, run_name=run.info.run_name)
+
+    def list_monitoring_runs_with_tag(
+        self,
+        experiment_id: str,
+        tag_key: str,
+    ) -> tuple[MonitoringRunTagSnapshot, ...]:
+        """Return active monitoring runs containing one tag.
+
+        MLflow search results are paginated and expose mutable MLflow entities.
+        This adapter exhausts all result pages and returns detached snapshots so
+        gateway policy does not depend on MLflow search or entity types.
+
+        Args:
+            experiment_id: Monitoring experiment identifier to search.
+            tag_key: Tag key that must be present on returned runs.
+
+        Returns:
+            Immutable run-and-tag snapshots in MLflow's returned order.
+        """
+        snapshots: list[MonitoringRunTagSnapshot] = []
+        page_token: str | None = None
+        filter_string = f"tags.`{tag_key}` IS NOT NULL"
+        while True:
+            page = self._client.search_runs(
+                experiment_ids=[experiment_id],
+                filter_string=filter_string,
+                run_view_type=ViewType.ACTIVE_ONLY,
+                max_results=1000,
+                page_token=page_token,
+            )
+            snapshots.extend(
+                MonitoringRunTagSnapshot(run_id=run.info.run_id, tags=run.data.tags) for run in page
+            )
+            page_token = page.token
+            if not page_token:
+                return tuple(snapshots)
 
     def get_run(self, run_id: str) -> Run | None:
         """Return any MLflow run, or `None` when MLflow reports it as missing.

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -1,12 +1,14 @@
 """Real-MLflow monitoring gateway for the current create/prepare/check workflow.
 
 This module is the runtime implementation of the `MonitoringGateway` protocol
-for the real-MLflow path. It intentionally does not use `search_runs()`;
-all timeline discovery is driven by:
+for the real-MLflow path. Normal timeline reads are driven by:
 
 1. One monitoring experiment per subject, named `{namespace_prefix}/{subject_id}`.
 2. Experiment tags that act as the timeline index.
 3. Direct `get_run()` calls for both training and monitoring runs.
+
+Monitoring-run allocation additionally uses a narrow active-run search to
+reconcile partial experiment-index writes from durable run identity tags.
 
 Design constraints that matter here:
 
@@ -14,8 +16,8 @@ Design constraints that matter here:
   tags, and artifact paths on training runs, but it must never mutate them.
 - Monitoring-run allocation is gateway-owned because MLflow assigns run ids at
   `create_run()` time.
-- The experiment-tag index is the source of truth for ordered monitoring-run
-  traversal and idempotency.
+- Monitoring-run identity tags are the allocation source of truth, while the
+  experiment-tag timeline index is a repairable projection used by normal reads.
 - Final run output is stored as `outputs/result.json` and the MLflow run is
   explicitly terminated by the gateway once orchestration reaches a terminal
   success or owned-failure outcome.
@@ -29,6 +31,7 @@ supports.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
 from mlflow_monitor.contract_checker import ContractEvidence
 from mlflow_monitor.domain import (
@@ -37,7 +40,11 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
     MonitoringRunReference,
 )
-from mlflow_monitor.errors import GatewayNamespaceViolation, TrainingRunMutationViolation
+from mlflow_monitor.errors import (
+    GatewayConsistencyViolation,
+    GatewayNamespaceViolation,
+    TrainingRunMutationViolation,
+)
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
     GatewayConfig,
@@ -46,7 +53,7 @@ from mlflow_monitor.gateway import (
     TimelineInitializationResult,
     TimelineState,
 )
-from mlflow_monitor.mlflow_client import MonitorMLflowClient
+from mlflow_monitor.mlflow_client import MonitoringRunTagSnapshot, MonitorMLflowClient
 from mlflow_monitor.recipe import SYSTEM_DEFAULT_RUN_SELECTOR_TOKEN
 from mlflow_monitor.result_contract import MonitorRunResult
 
@@ -66,6 +73,15 @@ _REFERENCE_TAG_PREFIX = "monitoring.reference."
 _RESULT_ARTIFACT_PATH = "outputs/result.json"
 _VISIBLE_NON_FAILED_STATUSES = frozenset({LifecycleStatus.CHECKED, LifecycleStatus.CLOSED})
 _REFERENCE_KINDS = ("baseline", "previous", "lkg", "custom")
+
+
+@dataclass(frozen=True, slots=True)
+class _MonitoringRunAllocation:
+    """Durable monitoring-run allocation identity reconstructed from run tags."""
+
+    key: IdempotencyKey
+    monitoring_run_id: str
+    sequence_index: int
 
 
 class MLflowMonitoringGateway:
@@ -110,14 +126,12 @@ class MLflowMonitoringGateway:
     def create_or_reuse_monitoring_run(
         self, key: IdempotencyKey
     ) -> CreateOrReuseMonitoringRunResult:
-        """Create or reuse a monitoring run using experiment-tag indexes.
+        """Create or reuse a monitoring run after reconciling allocation state.
 
-        The idempotency source of truth is the experiment tag
-        `training.{source_run_id}.monitoring_run_id`. If it exists, this method
-        returns the already-allocated monitoring run and attempts to reconstruct
-        its persisted state. If it does not exist, the gateway allocates the
-        next sequence index, creates the MLflow monitoring run, and updates the
-        experiment-tag index.
+        Monitoring-run identity tags are the durable allocation record. Before
+        allocating, the gateway validates those records and repairs their
+        experiment-tag timeline projection. Ambiguous or contradictory state
+        fails closed rather than risking a duplicate allocation.
 
         Args:
             key: Canonical monitoring intent identity.
@@ -128,29 +142,23 @@ class MLflowMonitoringGateway:
         self._validate_subject_id(key.subject_id)
         experiment_id = self._get_or_create_experiment_id(key.subject_id)
         experiment_tags = self._mlflow.get_monitoring_experiment_tags(experiment_id)
-        idempotency_tag = self._idempotency_tag(key.source_run_id)
-        existing_monitoring_run_id = experiment_tags.get(idempotency_tag)
-        if existing_monitoring_run_id:
-            existing_monitoring_run, recipe_identity_matches = self._resolve_existing_binding(
-                subject_id=key.subject_id,
-                monitoring_run_id=existing_monitoring_run_id,
-                recipe_id=key.recipe_id,
-                recipe_version=key.recipe_version,
+        allocations_by_key, sequence_index = self._reconcile_monitoring_run_allocations(
+            subject_id=key.subject_id,
+            experiment_id=experiment_id,
+            experiment_tags=experiment_tags,
+        )
+        existing_allocation = allocations_by_key.get(key)
+        if existing_allocation is not None:
+            return CreateOrReuseMonitoringRunResult(
+                monitoring_run_id=existing_allocation.monitoring_run_id,
+                sequence_index=existing_allocation.sequence_index,
+                existing_monitoring_run=self.get_monitoring_run(
+                    key.subject_id,
+                    existing_allocation.monitoring_run_id,
+                ),
+                allocated=False,
             )
-            if recipe_identity_matches:
-                sequence_index = (
-                    existing_monitoring_run.sequence_index
-                    if existing_monitoring_run is not None
-                    else self._resolve_sequence_index(experiment_tags, existing_monitoring_run_id)
-                )
-                return CreateOrReuseMonitoringRunResult(
-                    monitoring_run_id=existing_monitoring_run_id,
-                    sequence_index=sequence_index,
-                    existing_monitoring_run=existing_monitoring_run,
-                    allocated=False,
-                )
 
-        sequence_index = self._read_next_sequence_index(experiment_tags)
         source_run_name = self._mlflow.get_run_name(key.source_run_id)
         # MLflow assigns the monitoring run id, so the gateway has to create the
         # run before it can finish updating the experiment-level timeline index.
@@ -171,7 +179,7 @@ class MLflowMonitoringGateway:
                 f"{_RUN_TAG_PREFIX}{sequence_index}": monitoring_run_info.run_id,
                 _LATEST_TAG: monitoring_run_info.run_id,
                 _NEXT_SEQUENCE_TAG: str(sequence_index + 1),
-                idempotency_tag: monitoring_run_info.run_id,
+                self._idempotency_tag(key.source_run_id): monitoring_run_info.run_id,
             },
         )
         return CreateOrReuseMonitoringRunResult(
@@ -668,6 +676,311 @@ class MLflowMonitoringGateway:
             return None
         return self._mlflow.get_monitoring_experiment_tags(experiment_id)
 
+    def _reconcile_monitoring_run_allocations(
+        self,
+        *,
+        subject_id: str,
+        experiment_id: str,
+        experiment_tags: Mapping[str, str],
+    ) -> tuple[dict[IdempotencyKey, _MonitoringRunAllocation], int]:
+        """Validate durable allocations and repair their experiment-tag projection."""
+        snapshots = self._mlflow.list_monitoring_runs_with_tag(
+            experiment_id,
+            _SOURCE_RUN_TAG,
+        )
+        allocations = tuple(
+            self._parse_monitoring_run_allocation(subject_id, snapshot) for snapshot in snapshots
+        )
+        allocations_by_key: dict[IdempotencyKey, _MonitoringRunAllocation] = {}
+        allocations_by_sequence: dict[int, _MonitoringRunAllocation] = {}
+        allocations_by_run_id: dict[str, _MonitoringRunAllocation] = {}
+        for allocation in allocations:
+            existing_key_allocation = allocations_by_key.get(allocation.key)
+            if existing_key_allocation is not None:
+                raise self._allocation_consistency_error(
+                    reason="duplicate_identity",
+                    message="Multiple monitoring runs claim the same allocation identity.",
+                    details=(
+                        ("first_monitoring_run_id", existing_key_allocation.monitoring_run_id),
+                        ("second_monitoring_run_id", allocation.monitoring_run_id),
+                    ),
+                )
+            existing_sequence_allocation = allocations_by_sequence.get(allocation.sequence_index)
+            if existing_sequence_allocation is not None:
+                raise self._allocation_consistency_error(
+                    reason="duplicate_sequence",
+                    message=(
+                        "Multiple monitoring runs claim sequence index "
+                        f"{allocation.sequence_index}."
+                    ),
+                    details=(
+                        ("sequence_index", allocation.sequence_index),
+                        (
+                            "first_monitoring_run_id",
+                            existing_sequence_allocation.monitoring_run_id,
+                        ),
+                        ("second_monitoring_run_id", allocation.monitoring_run_id),
+                    ),
+                )
+            allocations_by_key[allocation.key] = allocation
+            allocations_by_sequence[allocation.sequence_index] = allocation
+            allocations_by_run_id[allocation.monitoring_run_id] = allocation
+
+        ordered_allocations = tuple(
+            sorted(allocations, key=lambda allocation: allocation.sequence_index)
+        )
+        for expected_sequence, allocation in enumerate(ordered_allocations):
+            if allocation.sequence_index != expected_sequence:
+                raise self._allocation_consistency_error(
+                    reason="sequence_gap",
+                    message=(
+                        "Monitoring allocation sequences must be contiguous from zero; "
+                        f"expected {expected_sequence}, got {allocation.sequence_index}."
+                    ),
+                    details=(
+                        ("expected_sequence_index", expected_sequence),
+                        ("actual_sequence_index", allocation.sequence_index),
+                    ),
+                )
+
+        next_sequence_index = len(ordered_allocations)
+        repairs = self._build_allocation_index_repairs(
+            experiment_tags=experiment_tags,
+            ordered_allocations=ordered_allocations,
+            allocations_by_sequence=allocations_by_sequence,
+            allocations_by_run_id=allocations_by_run_id,
+            next_sequence_index=next_sequence_index,
+        )
+        if repairs:
+            self._set_experiment_tags(experiment_id, repairs)
+        return allocations_by_key, next_sequence_index
+
+    def _parse_monitoring_run_allocation(
+        self,
+        subject_id: str,
+        snapshot: MonitoringRunTagSnapshot,
+    ) -> _MonitoringRunAllocation:
+        """Parse one durable allocation record from a monitoring-run tag snapshot."""
+        source_run_id = snapshot.tags.get(_SOURCE_RUN_TAG)
+        recipe_id = snapshot.tags.get(_RECIPE_ID_TAG)
+        recipe_version = snapshot.tags.get(_RECIPE_VERSION_TAG)
+        raw_sequence_index = snapshot.tags.get(_SEQUENCE_INDEX_TAG)
+        missing_fields = tuple(
+            field
+            for field, value in (
+                (_SOURCE_RUN_TAG, source_run_id),
+                (_RECIPE_ID_TAG, recipe_id),
+                (_RECIPE_VERSION_TAG, recipe_version),
+                (_SEQUENCE_INDEX_TAG, raw_sequence_index),
+            )
+            if not value
+        )
+        if not snapshot.run_id or missing_fields:
+            raise self._allocation_consistency_error(
+                reason="invalid_allocation",
+                message=(
+                    f"Monitoring run {snapshot.run_id!r} is missing durable allocation tags: "
+                    + ", ".join(missing_fields)
+                ),
+                details=(("monitoring_run_id", snapshot.run_id),),
+            )
+
+        assert source_run_id is not None
+        assert recipe_id is not None
+        assert recipe_version is not None
+        assert raw_sequence_index is not None
+
+        try:
+            sequence_index = int(raw_sequence_index)
+        except (TypeError, ValueError) as exc:
+            raise self._allocation_consistency_error(
+                reason="invalid_allocation",
+                message=(
+                    f"Monitoring run {snapshot.run_id!r} has a non-integer sequence index: "
+                    f"{raw_sequence_index!r}."
+                ),
+                details=(("monitoring_run_id", snapshot.run_id),),
+            ) from exc
+        if sequence_index < 0:
+            raise self._allocation_consistency_error(
+                reason="invalid_allocation",
+                message=(
+                    f"Monitoring run {snapshot.run_id!r} has a negative sequence index: "
+                    f"{sequence_index}."
+                ),
+                details=(
+                    ("monitoring_run_id", snapshot.run_id),
+                    ("sequence_index", sequence_index),
+                ),
+            )
+
+        return _MonitoringRunAllocation(
+            key=IdempotencyKey(
+                subject_id=subject_id,
+                source_run_id=source_run_id,
+                recipe_id=recipe_id,
+                recipe_version=recipe_version,
+            ),
+            monitoring_run_id=snapshot.run_id,
+            sequence_index=sequence_index,
+        )
+
+    def _build_allocation_index_repairs(
+        self,
+        *,
+        experiment_tags: Mapping[str, str],
+        ordered_allocations: tuple[_MonitoringRunAllocation, ...],
+        allocations_by_sequence: Mapping[int, _MonitoringRunAllocation],
+        allocations_by_run_id: Mapping[str, _MonitoringRunAllocation],
+        next_sequence_index: int,
+    ) -> dict[str, str]:
+        """Return validated experiment-tag repairs in deterministic write order."""
+        self._validate_timeline_index_tags(experiment_tags, allocations_by_sequence)
+        self._validate_allocation_pointer_tags(experiment_tags, allocations_by_run_id)
+
+        persisted_next_sequence = self._read_next_sequence_index(experiment_tags)
+        if persisted_next_sequence > next_sequence_index:
+            raise self._allocation_consistency_error(
+                reason="next_sequence_ahead",
+                message=(
+                    "monitoring.next_sequence_index is ahead of durable allocation state; "
+                    f"got {persisted_next_sequence}, expected {next_sequence_index}."
+                ),
+                details=(
+                    ("persisted_next_sequence_index", persisted_next_sequence),
+                    ("durable_next_sequence_index", next_sequence_index),
+                ),
+            )
+
+        repairs: dict[str, str] = {}
+        for allocation in ordered_allocations:
+            timeline_tag = f"{_RUN_TAG_PREFIX}{allocation.sequence_index}"
+            if timeline_tag not in experiment_tags:
+                repairs[timeline_tag] = allocation.monitoring_run_id
+
+        if ordered_allocations:
+            latest_run_id = ordered_allocations[-1].monitoring_run_id
+            if experiment_tags.get(_LATEST_TAG) != latest_run_id:
+                repairs[_LATEST_TAG] = latest_run_id
+            if persisted_next_sequence < next_sequence_index:
+                repairs[_NEXT_SEQUENCE_TAG] = str(next_sequence_index)
+
+        highest_allocation_by_source: dict[str, _MonitoringRunAllocation] = {}
+        for allocation in ordered_allocations:
+            highest_allocation_by_source[allocation.key.source_run_id] = allocation
+        for source_run_id in sorted(highest_allocation_by_source):
+            allocation = highest_allocation_by_source[source_run_id]
+            idempotency_tag = self._idempotency_tag(source_run_id)
+            if experiment_tags.get(idempotency_tag) != allocation.monitoring_run_id:
+                repairs[idempotency_tag] = allocation.monitoring_run_id
+        return repairs
+
+    def _validate_timeline_index_tags(
+        self,
+        experiment_tags: Mapping[str, str],
+        allocations_by_sequence: Mapping[int, _MonitoringRunAllocation],
+    ) -> None:
+        """Validate persisted timeline slots against durable allocations."""
+        for tag_key, monitoring_run_id in sorted(experiment_tags.items()):
+            if not tag_key.startswith(_RUN_TAG_PREFIX):
+                continue
+            raw_sequence_index = tag_key.removeprefix(_RUN_TAG_PREFIX)
+            try:
+                sequence_index = int(raw_sequence_index)
+            except ValueError as exc:
+                raise GatewayNamespaceViolation(
+                    message=(
+                        "Monitoring timeline index tag must end with a non-negative integer "
+                        f"sequence; got key={tag_key!r} value={monitoring_run_id!r}."
+                    )
+                ) from exc
+            if sequence_index < 0:
+                raise GatewayNamespaceViolation(
+                    message=(
+                        "Monitoring timeline index tag must end with a non-negative integer "
+                        f"sequence; got key={tag_key!r} value={monitoring_run_id!r}."
+                    )
+                )
+
+            allocation = allocations_by_sequence.get(sequence_index)
+            if allocation is None or allocation.monitoring_run_id != monitoring_run_id:
+                raise self._allocation_consistency_error(
+                    reason="timeline_conflict",
+                    message=(
+                        f"Experiment timeline slot {sequence_index} does not match its "
+                        "durable monitoring-run allocation."
+                    ),
+                    details=(
+                        ("sequence_index", sequence_index),
+                        ("indexed_monitoring_run_id", monitoring_run_id),
+                        (
+                            "durable_monitoring_run_id",
+                            None if allocation is None else allocation.monitoring_run_id,
+                        ),
+                    ),
+                )
+
+    def _validate_allocation_pointer_tags(
+        self,
+        experiment_tags: Mapping[str, str],
+        allocations_by_run_id: Mapping[str, _MonitoringRunAllocation],
+    ) -> None:
+        """Validate latest and source pointers before any repair writes occur."""
+        latest_run_id = experiment_tags.get(_LATEST_TAG)
+        if latest_run_id and latest_run_id not in allocations_by_run_id:
+            raise self._allocation_consistency_error(
+                reason="unknown_pointer",
+                message="monitoring.latest_run_id points to an unknown allocation.",
+                details=(("monitoring_run_id", latest_run_id),),
+            )
+
+        source_prefix = "training."
+        for tag_key, monitoring_run_id in sorted(experiment_tags.items()):
+            if not tag_key.startswith(source_prefix) or not tag_key.endswith(
+                _IDEMPOTENCY_TAG_SUFFIX
+            ):
+                continue
+            source_run_id = tag_key.removeprefix(source_prefix).removesuffix(
+                _IDEMPOTENCY_TAG_SUFFIX
+            )
+            if not source_run_id:
+                raise GatewayNamespaceViolation(
+                    message=f"Monitoring idempotency tag has an empty source run id: {tag_key!r}."
+                )
+            allocation = allocations_by_run_id.get(monitoring_run_id)
+            if allocation is None:
+                raise self._allocation_consistency_error(
+                    reason="unknown_pointer",
+                    message=f"Experiment tag {tag_key!r} points to an unknown allocation.",
+                    details=(("monitoring_run_id", monitoring_run_id),),
+                )
+            if allocation.key.source_run_id != source_run_id:
+                raise self._allocation_consistency_error(
+                    reason="source_binding_conflict",
+                    message=(
+                        f"Experiment tag {tag_key!r} points to a monitoring run allocated "
+                        f"for source {allocation.key.source_run_id!r}."
+                    ),
+                    details=(
+                        ("source_run_id", source_run_id),
+                        ("monitoring_run_id", monitoring_run_id),
+                    ),
+                )
+
+    def _allocation_consistency_error(
+        self,
+        *,
+        reason: str,
+        message: str,
+        details: tuple[tuple[str, str | int | None], ...] = (),
+    ) -> GatewayConsistencyViolation:
+        """Build one operator-visible allocation consistency error."""
+        return GatewayConsistencyViolation(
+            code="monitoring_allocation_inconsistent",
+            message=message,
+            details=(("reason", reason), *details),
+        )
+
     def _set_experiment_tags(self, experiment_id: str, tags: Mapping[str, str]) -> None:
         """Write a batch of experiment tags via the thin MLflow adapter."""
         for key, value in tags.items():
@@ -683,43 +996,22 @@ class MLflowMonitoringGateway:
         if raw_next_sequence_index is None or raw_next_sequence_index == "":
             return 0
         try:
-            return int(raw_next_sequence_index)
+            next_sequence_index = int(raw_next_sequence_index)
         except ValueError as exc:
             raise GatewayNamespaceViolation(
                 message=(
-                    "monitoring.next_sequence_index must be an integer string; "
+                    "monitoring.next_sequence_index must be a non-negative integer string; "
                     f"got {raw_next_sequence_index!r}."
                 )
             ) from exc
-
-    def _resolve_sequence_index(
-        self,
-        experiment_tags: Mapping[str, str],
-        monitoring_run_id: str,
-    ) -> int:
-        """Resolve a monitoring run's sequence index from experiment tags.
-
-        This is only used on idempotent replay paths where the run id is known
-        from the idempotency tag but the persisted run record could not be
-        reconstructed.
-        """
-        for key, value in experiment_tags.items():
-            if not key.startswith(_RUN_TAG_PREFIX) or value != monitoring_run_id:
-                continue
-            try:
-                return int(key.removeprefix(_RUN_TAG_PREFIX))
-            except ValueError as exc:
-                raise GatewayNamespaceViolation(
-                    message=(
-                        "Monitoring timeline index tag must end with an integer sequence; "
-                        f"got key={key!r} value={value!r}."
-                    )
-                ) from exc
-        raise GatewayNamespaceViolation(
-            message=(
-                f"Monitoring run {monitoring_run_id!r} is not indexed on the experiment timeline."
+        if next_sequence_index < 0:
+            raise GatewayNamespaceViolation(
+                message=(
+                    "monitoring.next_sequence_index must be a non-negative integer string; "
+                    f"got {raw_next_sequence_index!r}."
+                )
             )
-        )
+        return next_sequence_index
 
     def _indexed_monitoring_run_ids(self, experiment_tags: Mapping[str, str]) -> set[str]:
         """Return the set of monitoring run ids indexed on an experiment."""
@@ -751,32 +1043,6 @@ class MLflowMonitoringGateway:
                 continue
             references.append(MonitoringRunReference(kind=kind, reference_run_id=reference_run_id))
         return tuple(references)
-
-    def _resolve_existing_binding(
-        self,
-        *,
-        subject_id: str,
-        monitoring_run_id: str,
-        recipe_id: str,
-        recipe_version: str,
-    ) -> tuple[MonitoringRunRecord | None, bool]:
-        """Return the bound run plus whether its recipe identity still matches.
-
-        Experiment-tag idempotency is keyed only by source run id, so a bound
-        monitoring run must be checked for matching recipe identity before it
-        can be safely replayed.
-        """
-        # The binding may outlive a fully reconstructed MonitoringRunRecord, for
-        # example if allocation succeeded but later persistence did not.
-        existing_monitoring_run = self.get_monitoring_run(subject_id, monitoring_run_id)
-        run_tags = self._mlflow.get_run_tags(monitoring_run_id)
-        if not run_tags:
-            return existing_monitoring_run, False
-        return (
-            existing_monitoring_run,
-            run_tags.get(_RECIPE_ID_TAG) == recipe_id
-            and run_tags.get(_RECIPE_VERSION_TAG) == recipe_version,
-        )
 
     def _validate_namespace_prefix(self, prefix: str) -> None:
         """Validate namespace prefix can safely compose a monitoring namespace."""

--- a/tests/integration/test_mlflow_client.py
+++ b/tests/integration/test_mlflow_client.py
@@ -159,6 +159,41 @@ def test_create_run_and_read_run_data(tracking_uri: str, artifact_root_uri: str)
     assert tags["schema.age"] == "int"
 
 
+def test_list_monitoring_runs_with_tag_returns_only_active_matching_runs(
+    tracking_uri: str,
+    artifact_root_uri: str,
+) -> None:
+    client = MonitorMLflowClient(tracking_uri=tracking_uri)
+    raw = MlflowClient(tracking_uri=tracking_uri)
+    experiment_id = client.get_or_create_monitoring_experiment(
+        "allocation-search-monitoring",
+        artifact_location=artifact_root_uri,
+    )
+    matching = client.create_monitoring_run(
+        experiment_id,
+        tags={"training.source_run_id": "source-1"},
+    )
+    client.terminate_monitoring_run(matching.run_id, "FINISHED")
+    unrelated = client.create_monitoring_run(
+        experiment_id,
+        tags={"monitoring.sequence_index": "1"},
+    )
+    deleted = client.create_monitoring_run(
+        experiment_id,
+        tags={"training.source_run_id": "source-deleted"},
+    )
+    raw.delete_run(deleted.run_id)
+
+    snapshots = client.list_monitoring_runs_with_tag(
+        experiment_id,
+        "training.source_run_id",
+    )
+
+    assert tuple(snapshot.run_id for snapshot in snapshots) == (matching.run_id,)
+    assert snapshots[0].tags["training.source_run_id"] == "source-1"
+    assert unrelated.run_id not in {snapshot.run_id for snapshot in snapshots}
+
+
 def test_get_run_returns_none_for_missing_run(tracking_uri: str) -> None:
     client = MonitorMLflowClient(tracking_uri=tracking_uri)
 

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +40,15 @@ class FailingFinalizeMLflowMonitoringGateway(MLflowMonitoringGateway):
         raise RuntimeError("simulated finalization failure")
 
 
+class FailingAllocationIndexMLflowMonitoringGateway(MLflowMonitoringGateway):
+    """Fail once after run creation but before the allocation index is written."""
+
+    def _set_experiment_tags(self, experiment_id: str, tags: Mapping[str, str]) -> None:
+        if any(key.startswith("monitoring.run.") for key in tags):
+            raise RuntimeError("simulated allocation index failure")
+        super()._set_experiment_tags(experiment_id, tags)
+
+
 class ExplodingContractChecker:
     """Fail the test if checked replay re-enters contract evaluation."""
 
@@ -50,6 +59,84 @@ class ExplodingContractChecker:
     ) -> ContractCheckResult:
         _ = (contract, context)
         raise AssertionError("idempotent replay must not re-run check")
+
+
+def test_mlflow_gateway_repairs_zero_tag_orphan_before_next_allocation(
+    tracking_uri: str,
+    artifact_root_uri: str,
+    create_training_run: Callable[..., str],
+) -> None:
+    raw = MlflowClient(tracking_uri=tracking_uri)
+    first_source_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="first",
+        metrics={"f1": 0.91},
+        params={"feature_columns": "age"},
+        tags={"schema.age": "int"},
+    )
+    second_source_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="second",
+        metrics={"f1": 0.92},
+        params={"feature_columns": "age"},
+        tags={"schema.age": "int"},
+    )
+    first_key = IdempotencyKey(
+        subject_id="churn_model",
+        source_run_id=first_source_run_id,
+        recipe_id="system_default",
+        recipe_version="v0",
+    )
+    failing_gateway = FailingAllocationIndexMLflowMonitoringGateway(
+        GatewayConfig(),
+        tracking_uri=tracking_uri,
+        artifact_location=artifact_root_uri,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated allocation index failure"):
+        failing_gateway.create_or_reuse_monitoring_run(first_key)
+
+    experiment = raw.get_experiment_by_name("mlflow_monitor/churn_model")
+    assert experiment is not None
+    orphaned_runs = raw.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string=f"tags.`training.source_run_id` = '{first_source_run_id}'",
+    )
+    assert len(orphaned_runs) == 1
+    orphaned_run_id = orphaned_runs[0].info.run_id
+    assert experiment.tags == {}
+
+    repairing_gateway = MLflowMonitoringGateway(
+        GatewayConfig(),
+        tracking_uri=tracking_uri,
+        artifact_location=artifact_root_uri,
+    )
+    recovered = repairing_gateway.create_or_reuse_monitoring_run(first_key)
+    second = repairing_gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id=second_source_run_id,
+            recipe_id="system_default",
+            recipe_version="v0",
+        )
+    )
+
+    repaired_experiment = raw.get_experiment(experiment.experiment_id)
+    monitoring_runs = raw.search_runs(experiment_ids=[experiment.experiment_id])
+    assert recovered.monitoring_run_id == orphaned_run_id
+    assert recovered.sequence_index == 0
+    assert recovered.allocated is False
+    assert second.sequence_index == 1
+    assert second.allocated is True
+    assert len(monitoring_runs) == 2
+    assert repaired_experiment.tags["monitoring.run.0"] == orphaned_run_id
+    assert repaired_experiment.tags["monitoring.run.1"] == second.monitoring_run_id
+    assert repaired_experiment.tags["monitoring.latest_run_id"] == second.monitoring_run_id
+    assert repaired_experiment.tags["monitoring.next_sequence_index"] == "2"
 
 
 def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -41,7 +41,7 @@ class FailingFinalizeMLflowMonitoringGateway(MLflowMonitoringGateway):
 
 
 class FailingAllocationIndexMLflowMonitoringGateway(MLflowMonitoringGateway):
-    """Fail once after run creation but before the allocation index is written."""
+    """Fail after run creation but before the allocation index is written."""
 
     def _set_experiment_tags(self, experiment_id: str, tags: Mapping[str, str]) -> None:
         if any(key.startswith("monitoring.run.") for key in tags):

--- a/tests/test_mlflow_client_unit.py
+++ b/tests/test_mlflow_client_unit.py
@@ -5,11 +5,58 @@ from __future__ import annotations
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from mlflow.entities import Experiment
+from mlflow.entities import Experiment, ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
+from mlflow.store.entities.paged_list import PagedList
 
 from mlflow_monitor.mlflow_client import MonitorMLflowClient
+
+
+def test_list_monitoring_runs_with_tag_paginates_and_detaches_tags() -> None:
+    first_tags = {"training.source_run_id": "source-1"}
+    first_run = MagicMock()
+    first_run.info.run_id = "run-1"
+    first_run.data.tags = first_tags
+    second_run = MagicMock()
+    second_run.info.run_id = "run-2"
+    second_run.data.tags = {"training.source_run_id": "source-2"}
+    stub_client = MagicMock()
+    stub_client.search_runs.side_effect = [
+        PagedList([first_run], "next-page"),
+        PagedList([second_run], None),
+    ]
+
+    with patch("mlflow_monitor.mlflow_client.MlflowClient", return_value=stub_client):
+        client = MonitorMLflowClient(tracking_uri="file:///ignored")
+
+    snapshots = client.list_monitoring_runs_with_tag(
+        "experiment-1",
+        "training.source_run_id",
+    )
+
+    assert tuple(snapshot.run_id for snapshot in snapshots) == ("run-1", "run-2")
+    assert snapshots[0].tags == {"training.source_run_id": "source-1"}
+    first_tags["training.source_run_id"] = "changed"
+    assert snapshots[0].tags == {"training.source_run_id": "source-1"}
+    with pytest.raises(TypeError):
+        snapshots[0].tags["extra"] = "not-allowed"  # type: ignore[index]
+    assert stub_client.search_runs.call_args_list == [
+        call(
+            experiment_ids=["experiment-1"],
+            filter_string="tags.`training.source_run_id` IS NOT NULL",
+            run_view_type=ViewType.ACTIVE_ONLY,
+            max_results=1000,
+            page_token=None,
+        ),
+        call(
+            experiment_ids=["experiment-1"],
+            filter_string="tags.`training.source_run_id` IS NOT NULL",
+            run_view_type=ViewType.ACTIVE_ONLY,
+            max_results=1000,
+            page_token="next-page",
+        ),
+    ]
 
 
 def test_get_or_create_monitoring_experiment_recovers_from_duplicate_create_race() -> None:

--- a/tests/test_mlflow_client_unit.py
+++ b/tests/test_mlflow_client_unit.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from mlflow.entities import Experiment, ViewType
+from mlflow.entities import Experiment, Run, ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
-from mlflow.store.entities.paged_list import PagedList
 
 from mlflow_monitor.mlflow_client import MonitorMLflowClient
+
+
+class _PagedRuns(list[Run]):
+    def __init__(self, runs: list[Run], token: str | None) -> None:
+        super().__init__(runs)
+        self.token = token
 
 
 def test_list_monitoring_runs_with_tag_paginates_and_detaches_tags() -> None:
@@ -23,8 +28,8 @@ def test_list_monitoring_runs_with_tag_paginates_and_detaches_tags() -> None:
     second_run.data.tags = {"training.source_run_id": "source-2"}
     stub_client = MagicMock()
     stub_client.search_runs.side_effect = [
-        PagedList([first_run], "next-page"),
-        PagedList([second_run], None),
+        _PagedRuns([first_run], "next-page"),
+        _PagedRuns([second_run], None),
     ]
 
     with patch("mlflow_monitor.mlflow_client.MlflowClient", return_value=stub_client):

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from mlflow_monitor.domain import LifecycleStatus
-from mlflow_monitor.errors import GatewayNamespaceViolation
+from mlflow_monitor.errors import GatewayConsistencyViolation, GatewayNamespaceViolation
 from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
-from mlflow_monitor.mlflow_client import MonitoringRunInfo
+from mlflow_monitor.mlflow_client import MonitoringRunInfo, MonitoringRunTagSnapshot
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
 
@@ -44,6 +44,411 @@ def _make_result(
 
 def _make_mlflow_run(status: str) -> SimpleNamespace:
     return SimpleNamespace(info=SimpleNamespace(status=status))
+
+
+def _allocation_snapshot(
+    *,
+    run_id: str,
+    source_run_id: str,
+    sequence_index: int | str,
+    recipe_version: str = "v0",
+) -> MonitoringRunTagSnapshot:
+    return MonitoringRunTagSnapshot(
+        run_id=run_id,
+        tags={
+            "training.source_run_id": source_run_id,
+            "monitoring.sequence_index": str(sequence_index),
+            "monitoring.lifecycle_status": "created",
+            "monitoring.recipe_id": "system_default",
+            "monitoring.recipe_version": recipe_version,
+        },
+    )
+
+
+@pytest.mark.parametrize("persisted_tag_count", range(5))
+def test_create_or_reuse_monitoring_run_repairs_partial_allocation_index(
+    persisted_tag_count: int,
+) -> None:
+    canonical_tags = [
+        ("monitoring.run.0", "monitoring-run-1"),
+        ("monitoring.latest_run_id", "monitoring-run-1"),
+        ("monitoring.next_sequence_index", "1"),
+        ("training.train-run-1.monitoring_run_id", "monitoring-run-1"),
+    ]
+    experiment_tags = dict(canonical_tags[:persisted_tag_count])
+    stub_client = MagicMock()
+    stub_client.get_or_create_monitoring_experiment.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = experiment_tags
+    stub_client.list_monitoring_runs_with_tag.return_value = (
+        _allocation_snapshot(
+            run_id="monitoring-run-1",
+            source_run_id="train-run-1",
+            sequence_index=0,
+        ),
+    )
+    stub_client.get_run_tags.return_value = dict(
+        stub_client.list_monitoring_runs_with_tag.return_value[0].tags
+    )
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    result = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-1",
+            recipe_id="system_default",
+            recipe_version="v0",
+        )
+    )
+
+    assert result.monitoring_run_id == "monitoring-run-1"
+    assert result.sequence_index == 0
+    assert result.allocated is False
+    assert stub_client.set_monitoring_experiment_tag.call_args_list == [
+        call("experiment-1", key, value) for key, value in canonical_tags[persisted_tag_count:]
+    ]
+    stub_client.create_monitoring_run.assert_not_called()
+
+
+def test_create_or_reuse_monitoring_run_repairs_orphan_before_new_allocation() -> None:
+    stub_client = MagicMock()
+    stub_client.get_or_create_monitoring_experiment.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {}
+    stub_client.list_monitoring_runs_with_tag.return_value = (
+        _allocation_snapshot(
+            run_id="monitoring-run-1",
+            source_run_id="train-run-1",
+            sequence_index=0,
+        ),
+    )
+    stub_client.create_monitoring_run.return_value = MonitoringRunInfo(
+        run_id="monitoring-run-2",
+        run_name="monitoring-run-2",
+    )
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    result = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-2",
+            recipe_id="system_default",
+            recipe_version="v0",
+        )
+    )
+
+    assert result.monitoring_run_id == "monitoring-run-2"
+    assert result.sequence_index == 1
+    assert result.allocated is True
+    stub_client.create_monitoring_run.assert_called_once_with(
+        "experiment-1",
+        tags={
+            "training.source_run_id": "train-run-2",
+            "monitoring.sequence_index": "1",
+            "monitoring.lifecycle_status": "created",
+            "monitoring.recipe_id": "system_default",
+            "monitoring.recipe_version": "v0",
+        },
+        source_run_name=stub_client.get_run_name.return_value,
+    )
+    assert stub_client.set_monitoring_experiment_tag.call_args_list == [
+        call("experiment-1", "monitoring.run.0", "monitoring-run-1"),
+        call("experiment-1", "monitoring.latest_run_id", "monitoring-run-1"),
+        call("experiment-1", "monitoring.next_sequence_index", "1"),
+        call(
+            "experiment-1",
+            "training.train-run-1.monitoring_run_id",
+            "monitoring-run-1",
+        ),
+        call("experiment-1", "monitoring.run.1", "monitoring-run-2"),
+        call("experiment-1", "monitoring.latest_run_id", "monitoring-run-2"),
+        call("experiment-1", "monitoring.next_sequence_index", "2"),
+        call(
+            "experiment-1",
+            "training.train-run-2.monitoring_run_id",
+            "monitoring-run-2",
+        ),
+    ]
+
+
+def test_create_or_reuse_monitoring_run_reuses_older_recipe_without_rewriting_cache() -> None:
+    v0 = _allocation_snapshot(
+        run_id="monitoring-run-v0",
+        source_run_id="train-run-1",
+        sequence_index=0,
+        recipe_version="v0",
+    )
+    v1 = _allocation_snapshot(
+        run_id="monitoring-run-v1",
+        source_run_id="train-run-1",
+        sequence_index=1,
+        recipe_version="v1",
+    )
+    stub_client = MagicMock()
+    stub_client.get_or_create_monitoring_experiment.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {
+        "monitoring.run.0": "monitoring-run-v0",
+        "monitoring.run.1": "monitoring-run-v1",
+        "monitoring.latest_run_id": "monitoring-run-v1",
+        "monitoring.next_sequence_index": "2",
+        "training.train-run-1.monitoring_run_id": "monitoring-run-v1",
+    }
+    stub_client.list_monitoring_runs_with_tag.return_value = (v1, v0)
+    stub_client.get_run_tags.return_value = dict(v0.tags)
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    result = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-1",
+            recipe_id="system_default",
+            recipe_version="v0",
+        )
+    )
+
+    assert result.monitoring_run_id == "monitoring-run-v0"
+    assert result.sequence_index == 0
+    assert result.allocated is False
+    stub_client.set_monitoring_experiment_tag.assert_not_called()
+    stub_client.create_monitoring_run.assert_not_called()
+
+
+def test_create_or_reuse_monitoring_run_repairs_stale_latest_and_source_binding() -> None:
+    v0 = _allocation_snapshot(
+        run_id="monitoring-run-v0",
+        source_run_id="train-run-1",
+        sequence_index=0,
+        recipe_version="v0",
+    )
+    v1 = _allocation_snapshot(
+        run_id="monitoring-run-v1",
+        source_run_id="train-run-1",
+        sequence_index=1,
+        recipe_version="v1",
+    )
+    stub_client = MagicMock()
+    stub_client.get_or_create_monitoring_experiment.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {
+        "monitoring.run.0": "monitoring-run-v0",
+        "monitoring.run.1": "monitoring-run-v1",
+        "monitoring.latest_run_id": "monitoring-run-v0",
+        "monitoring.next_sequence_index": "2",
+        "training.train-run-1.monitoring_run_id": "monitoring-run-v0",
+    }
+    stub_client.list_monitoring_runs_with_tag.return_value = (v0, v1)
+    stub_client.get_run_tags.return_value = dict(v0.tags)
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    result = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-1",
+            recipe_id="system_default",
+            recipe_version="v0",
+        )
+    )
+
+    assert result.monitoring_run_id == "monitoring-run-v0"
+    assert stub_client.set_monitoring_experiment_tag.call_args_list == [
+        call("experiment-1", "monitoring.latest_run_id", "monitoring-run-v1"),
+        call(
+            "experiment-1",
+            "training.train-run-1.monitoring_run_id",
+            "monitoring-run-v1",
+        ),
+    ]
+    stub_client.create_monitoring_run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("snapshots", "experiment_tags", "expected_reason"),
+    [
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+                _allocation_snapshot(
+                    run_id="monitoring-run-2",
+                    source_run_id="train-run-1",
+                    sequence_index=1,
+                ),
+            ),
+            {},
+            "duplicate_identity",
+            id="duplicate-identity",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+                _allocation_snapshot(
+                    run_id="monitoring-run-2",
+                    source_run_id="train-run-2",
+                    sequence_index=0,
+                ),
+            ),
+            {},
+            "duplicate_sequence",
+            id="duplicate-sequence",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=-1,
+                ),
+            ),
+            {},
+            "invalid_allocation",
+            id="negative-sequence",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index="not-an-int",
+                ),
+            ),
+            {},
+            "invalid_allocation",
+            id="malformed-sequence",
+        ),
+        pytest.param(
+            (
+                MonitoringRunTagSnapshot(
+                    run_id="monitoring-run-1",
+                    tags={
+                        "training.source_run_id": "train-run-1",
+                        "monitoring.sequence_index": "0",
+                        "monitoring.recipe_version": "v0",
+                    },
+                ),
+            ),
+            {},
+            "invalid_allocation",
+            id="missing-recipe-id",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=1,
+                ),
+            ),
+            {},
+            "sequence_gap",
+            id="sequence-gap",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+            ),
+            {"monitoring.run.0": "unknown-run"},
+            "timeline_conflict",
+            id="timeline-conflict",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+            ),
+            {"monitoring.latest_run_id": "unknown-run"},
+            "unknown_pointer",
+            id="unknown-latest-pointer",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+            ),
+            {
+                "monitoring.next_sequence_index": "0",
+                "training.train-run-1.monitoring_run_id": "unknown-run",
+            },
+            "unknown_pointer",
+            id="repairable-next-plus-unknown-pointer",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+            ),
+            {"training.train-run-2.monitoring_run_id": "monitoring-run-1"},
+            "source_binding_conflict",
+            id="wrong-source-binding",
+        ),
+        pytest.param(
+            (
+                _allocation_snapshot(
+                    run_id="monitoring-run-1",
+                    source_run_id="train-run-1",
+                    sequence_index=0,
+                ),
+            ),
+            {"monitoring.next_sequence_index": "2"},
+            "next_sequence_ahead",
+            id="next-sequence-ahead",
+        ),
+    ],
+)
+def test_create_or_reuse_monitoring_run_fails_closed_before_writes(
+    snapshots: tuple[MonitoringRunTagSnapshot, ...],
+    experiment_tags: dict[str, str],
+    expected_reason: str,
+) -> None:
+    stub_client = MagicMock()
+    stub_client.get_or_create_monitoring_experiment.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = experiment_tags
+    stub_client.list_monitoring_runs_with_tag.return_value = snapshots
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        gateway.create_or_reuse_monitoring_run(
+            IdempotencyKey(
+                subject_id="churn_model",
+                source_run_id="train-run-new",
+                recipe_id="system_default",
+                recipe_version="v0",
+            )
+        )
+
+    assert exc_info.value.code == "monitoring_allocation_inconsistent"
+    assert ("reason", expected_reason) in exc_info.value.details
+    stub_client.set_monitoring_experiment_tag.assert_not_called()
+    stub_client.create_monitoring_run.assert_not_called()
 
 
 def test_create_or_reuse_monitoring_run_writes_idempotency_tag_last() -> None:


### PR DESCRIPTION
## Summary

- Treat monitoring-run identity tags written by `create_run()` as the durable allocation record.
- Discover active allocations through a paginated MLflow adapter query.
- Validate and repair the experiment-level timeline projection before each create-or-reuse decision.
- Reuse exact source-and-recipe identities while failing closed on ambiguous or contradictory state.
- Add unit and real-MLflow fault-injection coverage for partial writes, replay, repair ordering, and consistency failures.
- Update the current architecture documentation to describe the experiment index as a repairable projection.

## Root cause

MLflow creates the monitoring run before the gateway writes the four experiment-level allocation tags. A failure between those operations leaves a durable run with an incomplete or missing experiment index, so the previous retry path could allocate a duplicate run or reuse incomplete state.

## Impact

Retries now recover uniquely identifiable partial allocations without creating duplicates. Canonical timeline, latest, next-sequence, and source bindings are restored lazily during allocation. Ambiguous state raises `monitoring_allocation_inconsistent` before any repair write or new run creation.


## Review note

This PR also surfaces `AGENTS.md`. This has been untracked.

Closes #46