### PR TITLE
Migrate monitoring records to paired identities

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,13 @@
 
 ## Validation
 
-<!-- List the exact commands or checks run and their results. Explain any omissions. -->
+<!-- Check only commands that were run successfully. Explain any omissions below. -->
 
-- `command` — result
+- [ ] `uv sync --extra dev`
+- [ ] `uv run pytest`
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run pyright`
+- [ ] `uv build`
+
+<!-- Validation omissions, if any: -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What changed
+
+<!-- Summarize the concrete changes in this pull request. -->
+
+-
+
+## Why
+
+<!-- Explain the problem, requirement, or ticket outcome this change addresses. -->
+
+## Impact
+
+<!-- Describe user-facing or developer-facing behavior, compatibility, and migration impact. -->
+
+## Validation
+
+<!-- List the exact commands or checks run and their results. Explain any omissions. -->
+
+- `command` — result

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -73,7 +73,14 @@ CONTRACT_CHECK_REASON_CODE_BLOCKING = MappingProxyType(
     }
 )
 
-_MONITORING_RUN_REFERENCE_KINDS = frozenset(("baseline", "previous", "lkg", "custom"))
+_MONITORING_RUN_REFERENCE_KINDS = frozenset(
+    (
+        DiffReferenceKind.BASELINE,
+        DiffReferenceKind.PREVIOUS,
+        DiffReferenceKind.LKG,
+        DiffReferenceKind.CUSTOM,
+    )
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,22 +182,38 @@ class MonitoringRunReference:
 
     Attributes:
         kind: Reference kind for the monitoring run lineage.
-        reference_run_id: Concrete training or monitoring run ID for the reference.
+        monitoring_run_id: Referenced monitoring run identifier, or None for the
+            source-only baseline.
+        source_run_id: Immutable source run identifier for the reference.
     """
 
-    kind: str
-    reference_run_id: str
+    kind: DiffReferenceKind
+    monitoring_run_id: str | None
+    source_run_id: str
 
     def __post_init__(self) -> None:
         """Validate run-level reference shape."""
-        if self.kind not in _MONITORING_RUN_REFERENCE_KINDS:
-            raise ValueError(f"Unsupported monitoring run reference kind {self.kind!r}.")
-        if not self.reference_run_id.strip():
-            raise ValueError("MonitoringRunReference.reference_run_id must be non-empty.")
+        try:
+            kind = DiffReferenceKind(self.kind)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported monitoring run reference kind {self.kind!r}.") from exc
+        if kind not in _MONITORING_RUN_REFERENCE_KINDS:
+            raise ValueError(f"Unsupported monitoring run reference kind {kind.value!r}.")
+        object.__setattr__(self, "kind", kind)
+        _validate_reference_identity(
+            entity="MonitoringRunReference",
+            kind=kind,
+            monitoring_run_id=self.monitoring_run_id,
+            source_run_id=self.source_run_id,
+        )
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, str | None]:
         """Serialize this run-level reference into a deterministic dictionary."""
-        return {"kind": self.kind, "reference_run_id": self.reference_run_id}
+        return {
+            "kind": self.kind.value,
+            "monitoring_run_id": self.monitoring_run_id,
+            "source_run_id": self.source_run_id,
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -199,26 +222,50 @@ class DiffReference:
 
     Attributes:
         kind: The reference kind for this diff (e.g., baseline, previous, lkg).
-        reference_id: The ID of the reference entity this diff is comparing to.
-            For `baseline`, this is the pinned baseline `source_run_id`.
-            For `previous`, `lkg`, and `custom`, this is a monitoring run ID.
-            Structural references must omit the ID.
+        monitoring_run_id: Referenced monitoring run identifier, or None for the
+            source-only baseline and legacy structural references.
+        source_run_id: Immutable source run identifier for the reference. This is
+            temporarily optional only for the legacy structural kind removed by
+            V0-003.
     """
 
     kind: DiffReferenceKind
-    reference_id: str | None
+    monitoring_run_id: str | None
+    source_run_id: str | None
 
     def __post_init__(self) -> None:
         """Validate that reference identity presence matches the reference kind."""
         if self.kind is DiffReferenceKind.STRUCTURAL:
-            if self.reference_id is not None:
-                raise ValueError("DiffReference with kind='structural' must not set reference_id.")
+            if self.monitoring_run_id is not None or self.source_run_id is not None:
+                raise ValueError("DiffReference with kind='structural' must not set run identity.")
             return
 
-        if self.reference_id is None or not self.reference_id.strip():
-            raise ValueError(
-                f"DiffReference with kind={self.kind.value!r} requires a non-empty reference_id."
-            )
+        _validate_reference_identity(
+            entity="DiffReference",
+            kind=self.kind,
+            monitoring_run_id=self.monitoring_run_id,
+            source_run_id=self.source_run_id,
+        )
+
+
+def _validate_reference_identity(
+    *,
+    entity: str,
+    kind: DiffReferenceKind,
+    monitoring_run_id: str | None,
+    source_run_id: str | None,
+) -> None:
+    """Validate source-only baseline and paired monitoring reference identity."""
+    if source_run_id is None or not source_run_id.strip():
+        raise ValueError(f"{entity} with kind={kind.value!r} requires a non-empty source_run_id.")
+    if kind is DiffReferenceKind.BASELINE:
+        if monitoring_run_id is not None:
+            raise ValueError(f"{entity} with kind='baseline' must not set monitoring_run_id.")
+        return
+    if monitoring_run_id is None or not monitoring_run_id.strip():
+        raise ValueError(
+            f"{entity} with kind={kind.value!r} requires a non-empty monitoring_run_id."
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -74,6 +74,7 @@ class MonitoringRunRecord:
 
     Attributes:
         monitoring_run_id: Monitoring run identifier.
+        source_run_id: Immutable source training run identifier.
         sequence_index: Monotonic per-subject sequence index.
         lifecycle_status: Current lifecycle status.
         comparability_status: Optional comparability status for the run.
@@ -82,6 +83,7 @@ class MonitoringRunRecord:
     """
 
     monitoring_run_id: str
+    source_run_id: str
     sequence_index: int
     lifecycle_status: LifecycleStatus
     comparability_status: ComparabilityStatus | None = None
@@ -89,7 +91,9 @@ class MonitoringRunRecord:
     references: tuple[MonitoringRunReference, ...] = ()
 
     def __post_init__(self) -> None:
-        """Freeze persisted references after a defensive copy."""
+        """Validate source identity and freeze references after a defensive copy."""
+        if not self.source_run_id.strip():
+            raise ValueError("MonitoringRunRecord.source_run_id must be non-empty.")
         object.__setattr__(
             self,
             "references",
@@ -133,6 +137,7 @@ class CreateOrReuseMonitoringRunResult:
 
     Attributes:
         monitoring_run_id: Monitoring run identifier owned by the gateway.
+        source_run_id: Immutable source training run identifier.
         sequence_index: Monotonic per-subject sequence index.
         existing_monitoring_run: Existing stored monitoring run record, if any. This may be
             None even when a prior idempotency binding already exists.
@@ -141,6 +146,7 @@ class CreateOrReuseMonitoringRunResult:
     """
 
     monitoring_run_id: str
+    source_run_id: str
     sequence_index: int
     existing_monitoring_run: MonitoringRunRecord | None
     allocated: bool
@@ -221,6 +227,7 @@ class MonitoringGateway(Protocol):
         self,
         subject_id: str,
         monitoring_run_id: str,
+        source_run_id: str,
         lifecycle_status: LifecycleStatus,
         sequence_index: int,
         contract_check_result: ContractCheckResult | None = None,
@@ -329,6 +336,7 @@ class InMemoryMonitoringGateway:
             )
             return CreateOrReuseMonitoringRunResult(
                 monitoring_run_id=existing_monitoring_run_id,
+                source_run_id=key.source_run_id,
                 sequence_index=sequence_index,
                 existing_monitoring_run=existing_monitoring_run,
                 allocated=False,
@@ -340,6 +348,7 @@ class InMemoryMonitoringGateway:
         self._idempotency_bindings[key] = (new_monitoring_run_id, sequence_index)
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=new_monitoring_run_id,
+            source_run_id=key.source_run_id,
             sequence_index=sequence_index,
             existing_monitoring_run=None,
             allocated=True,
@@ -422,6 +431,7 @@ class InMemoryMonitoringGateway:
         self,
         subject_id: str,
         monitoring_run_id: str,
+        source_run_id: str,
         lifecycle_status: LifecycleStatus,
         sequence_index: int,
         contract_check_result: ContractCheckResult | None = None,
@@ -432,6 +442,7 @@ class InMemoryMonitoringGateway:
         Args:
             subject_id: Monitored subject identifier.
             monitoring_run_id: Monitoring run identifier.
+            source_run_id: Immutable source training run identifier.
             lifecycle_status: Current lifecycle status of the run.
             sequence_index: Monotonic per-subject sequence index for ordering.
             contract_check_result: Optional contract check result to persist for the run.
@@ -446,6 +457,15 @@ class InMemoryMonitoringGateway:
         """
         self._validate_subject_id(subject_id)
         self._validate_monitoring_namespace(subject_id)
+        self._validate_allocated_source_identity(
+            subject_id=subject_id,
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+        )
+        self._validate_reference_source_identities(
+            subject_id=subject_id,
+            references=references,
+        )
 
         comparability_status: ComparabilityStatus | None = (
             contract_check_result.status if contract_check_result else None
@@ -457,6 +477,7 @@ class InMemoryMonitoringGateway:
         if monitoring_run is None:
             subject_runs[monitoring_run_id] = MonitoringRunRecord(
                 monitoring_run_id=monitoring_run_id,
+                source_run_id=source_run_id,
                 sequence_index=sequence_index,
                 lifecycle_status=lifecycle_status,
                 comparability_status=comparability_status,
@@ -467,6 +488,7 @@ class InMemoryMonitoringGateway:
 
         self._validate_upsert_existing_monitoring_run(
             monitoring_run,
+            source_run_id,
             sequence_index,
             contract_check_result,
             references,
@@ -828,6 +850,7 @@ class InMemoryMonitoringGateway:
     def _validate_upsert_existing_monitoring_run(
         self,
         monitoring_run: MonitoringRunRecord,
+        source_run_id: str,
         sequence_index: int,
         contract_check_result: ContractCheckResult | None,
         references: tuple[MonitoringRunReference, ...] | None,
@@ -836,6 +859,7 @@ class InMemoryMonitoringGateway:
 
         Args:
             monitoring_run: The existing monitoring run record being updated.
+            source_run_id: The source run identifier being written for the run.
             sequence_index: The new sequence index being written for the run.
             contract_check_result: The new contract check result being written for the run.
             references: The new typed references being written for the run.
@@ -848,6 +872,9 @@ class InMemoryMonitoringGateway:
             None
         """
         details: tuple[tuple[str, str | int | None], ...] = ()
+
+        if monitoring_run.source_run_id != source_run_id:
+            details += (("source_run_id", source_run_id),)
 
         if monitoring_run.sequence_index != sequence_index:
             details += (("sequence_index", sequence_index),)
@@ -917,12 +944,68 @@ class InMemoryMonitoringGateway:
         )
         self._monitoring_runs_by_subject[subject_id][monitoring_run_id] = MonitoringRunRecord(
             monitoring_run_id=monitoring_run_id,
+            source_run_id=monitoring_run.source_run_id,
             sequence_index=monitoring_run.sequence_index,
             lifecycle_status=lifecycle_status,
             comparability_status=effective_comparability_status,
             contract_check_result=effective_contract_check_result,
             references=effective_references,
         )
+
+    def _validate_allocated_source_identity(
+        self,
+        *,
+        subject_id: str,
+        monitoring_run_id: str,
+        source_run_id: str,
+    ) -> None:
+        """Reject a source identity that conflicts with an existing allocation."""
+        for key, binding in self._idempotency_bindings.items():
+            allocated_monitoring_run_id, _ = binding
+            if key.subject_id != subject_id or allocated_monitoring_run_id != monitoring_run_id:
+                continue
+            if key.source_run_id != source_run_id:
+                raise GatewayConsistencyViolation(
+                    code="monitoring_run_upsert_field_override",
+                    message=(
+                        "Attempted to upsert monitoring run with immutable field value: "
+                        f"source_run_id={source_run_id!r}"
+                    ),
+                    details=(("source_run_id", source_run_id),),
+                )
+            return
+
+    def _validate_reference_source_identities(
+        self,
+        *,
+        subject_id: str,
+        references: tuple[MonitoringRunReference, ...] | None,
+    ) -> None:
+        """Reject a reference pair that contradicts an existing monitoring record."""
+        if references is None:
+            return
+        subject_runs = self._monitoring_runs_by_subject.get(subject_id, {})
+        for reference in references:
+            if reference.monitoring_run_id is None:
+                continue
+            persisted_reference = subject_runs.get(reference.monitoring_run_id)
+            if (
+                persisted_reference is None
+                or persisted_reference.source_run_id == reference.source_run_id
+            ):
+                continue
+            raise GatewayConsistencyViolation(
+                code="monitoring_run_upsert_field_override",
+                message=(
+                    "Monitoring run source identity is inconsistent for "
+                    f"monitoring_run_id={reference.monitoring_run_id!r}."
+                ),
+                details=(
+                    ("monitoring_run_id", reference.monitoring_run_id),
+                    ("source_run_id", reference.source_run_id),
+                    ("persisted_source_run_id", persisted_reference.source_run_id),
+                ),
+            )
 
     def _generate_monitoring_run_id(self) -> str:
         """Return a new opaque monitoring run identifier."""

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -294,6 +294,18 @@ class MLflowMonitoringGateway:
             references: Optional ordered references used during check.
         """
         self._validate_subject_id(subject_id)
+        if self.resolve_timeline_monitoring_run_id(subject_id, monitoring_run_id) is None:
+            raise GatewayConsistencyViolation(
+                code="monitoring_run_subject_inconsistent",
+                message=(
+                    f"Monitoring run {monitoring_run_id!r} is not indexed on "
+                    f"subject_id={subject_id!r}."
+                ),
+                details=(
+                    ("subject_id", subject_id),
+                    ("monitoring_run_id", monitoring_run_id),
+                ),
+            )
         persisted_source_run_id = self._mlflow.get_run_tags(monitoring_run_id).get(_SOURCE_RUN_TAG)
         if persisted_source_run_id != source_run_id:
             raise self._source_identity_consistency_error(

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -37,6 +37,7 @@ from mlflow_monitor.contract_checker import ContractEvidence
 from mlflow_monitor.domain import (
     ComparabilityStatus,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
 )
@@ -151,6 +152,7 @@ class MLflowMonitoringGateway:
         if existing_allocation is not None:
             return CreateOrReuseMonitoringRunResult(
                 monitoring_run_id=existing_allocation.monitoring_run_id,
+                source_run_id=existing_allocation.key.source_run_id,
                 sequence_index=existing_allocation.sequence_index,
                 existing_monitoring_run=self.get_monitoring_run(
                     key.subject_id,
@@ -184,6 +186,7 @@ class MLflowMonitoringGateway:
         )
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=monitoring_run_info.run_id,
+            source_run_id=key.source_run_id,
             sequence_index=sequence_index,
             existing_monitoring_run=None,
             allocated=True,
@@ -267,6 +270,7 @@ class MLflowMonitoringGateway:
         self,
         subject_id: str,
         monitoring_run_id: str,
+        source_run_id: str,
         lifecycle_status: LifecycleStatus,
         sequence_index: int,
         contract_check_result: ContractCheckResult | None = None,
@@ -282,6 +286,7 @@ class MLflowMonitoringGateway:
         Args:
             subject_id: Monitored subject identifier.
             monitoring_run_id: Monitoring run id to update.
+            source_run_id: Immutable source training run identifier.
             lifecycle_status: Lifecycle status to persist.
             sequence_index: Stable timeline sequence index for the run.
             contract_check_result: Optional check result used to derive the
@@ -289,6 +294,13 @@ class MLflowMonitoringGateway:
             references: Optional ordered references used during check.
         """
         self._validate_subject_id(subject_id)
+        persisted_source_run_id = self._mlflow.get_run_tags(monitoring_run_id).get(_SOURCE_RUN_TAG)
+        if persisted_source_run_id != source_run_id:
+            raise self._source_identity_consistency_error(
+                monitoring_run_id=monitoring_run_id,
+                source_run_id=source_run_id,
+                persisted_source_run_id=persisted_source_run_id,
+            )
         monitoring_tags = {
             _SEQUENCE_INDEX_TAG: str(sequence_index),
             _LIFECYCLE_STATUS_TAG: lifecycle_status.value,
@@ -297,8 +309,22 @@ class MLflowMonitoringGateway:
             monitoring_tags[_COMPARABILITY_STATUS_TAG] = contract_check_result.status.value
         if references is not None:
             for reference in references:
-                monitoring_tags[f"{_REFERENCE_TAG_PREFIX}{reference.kind}"] = (
-                    reference.reference_run_id
+                if reference.kind is DiffReferenceKind.BASELINE:
+                    reference_tag_value = reference.source_run_id
+                else:
+                    assert reference.monitoring_run_id is not None
+                    persisted_reference_source_run_id = self._mlflow.get_run_tags(
+                        reference.monitoring_run_id
+                    ).get(_SOURCE_RUN_TAG)
+                    if persisted_reference_source_run_id != reference.source_run_id:
+                        raise self._source_identity_consistency_error(
+                            monitoring_run_id=reference.monitoring_run_id,
+                            source_run_id=reference.source_run_id,
+                            persisted_source_run_id=persisted_reference_source_run_id,
+                        )
+                    reference_tag_value = reference.monitoring_run_id
+                monitoring_tags[f"{_REFERENCE_TAG_PREFIX}{reference.kind.value}"] = (
+                    reference_tag_value
                 )
         self._mlflow.set_monitoring_run_tags(monitoring_run_id, monitoring_tags)
 
@@ -333,7 +359,8 @@ class MLflowMonitoringGateway:
             return None
         lifecycle_status_value = run_tags.get(_LIFECYCLE_STATUS_TAG)
         sequence_index_value = run_tags.get(_SEQUENCE_INDEX_TAG)
-        if lifecycle_status_value is None or sequence_index_value is None:
+        source_run_id = run_tags.get(_SOURCE_RUN_TAG)
+        if lifecycle_status_value is None or sequence_index_value is None or not source_run_id:
             return None
 
         try:
@@ -357,6 +384,7 @@ class MLflowMonitoringGateway:
 
         return MonitoringRunRecord(
             monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
             sequence_index=sequence_index,
             lifecycle_status=lifecycle_status,
             comparability_status=comparability_status,
@@ -1038,11 +1066,58 @@ class MLflowMonitoringGateway:
         """
         references: list[MonitoringRunReference] = []
         for kind in _REFERENCE_KINDS:
-            reference_run_id = run_tags.get(f"{_REFERENCE_TAG_PREFIX}{kind}")
-            if not reference_run_id:
+            reference_tag_value = run_tags.get(f"{_REFERENCE_TAG_PREFIX}{kind}")
+            if not reference_tag_value:
                 continue
-            references.append(MonitoringRunReference(kind=kind, reference_run_id=reference_run_id))
+            reference_kind = DiffReferenceKind(kind)
+            if reference_kind is DiffReferenceKind.BASELINE:
+                references.append(
+                    MonitoringRunReference(
+                        kind=reference_kind,
+                        monitoring_run_id=None,
+                        source_run_id=reference_tag_value,
+                    )
+                )
+                continue
+            reference_monitoring_run_id = reference_tag_value
+            reference_source_run_id = self._mlflow.get_run_tags(reference_monitoring_run_id).get(
+                _SOURCE_RUN_TAG
+            )
+            if not reference_source_run_id:
+                raise self._source_identity_consistency_error(
+                    monitoring_run_id=reference_monitoring_run_id,
+                    source_run_id=None,
+                    persisted_source_run_id=reference_source_run_id,
+                )
+            references.append(
+                MonitoringRunReference(
+                    kind=reference_kind,
+                    monitoring_run_id=reference_monitoring_run_id,
+                    source_run_id=reference_source_run_id,
+                )
+            )
         return tuple(references)
+
+    def _source_identity_consistency_error(
+        self,
+        *,
+        monitoring_run_id: str,
+        source_run_id: str | None,
+        persisted_source_run_id: str | None,
+    ) -> GatewayConsistencyViolation:
+        """Build a structured error for one contradictory monitoring/source pair."""
+        return GatewayConsistencyViolation(
+            code="monitoring_run_upsert_field_override",
+            message=(
+                "Monitoring run source identity is inconsistent for "
+                f"monitoring_run_id={monitoring_run_id!r}."
+            ),
+            details=(
+                ("monitoring_run_id", monitoring_run_id),
+                ("source_run_id", source_run_id),
+                ("persisted_source_run_id", persisted_source_run_id),
+            ),
+        )
 
     def _validate_namespace_prefix(self, prefix: str) -> None:
         """Validate namespace prefix can safely compose a monitoring namespace."""

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -10,12 +10,14 @@ from mlflow_monitor.contract_checker import ContractChecker
 from mlflow_monitor.domain import (
     Contract,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
     CheckStageError,
     ContractResolutionError,
+    GatewayConsistencyViolation,
     PrepareStageError,
     RecipeValidationError,
     TerminalRunRetryError,
@@ -150,7 +152,7 @@ def _resolve_orchestration_state(
     create_or_reuse_result = gateway.create_or_reuse_monitoring_run(idempotency_key)
     state = OrchestrationState(
         subject_id=subject_id,
-        source_run_id=source_run_id,
+        source_run_id=create_or_reuse_result.source_run_id,
         baseline_source_run_id=baseline_source_run_id,
         compiled_plan=compiled_plan,
         resolved_contract=resolved_contract,
@@ -227,6 +229,7 @@ def _run_prepare_monitoring_run_slice(
         gateway.upsert_monitoring_run(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            source_run_id=state.source_run_id,
             lifecycle_status=LifecycleStatus.CREATED,
             sequence_index=state.sequence_index,
         )
@@ -245,6 +248,7 @@ def _run_prepare_monitoring_run_slice(
         gateway.upsert_monitoring_run(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            source_run_id=state.source_run_id,
             lifecycle_status=LifecycleStatus.FAILED,
             sequence_index=state.sequence_index,
         )
@@ -268,6 +272,7 @@ def _run_prepare_monitoring_run_slice(
         gateway.upsert_monitoring_run(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            source_run_id=state.source_run_id,
             lifecycle_status=LifecycleStatus.PREPARED,
             sequence_index=state.sequence_index,
         )
@@ -307,6 +312,7 @@ def _run_check_monitoring_run_slice(
         gateway.upsert_monitoring_run(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            source_run_id=state.source_run_id,
             lifecycle_status=LifecycleStatus.FAILED,
             sequence_index=state.sequence_index,
         )
@@ -326,10 +332,11 @@ def _run_check_monitoring_run_slice(
     gateway.upsert_monitoring_run(
         subject_id=state.subject_id,
         monitoring_run_id=state.monitoring_run_id,
+        source_run_id=state.source_run_id,
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=state.sequence_index,
         contract_check_result=contract_check_result,
-        references=_build_monitoring_run_references(prepared_context),
+        references=_build_monitoring_run_references(prepared_context, gateway),
     )
     result = _build_success_monitoring_run_result(
         subject_id=state.subject_id,
@@ -375,7 +382,7 @@ def _build_success_monitoring_run_result(
         summary=None,
         finding_ids=(),
         diff_ids=(),
-        references=_build_monitoring_run_references(prepared_context),
+        references=_build_monitoring_run_references(prepared_context, gateway),
         error=None,
     )
 
@@ -457,43 +464,80 @@ def _build_failure_monitoring_run_result(
 
 def _build_monitoring_run_references(
     prepared_context,
+    gateway: MonitoringGateway,
 ) -> tuple[MonitoringRunReference, ...]:
     """Build ordered typed references for persistence.
 
     Args:
         prepared_context: The prepared context produced by the prepare stage for this run.
+        gateway: Gateway used to hydrate source identity for monitoring-run references.
 
     Returns:
         Ordered typed references used during contract check.
     """
     references = [
         MonitoringRunReference(
-            kind="baseline",
-            reference_run_id=prepared_context.baseline_source_run_id,
+            kind=DiffReferenceKind.BASELINE,
+            monitoring_run_id=None,
+            source_run_id=prepared_context.baseline_source_run_id,
         )
     ]
     if prepared_context.previous_monitoring_run_id is not None:
         references.append(
-            MonitoringRunReference(
-                kind="previous",
-                reference_run_id=prepared_context.previous_monitoring_run_id,
+            _hydrate_monitoring_run_reference(
+                kind=DiffReferenceKind.PREVIOUS,
+                subject_id=prepared_context.subject_id,
+                monitoring_run_id=prepared_context.previous_monitoring_run_id,
+                gateway=gateway,
             )
         )
     if prepared_context.active_lkg_monitoring_run_id is not None:
         references.append(
-            MonitoringRunReference(
-                kind="lkg",
-                reference_run_id=prepared_context.active_lkg_monitoring_run_id,
+            _hydrate_monitoring_run_reference(
+                kind=DiffReferenceKind.LKG,
+                subject_id=prepared_context.subject_id,
+                monitoring_run_id=prepared_context.active_lkg_monitoring_run_id,
+                gateway=gateway,
             )
         )
     if prepared_context.custom_reference_monitoring_run_id is not None:
         references.append(
-            MonitoringRunReference(
-                kind="custom",
-                reference_run_id=prepared_context.custom_reference_monitoring_run_id,
+            _hydrate_monitoring_run_reference(
+                kind=DiffReferenceKind.CUSTOM,
+                subject_id=prepared_context.subject_id,
+                monitoring_run_id=prepared_context.custom_reference_monitoring_run_id,
+                gateway=gateway,
             )
         )
     return tuple(references)
+
+
+def _hydrate_monitoring_run_reference(
+    *,
+    kind: DiffReferenceKind,
+    subject_id: str,
+    monitoring_run_id: str,
+    gateway: MonitoringGateway,
+) -> MonitoringRunReference:
+    """Hydrate a complete reference pair from a monitoring-run pointer."""
+    record = gateway.get_monitoring_run(subject_id, monitoring_run_id)
+    if record is None:
+        raise GatewayConsistencyViolation(
+            code="monitoring_reference_inconsistent",
+            message=(
+                "Monitoring reference could not be hydrated for "
+                f"monitoring_run_id={monitoring_run_id!r}."
+            ),
+            details=(
+                ("kind", kind.value),
+                ("monitoring_run_id", monitoring_run_id),
+            ),
+        )
+    return MonitoringRunReference(
+        kind=kind,
+        monitoring_run_id=record.monitoring_run_id,
+        source_run_id=record.source_run_id,
+    )
 
 
 def _error_code_for_stage(stage: str, error: Exception) -> str:

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -128,8 +128,10 @@ def test_mlflow_gateway_repairs_zero_tag_orphan_before_next_allocation(
     repaired_experiment = raw.get_experiment(experiment.experiment_id)
     monitoring_runs = raw.search_runs(experiment_ids=[experiment.experiment_id])
     assert recovered.monitoring_run_id == orphaned_run_id
+    assert recovered.source_run_id == first_source_run_id
     assert recovered.sequence_index == 0
     assert recovered.allocated is False
+    assert second.source_run_id == second_source_run_id
     assert second.sequence_index == 1
     assert second.allocated is True
     assert len(monitoring_runs) == 2
@@ -190,7 +192,11 @@ def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(
     assert result.lifecycle_status is LifecycleStatus.CHECKED
     assert result.comparability_status is ComparabilityStatus.PASS
     assert result.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id=baseline_run_id),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id=baseline_run_id,
+        ),
     )
     assert experiment.tags["training.baseline_run_id"] == baseline_run_id
     assert experiment.tags["monitoring.latest_run_id"] == result.monitoring_run_id
@@ -368,8 +374,16 @@ def test_mlflow_gateway_reuses_baseline_resolves_previous_and_idempotent_rerun(
     experiment = raw.get_experiment_by_name("mlflow_monitor/churn_model")
     assert experiment is not None
     assert second.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id=baseline_run_id),
-        MonitoringRunReference(kind="previous", reference_run_id=first.monitoring_run_id),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id=baseline_run_id,
+        ),
+        MonitoringRunReference(
+            kind="previous",
+            monitoring_run_id=first.monitoring_run_id,
+            source_run_id=first_current_run_id,
+        ),
     )
     assert second.comparability_status is ComparabilityStatus.FAIL
     assert replay.monitoring_run_id == second.monitoring_run_id

--- a/tests/integration/test_monitor_api.py
+++ b/tests/integration/test_monitor_api.py
@@ -66,7 +66,11 @@ def test_monitor_run_defaults_to_real_mlflow_gateway(
     assert result.lifecycle_status is LifecycleStatus.CHECKED
     assert result.comparability_status is ComparabilityStatus.PASS
     assert result.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id=baseline_run_id),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id=baseline_run_id,
+        ),
     )
     assert experiment.tags["monitoring.latest_run_id"] == result.monitoring_run_id
 

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -15,6 +15,7 @@ from mlflow_monitor.domain import (
     Finding,
     FindingSeverity,
     LifecycleStatus,
+    MonitoringRunReference,
     Run,
     Timeline,
 )
@@ -65,7 +66,8 @@ def test_canonical_entities_can_be_constructed() -> None:
         monitoring_run_id="monitoring-run-1",
         reference=DiffReference(
             kind=DiffReferenceKind.BASELINE,
-            reference_id="train-run-0",
+            monitoring_run_id=None,
+            source_run_id="train-run-0",
         ),
         metric_deltas={"f1": -0.02},
         metadata={"window": "full"},
@@ -181,21 +183,83 @@ def test_finding_references_one_or_more_diffs() -> None:
     assert finding.evidence_diff_ids == ("diff-1", "diff-2")
 
 
-def test_diff_requires_reference_id_for_non_structural_reference_kinds() -> None:
-    """Non-structural diff references should require a concrete reference id."""
-    with pytest.raises(ValueError, match="requires a non-empty reference_id"):
-        DiffReference(
+def test_monitoring_run_reference_serializes_paired_identity() -> None:
+    """Monitoring-run references should expose explicit paired identity fields."""
+    reference = MonitoringRunReference(
+        kind=DiffReferenceKind.PREVIOUS,
+        monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
+    )
+
+    assert reference.to_dict() == {
+        "kind": "previous",
+        "monitoring_run_id": "monitoring-run-1",
+        "source_run_id": "train-run-1",
+    }
+
+
+@pytest.mark.parametrize("reference_type", [MonitoringRunReference, DiffReference])
+def test_baseline_reference_requires_source_only(reference_type: type) -> None:
+    """Baseline references should carry the baseline source without a monitoring run."""
+    reference = reference_type(
+        kind=DiffReferenceKind.BASELINE,
+        monitoring_run_id=None,
+        source_run_id="train-run-baseline",
+    )
+
+    assert reference.monitoring_run_id is None
+    assert reference.source_run_id == "train-run-baseline"
+
+    with pytest.raises(ValueError, match="must not set monitoring_run_id"):
+        reference_type(
             kind=DiffReferenceKind.BASELINE,
-            reference_id=None,
+            monitoring_run_id="monitoring-run-baseline",
+            source_run_id="train-run-baseline",
         )
 
 
-def test_diff_structural_reference_kind_forbids_reference_id() -> None:
-    """Structural diffs should not carry a concrete reference id."""
-    with pytest.raises(ValueError, match="must not set reference_id"):
+@pytest.mark.parametrize("reference_type", [MonitoringRunReference, DiffReference])
+@pytest.mark.parametrize(
+    "kind",
+    [DiffReferenceKind.PREVIOUS, DiffReferenceKind.LKG, DiffReferenceKind.CUSTOM],
+)
+def test_monitoring_reference_kinds_require_paired_identity(
+    reference_type: type,
+    kind: DiffReferenceKind,
+) -> None:
+    """Monitoring-run-backed references should require both immutable IDs."""
+    with pytest.raises(ValueError, match="requires a non-empty monitoring_run_id"):
+        reference_type(
+            kind=kind,
+            monitoring_run_id=None,
+            source_run_id="train-run-1",
+        )
+
+    with pytest.raises(ValueError, match="requires a non-empty source_run_id"):
+        reference_type(
+            kind=kind,
+            monitoring_run_id="monitoring-run-1",
+            source_run_id="",
+        )
+
+
+def test_diff_requires_source_run_id_for_baseline_reference() -> None:
+    """Baseline diff references should require a concrete source run id."""
+    with pytest.raises(ValueError, match="requires a non-empty source_run_id"):
+        DiffReference(
+            kind=DiffReferenceKind.BASELINE,
+            monitoring_run_id=None,
+            source_run_id="",
+        )
+
+
+def test_diff_structural_reference_kind_temporarily_forbids_run_identity() -> None:
+    """Legacy structural references should remain identity-free until V0-003 removes them."""
+    with pytest.raises(ValueError, match="must not set run identity"):
         DiffReference(
             kind=DiffReferenceKind.STRUCTURAL,
-            reference_id="train-run-0",
+            monitoring_run_id=None,
+            source_run_id="train-run-0",
         )
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -31,10 +31,12 @@ def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:
     second = gateway.create_or_reuse_monitoring_run(key)
 
     assert first.monitoring_run_id.startswith("monitoring-run-")
+    assert first.source_run_id == "train-run-1"
     assert first.sequence_index == 0
     assert first.existing_monitoring_run is None
     assert first.allocated is True
     assert second.monitoring_run_id == first.monitoring_run_id
+    assert second.source_run_id == first.source_run_id
     assert second.sequence_index == first.sequence_index
     assert second.existing_monitoring_run is None
     assert second.allocated is False
@@ -180,18 +182,21 @@ def test_list_timeline_runs_includes_failed_by_default() -> None:
     gateway.upsert_monitoring_run(
         subject_id=subject_id,
         monitoring_run_id="monitoring-run-created",
+        source_run_id="train-run-created",
         lifecycle_status=LifecycleStatus.CREATED,
         sequence_index=0,
     )
     gateway.upsert_monitoring_run(
         subject_id=subject_id,
         monitoring_run_id="monitoring-run-failed",
+        source_run_id="train-run-failed",
         lifecycle_status=LifecycleStatus.FAILED,
         sequence_index=1,
     )
     gateway.upsert_monitoring_run(
         subject_id=subject_id,
         monitoring_run_id="monitoring-run-closed",
+        source_run_id="train-run-closed",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=2,
     )
@@ -212,18 +217,21 @@ def test_list_timeline_runs_excludes_failed_when_requested() -> None:
     gateway.upsert_monitoring_run(
         subject_id=subject_id,
         monitoring_run_id="monitoring-run-checked",
+        source_run_id="train-run-checked",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
     )
     gateway.upsert_monitoring_run(
         subject_id=subject_id,
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=1,
     )
     gateway.upsert_monitoring_run(
         subject_id=subject_id,
         monitoring_run_id="monitoring-run-2",
+        source_run_id="train-run-2",
         lifecycle_status=LifecycleStatus.FAILED,
         sequence_index=2,
     )
@@ -249,6 +257,7 @@ def test_namespace_violation_raises_on_invalid_monitoring_write() -> None:
         gateway.upsert_monitoring_run(
             subject_id="team/churn_model",
             monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-1",
             lifecycle_status=LifecycleStatus.CREATED,
             sequence_index=0,
         )
@@ -415,12 +424,14 @@ def test_resolve_timeline_monitoring_run_id_requires_same_subject_timeline() -> 
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
     )
     gateway.upsert_monitoring_run(
         subject_id="fraud_model",
         monitoring_run_id="monitoring-run-foreign",
+        source_run_id="train-run-foreign",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
     )
@@ -475,6 +486,7 @@ def test_upsert_monitoring_run_comparability_status_is_derived_from_contract_che
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
         contract_check_result=result,
@@ -502,6 +514,7 @@ def test_upsert_monitoring_run_stores_contract_check_outputs() -> None:
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
         contract_check_result=result,
@@ -533,22 +546,111 @@ def test_upsert_monitoring_run_stores_references() -> None:
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
         contract_check_result=result,
         references=(
-            MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
-            MonitoringRunReference(kind="lkg", reference_run_id="monitoring-run-lkg"),
+            MonitoringRunReference(
+                kind="baseline",
+                monitoring_run_id=None,
+                source_run_id="train-run-baseline",
+            ),
+            MonitoringRunReference(
+                kind="lkg",
+                monitoring_run_id="monitoring-run-lkg",
+                source_run_id="train-run-lkg",
+            ),
         ),
     )
 
     stored = gateway.get_monitoring_run("churn_model", "monitoring-run-1")
 
     assert stored is not None
+    assert stored.source_run_id == "train-run-1"
     assert stored.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
-        MonitoringRunReference(kind="lkg", reference_run_id="monitoring-run-lkg"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind="lkg",
+            monitoring_run_id="monitoring-run-lkg",
+            source_run_id="train-run-lkg",
+        ),
     )
+
+
+def test_upsert_monitoring_run_rejects_source_identity_conflict() -> None:
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+    allocation = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-1",
+            recipe_id="default",
+            recipe_version="v0",
+        )
+    )
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        gateway.upsert_monitoring_run(
+            subject_id="churn_model",
+            monitoring_run_id=allocation.monitoring_run_id,
+            source_run_id="train-run-2",
+            lifecycle_status=LifecycleStatus.CREATED,
+            sequence_index=allocation.sequence_index,
+        )
+
+    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert exc_info.value.details == (("source_run_id", "train-run-2"),)
+
+
+def test_upsert_monitoring_run_requires_nonempty_source_run_id() -> None:
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+
+    with pytest.raises(ValueError, match="MonitoringRunRecord.source_run_id must be non-empty"):
+        gateway.upsert_monitoring_run(
+            subject_id="churn_model",
+            monitoring_run_id="monitoring-run-1",
+            source_run_id="",
+            lifecycle_status=LifecycleStatus.CREATED,
+            sequence_index=0,
+        )
+
+
+def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+    gateway.upsert_monitoring_run(
+        subject_id="churn_model",
+        monitoring_run_id="monitoring-run-previous",
+        source_run_id="train-run-persisted-reference",
+        lifecycle_status=LifecycleStatus.CLOSED,
+        sequence_index=0,
+    )
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        gateway.upsert_monitoring_run(
+            subject_id="churn_model",
+            monitoring_run_id="monitoring-run-current",
+            source_run_id="train-run-current",
+            lifecycle_status=LifecycleStatus.CHECKED,
+            sequence_index=1,
+            references=(
+                MonitoringRunReference(
+                    kind="previous",
+                    monitoring_run_id="monitoring-run-previous",
+                    source_run_id="train-run-claimed-reference",
+                ),
+            ),
+        )
+
+    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert dict(exc_info.value.details) == {
+        "monitoring_run_id": "monitoring-run-previous",
+        "source_run_id": "train-run-claimed-reference",
+        "persisted_source_run_id": "train-run-persisted-reference",
+    }
 
 
 def test_upsert_monitoring_run_preserves_check_outputs_when_only_lifecycle_status_changes() -> None:
@@ -567,18 +669,28 @@ def test_upsert_monitoring_run_preserves_check_outputs_when_only_lifecycle_statu
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
         contract_check_result=result,
         references=(
-            MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
-            MonitoringRunReference(kind="lkg", reference_run_id="monitoring-run-lkg"),
+            MonitoringRunReference(
+                kind="baseline",
+                monitoring_run_id=None,
+                source_run_id="train-run-baseline",
+            ),
+            MonitoringRunReference(
+                kind="lkg",
+                monitoring_run_id="monitoring-run-lkg",
+                source_run_id="train-run-lkg",
+            ),
         ),
     )
 
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
     )
@@ -590,8 +702,16 @@ def test_upsert_monitoring_run_preserves_check_outputs_when_only_lifecycle_statu
     assert stored.comparability_status is ComparabilityStatus.FAIL
     assert stored.contract_check_result == result
     assert stored.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
-        MonitoringRunReference(kind="lkg", reference_run_id="monitoring-run-lkg"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind="lkg",
+            monitoring_run_id="monitoring-run-lkg",
+            source_run_id="train-run-lkg",
+        ),
     )
 
 
@@ -601,6 +721,7 @@ def test_upsert_monitoring_run_rejects_changed_sequence_index() -> None:
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CREATED,
         sequence_index=0,
     )
@@ -609,6 +730,7 @@ def test_upsert_monitoring_run_rejects_changed_sequence_index() -> None:
         gateway.upsert_monitoring_run(
             subject_id="churn_model",
             monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-1",
             lifecycle_status=LifecycleStatus.CREATED,
             sequence_index=1,
         )
@@ -644,6 +766,7 @@ def test_upsert_monitoring_run_reports_all_immutable_field_overrides() -> None:
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
         contract_check_result=original_result,
@@ -653,6 +776,7 @@ def test_upsert_monitoring_run_reports_all_immutable_field_overrides() -> None:
         gateway.upsert_monitoring_run(
             subject_id="churn_model",
             monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-1",
             lifecycle_status=LifecycleStatus.CLOSED,
             sequence_index=1,
             contract_check_result=replacement_result,
@@ -692,6 +816,7 @@ def test_upsert_monitoring_run_rejects_changed_contract_check_result_after_initi
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-1",
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=0,
         contract_check_result=original_result,
@@ -701,6 +826,7 @@ def test_upsert_monitoring_run_rejects_changed_contract_check_result_after_initi
         gateway.upsert_monitoring_run(
             subject_id="churn_model",
             monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-1",
             lifecycle_status=LifecycleStatus.CHECKED,
             sequence_index=0,
             contract_check_result=replacement_result,

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -96,7 +96,8 @@ DIFF = Diff(
     monitoring_run_id="monitoring-run-2",
     reference=DiffReference(
         kind=DiffReferenceKind.BASELINE,
-        reference_id="training-run-1",
+        monitoring_run_id=None,
+        source_run_id="training-run-1",
     ),
     metric_deltas={"kl": -0.05},
     metadata={"feature": "age"},
@@ -270,7 +271,8 @@ class TestInvariantFindingToDiffEvidence:
             monitoring_run_id="monitoring-run-3",
             reference=DiffReference(
                 kind=DiffReferenceKind.BASELINE,
-                reference_id="train-run-3",
+                monitoring_run_id=None,
+                source_run_id="train-run-3",
             ),
             metric_deltas={"kl": -0.05},
             metadata={"feature": "age"},
@@ -299,7 +301,8 @@ class TestInvariantFindingToDiffEvidence:
             monitoring_run_id="monitoring-run-2",
             reference=DiffReference(
                 kind=DiffReferenceKind.BASELINE,
-                reference_id="train-run-1",
+                monitoring_run_id=None,
+                source_run_id="train-run-1",
             ),
             metric_deltas={"kl": -0.05},
             metadata={"feature": "age"},

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from mlflow_monitor.domain import LifecycleStatus
+from mlflow_monitor.domain import DiffReferenceKind, LifecycleStatus, MonitoringRunReference
 from mlflow_monitor.errors import GatewayConsistencyViolation, GatewayNamespaceViolation
 from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
 from mlflow_monitor.mlflow_client import MonitoringRunInfo, MonitoringRunTagSnapshot
@@ -104,6 +104,7 @@ def test_create_or_reuse_monitoring_run_repairs_partial_allocation_index(
     )
 
     assert result.monitoring_run_id == "monitoring-run-1"
+    assert result.source_run_id == "train-run-1"
     assert result.sequence_index == 0
     assert result.allocated is False
     assert stub_client.set_monitoring_experiment_tag.call_args_list == [
@@ -141,6 +142,7 @@ def test_create_or_reuse_monitoring_run_repairs_orphan_before_new_allocation() -
     )
 
     assert result.monitoring_run_id == "monitoring-run-2"
+    assert result.source_run_id == "train-run-2"
     assert result.sequence_index == 1
     assert result.allocated is True
     stub_client.create_monitoring_run.assert_called_once_with(
@@ -654,6 +656,111 @@ def test_get_monitoring_run_returns_none_for_malformed_persisted_tags(
     assert gateway.get_monitoring_run("churn_model", "monitoring-run-1") is None
 
 
+def test_get_monitoring_run_hydrates_source_and_reference_pairs() -> None:
+    stub_client = MagicMock()
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {
+        "monitoring.run.0": "monitoring-run-previous",
+        "monitoring.run.1": "monitoring-run-current",
+    }
+
+    def get_run_tags(monitoring_run_id: str) -> dict[str, str]:
+        if monitoring_run_id == "monitoring-run-current":
+            return {
+                "training.source_run_id": "train-run-current",
+                "monitoring.sequence_index": "1",
+                "monitoring.lifecycle_status": "checked",
+                "monitoring.reference.baseline": "train-run-baseline",
+                "monitoring.reference.previous": "monitoring-run-previous",
+            }
+        return {"training.source_run_id": "train-run-previous"}
+
+    stub_client.get_run_tags.side_effect = get_run_tags
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    record = gateway.get_monitoring_run("churn_model", "monitoring-run-current")
+
+    assert record is not None
+    assert record.source_run_id == "train-run-current"
+    assert record.references == (
+        MonitoringRunReference(
+            kind=DiffReferenceKind.BASELINE,
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind=DiffReferenceKind.PREVIOUS,
+            monitoring_run_id="monitoring-run-previous",
+            source_run_id="train-run-previous",
+        ),
+    )
+
+
+def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
+    stub_client = MagicMock()
+
+    def get_run_tags(monitoring_run_id: str) -> dict[str, str]:
+        if monitoring_run_id == "monitoring-run-current":
+            return {"training.source_run_id": "train-run-current"}
+        return {"training.source_run_id": "train-run-persisted-reference"}
+
+    stub_client.get_run_tags.side_effect = get_run_tags
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        gateway.upsert_monitoring_run(
+            subject_id="churn_model",
+            monitoring_run_id="monitoring-run-current",
+            source_run_id="train-run-current",
+            lifecycle_status=LifecycleStatus.CHECKED,
+            sequence_index=1,
+            references=(
+                MonitoringRunReference(
+                    kind=DiffReferenceKind.PREVIOUS,
+                    monitoring_run_id="monitoring-run-previous",
+                    source_run_id="train-run-claimed-reference",
+                ),
+            ),
+        )
+
+    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert dict(exc_info.value.details) == {
+        "monitoring_run_id": "monitoring-run-previous",
+        "source_run_id": "train-run-claimed-reference",
+        "persisted_source_run_id": "train-run-persisted-reference",
+    }
+
+
+def test_upsert_monitoring_run_rejects_conflicting_primary_pair() -> None:
+    stub_client = MagicMock()
+    stub_client.get_run_tags.return_value = {
+        "training.source_run_id": "train-run-persisted",
+    }
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        gateway.upsert_monitoring_run(
+            subject_id="churn_model",
+            monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-claimed",
+            lifecycle_status=LifecycleStatus.CREATED,
+            sequence_index=0,
+        )
+
+    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert dict(exc_info.value.details) == {
+        "monitoring_run_id": "monitoring-run-1",
+        "source_run_id": "train-run-claimed",
+        "persisted_source_run_id": "train-run-persisted",
+    }
+
+
 def test_resolve_timeline_monitoring_run_id_ignores_malformed_index_tag_keys() -> None:
     stub_client = MagicMock()
     stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
@@ -699,6 +806,7 @@ def test_list_timeline_monitoring_runs_skips_malformed_reconstructed_run() -> No
             "monitoring.lifecycle_status": "checked",
         },
         {
+            "training.source_run_id": "train-run-good",
             "monitoring.sequence_index": "1",
             "monitoring.lifecycle_status": "checked",
             "monitoring.comparability_status": "pass",

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -700,6 +700,10 @@ def test_get_monitoring_run_hydrates_source_and_reference_pairs() -> None:
 
 def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
     stub_client = MagicMock()
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {
+        "monitoring.run.1": "monitoring-run-current",
+    }
 
     def get_run_tags(monitoring_run_id: str) -> dict[str, str]:
         if monitoring_run_id == "monitoring-run-current":
@@ -737,6 +741,10 @@ def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
 
 def test_upsert_monitoring_run_rejects_conflicting_primary_pair() -> None:
     stub_client = MagicMock()
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {
+        "monitoring.run.0": "monitoring-run-1",
+    }
     stub_client.get_run_tags.return_value = {
         "training.source_run_id": "train-run-persisted",
     }
@@ -759,6 +767,37 @@ def test_upsert_monitoring_run_rejects_conflicting_primary_pair() -> None:
         "source_run_id": "train-run-claimed",
         "persisted_source_run_id": "train-run-persisted",
     }
+
+
+def test_upsert_monitoring_run_rejects_run_outside_subject_timeline_before_run_access() -> None:
+    stub_client = MagicMock()
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-churn"
+    stub_client.get_monitoring_experiment_tags.return_value = {
+        "monitoring.run.0": "monitoring-run-churn",
+    }
+    stub_client.get_run_tags.return_value = {
+        "training.source_run_id": "train-run-foreign",
+    }
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        gateway.upsert_monitoring_run(
+            subject_id="churn_model",
+            monitoring_run_id="monitoring-run-foreign",
+            source_run_id="train-run-foreign",
+            lifecycle_status=LifecycleStatus.CHECKED,
+            sequence_index=0,
+        )
+
+    assert exc_info.value.code == "monitoring_run_subject_inconsistent"
+    assert exc_info.value.details == (
+        ("subject_id", "churn_model"),
+        ("monitoring_run_id", "monitoring-run-foreign"),
+    )
+    stub_client.get_run_tags.assert_not_called()
+    stub_client.set_monitoring_run_tags.assert_not_called()
 
 
 def test_resolve_timeline_monitoring_run_id_ignores_malformed_index_tag_keys() -> None:
@@ -802,6 +841,7 @@ def test_list_timeline_monitoring_runs_skips_malformed_reconstructed_run() -> No
     }
     stub_client.get_run_tags.side_effect = [
         {
+            "training.source_run_id": "train-run-bad",
             "monitoring.sequence_index": "not-an-int",
             "monitoring.lifecycle_status": "checked",
         },

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -82,6 +82,7 @@ class BrokenUpsertGateway(InMemoryMonitoringGateway):
         self,
         subject_id: str,
         monitoring_run_id: str,
+        source_run_id: str,
         lifecycle_status: LifecycleStatus,
         sequence_index: int,
         contract_check_result: ContractCheckResult | None = None,
@@ -95,6 +96,7 @@ class BrokenUpsertGateway(InMemoryMonitoringGateway):
         super().upsert_monitoring_run(
             subject_id=subject_id,
             monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
             lifecycle_status=lifecycle_status,
             sequence_index=sequence_index,
             contract_check_result=contract_check_result,
@@ -152,6 +154,7 @@ class AllocationOnlyReplayGateway(InMemoryMonitoringGateway):
         self._replayed = True
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=replayed.monitoring_run_id,
+            source_run_id=replayed.source_run_id,
             sequence_index=replayed.sequence_index,
             existing_monitoring_run=None,
             allocated=False,
@@ -192,13 +195,18 @@ def test_run_orchestration_first_run_persists_checked_state() -> None:
     assert result.comparability_status is ComparabilityStatus.PASS
     assert result.timeline_id == "timeline-churn_model"
     assert result.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
     )
     assert result.finding_ids == ()
     assert result.diff_ids == ()
     assert result.summary is None
     assert result.error is None
     assert stored is not None
+    assert stored.source_run_id == "train-run-current"
     assert stored.sequence_index == 0
     assert stored.lifecycle_status is LifecycleStatus.CHECKED
     assert stored.comparability_status is ComparabilityStatus.PASS
@@ -272,8 +280,16 @@ def test_run_orchestration_later_run_can_omit_baseline_source_run_id() -> None:
     assert first.lifecycle_status is LifecycleStatus.CHECKED
     assert second.lifecycle_status is LifecycleStatus.CHECKED
     assert second.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
-        MonitoringRunReference(kind="previous", reference_run_id=first.monitoring_run_id),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind="previous",
+            monitoring_run_id=first.monitoring_run_id,
+            source_run_id="train-run-current",
+        ),
     )
 
 
@@ -693,13 +709,24 @@ def test_run_orchestration_checked_rerun_omitting_baseline_replays_result() -> N
     assert second.lifecycle_status is LifecycleStatus.CHECKED
     assert second.comparability_status is ComparabilityStatus.PASS
     assert second.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
     )
     assert second.error is None
 
 
 def test_run_orchestration_checked_rerun_preserves_references() -> None:
     gateway = make_gateway()
+    gateway.upsert_monitoring_run(
+        subject_id="churn_model",
+        monitoring_run_id="monitoring-run-lkg",
+        source_run_id="train-run-lkg",
+        lifecycle_status=LifecycleStatus.CREATED,
+        sequence_index=0,
+    )
     gateway.set_active_lkg_monitoring_run_id("churn_model", "monitoring-run-lkg")
 
     first = run_orchestration(
@@ -718,8 +745,16 @@ def test_run_orchestration_checked_rerun_preserves_references() -> None:
     )
 
     assert first.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-baseline"),
-        MonitoringRunReference(kind="lkg", reference_run_id="monitoring-run-lkg"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind="lkg",
+            monitoring_run_id="monitoring-run-lkg",
+            source_run_id="train-run-lkg",
+        ),
     )
     assert second.monitoring_run_id == first.monitoring_run_id
     assert second.references == first.references

--- a/tests/test_result_contract.py
+++ b/tests/test_result_contract.py
@@ -17,7 +17,13 @@ def test_monitor_run_result_success_envelope_construction() -> None:
         summary={"status": "ok"},
         finding_ids=("finding-1",),
         diff_ids=("diff-1",),
-        references=(MonitoringRunReference(kind="baseline", reference_run_id="train-run-1"),),
+        references=(
+            MonitoringRunReference(
+                kind="baseline",
+                monitoring_run_id=None,
+                source_run_id="train-run-1",
+            ),
+        ),
     )
 
     assert result.monitoring_run_id == "monitoring-run-1"
@@ -29,7 +35,11 @@ def test_monitor_run_result_success_envelope_construction() -> None:
     assert result.finding_ids == ("finding-1",)
     assert result.diff_ids == ("diff-1",)
     assert result.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-1"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-1",
+        ),
     )
     assert result.error is None
 
@@ -77,7 +87,13 @@ def test_monitor_run_result_to_dict_serializes_enums_and_error() -> None:
         summary={"outcome": "failed"},
         finding_ids=("finding-2",),
         diff_ids=("diff-2",),
-        references=(MonitoringRunReference(kind="baseline", reference_run_id="train-run-2"),),
+        references=(
+            MonitoringRunReference(
+                kind="baseline",
+                monitoring_run_id=None,
+                source_run_id="train-run-2",
+            ),
+        ),
         error=error,
     )
 
@@ -91,7 +107,13 @@ def test_monitor_run_result_to_dict_serializes_enums_and_error() -> None:
         "stage": "check",
         "details": {"checker": "default"},
     }
-    assert serialized["references"] == [{"kind": "baseline", "reference_run_id": "train-run-2"}]
+    assert serialized["references"] == [
+        {
+            "kind": "baseline",
+            "monitoring_run_id": None,
+            "source_run_id": "train-run-2",
+        }
+    ]
 
 
 def test_monitor_run_result_to_dict_stable_keys_for_success_and_failure() -> None:
@@ -192,7 +214,13 @@ def test_monitor_run_error_details_are_immutable_after_construction() -> None:
 def test_monitor_run_result_collections_are_immutable_after_construction() -> None:
     """Result collection fields should be copied defensively and immutable."""
     summary = {"status": "ok"}
-    references = [MonitoringRunReference(kind="baseline", reference_run_id="train-run-1")]
+    references = [
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-1",
+        )
+    ]
     finding_ids = ["finding-1"]
     diff_ids = ["diff-1"]
     result = MonitorRunResult(
@@ -208,13 +236,23 @@ def test_monitor_run_result_collections_are_immutable_after_construction() -> No
     )
 
     summary["status"] = "mutated"
-    references.append(MonitoringRunReference(kind="lkg", reference_run_id="monitoring-run-1"))
+    references.append(
+        MonitoringRunReference(
+            kind="lkg",
+            monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-lkg",
+        )
+    )
     finding_ids.append("finding-2")
     diff_ids.append("diff-2")
 
     assert result.summary == {"status": "ok"}
     assert result.references == (
-        MonitoringRunReference(kind="baseline", reference_run_id="train-run-1"),
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-1",
+        ),
     )
     assert result.finding_ids == ("finding-1",)
     assert result.diff_ids == ("diff-1",)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -98,12 +98,14 @@ def make_gateway_with_timeline() -> InMemoryMonitoringGateway:
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-prev",
+        source_run_id="train-run-prev",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
     )
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id="monitoring-run-custom-1",
+        source_run_id="train-run-custom-1",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=1,
     )
@@ -888,6 +890,7 @@ def test_prepare_run_context_fails_when_custom_reference_is_on_another_subject()
     gateway.upsert_monitoring_run(
         subject_id="fraud_model",
         monitoring_run_id="monitoring-run-foreign",
+        source_run_id="train-run-foreign",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
     )


### PR DESCRIPTION
## What changed

- replace ambiguous monitoring reference identity with explicit `monitoring_run_id` and `source_run_id` fields
- require source-only baseline references and paired previous/LKG/custom references
- add immutable `source_run_id` to `MonitoringRunRecord` and monitoring-run allocation results
- hydrate MLflow record and reference pairs from the existing `training.source_run_id` allocation tag
- fail closed with structured gateway consistency errors when supplied identity pairs contradict persisted state
- migrate orchestration, result serialization, unit tests, and real-MLflow integration tests to the paired shape
- add a repository PR template with the same What changed, Why, Impact, and Validation layout
- make the canonical six-command validation gate an explicit PR checklist

## Why

V0-002 requires every materialized monitoring-run record and reference to retain the source training-run identity. The prior `reference_run_id` field was ambiguous because baseline references held a source run ID while other kinds held a monitoring run ID.

A default PR template keeps future change descriptions consistent and makes validation omissions visible before review.

## Impact

Baseline references now serialize as `{kind, monitoring_run_id: null, source_run_id}`. Previous, LKG, and custom references serialize both IDs. Existing MLflow reference tags remain compatible: baseline tags still store the baseline source ID, while monitoring-run-backed tags still store the referenced monitoring run ID and hydrate its source ID from the referenced run's allocation tag.

The legacy structural Diff reference remains temporarily identity-free; V0-003 owns its removal and the final atomic Diff model.

After this PR merges, newly opened PRs will be pre-populated with the standard four-section layout and explicit validation checkboxes.

## Validation

- [x] `uv sync --extra dev`
- [x] `uv run pytest` — 299 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv build`
