### PR TITLE
[V0-003] Add Diff and Coverage Models

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,11 +16,13 @@
 
 <!-- Check only commands that were run successfully. Explain any omissions below. -->
 
-- [ ] `uv sync --extra dev`
+- [ ] `uv sync --extra dev --group doc`
 - [ ] `uv run pytest`
 - [ ] `uv run ruff check .`
 - [ ] `uv run ruff format --check .`
 - [ ] `uv run pyright`
 - [ ] `uv build`
+- [ ] Update `docs/v0/`
+- [ ] Update `docs/site/`
 
 <!-- Validation omissions, if any: -->

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -501,15 +501,17 @@ class ReferenceComparisonCoverage:
         """Validate ReferenceComparisonCoverage for atomic shape."""
         if self.reference_kind not in DiffReferenceKind:
             raise ValueError(
-                f"ReferenceComparisonCoverage has an unrecognized reference_kind: {self.reference_kind!r}."
+                "ReferenceComparisonCoverage has an unrecognized "
+                f"reference_kind: {self.reference_kind!r}."
             )
 
-        if self.reference:
+        if self.reference is not None:
             if not isinstance(self.reference, DiffReference):
                 raise ValueError("Coverage reference must be a DiffReference.")
             if self.reference_kind != self.reference.kind:
                 raise ValueError(
-                    "ReferenceComparisonCoverage 'reference_kind' must match the kind of the provided 'reference'."
+                    "ReferenceComparisonCoverage 'reference_kind' must match the kind of "
+                    "the provided 'reference'."
                 )
 
         if self.status == ReferenceComparisonStatus.COMPLETED:

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -7,6 +7,7 @@ workflow rules and invariant enforcement live in the higher-level runtime.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
@@ -63,6 +64,14 @@ class ContractCheckReasonCode(StrEnum):
     DATA_SCOPE_MISMATCH = "data_scope_mismatch"
 
 
+class ReferenceComparisonStatus(StrEnum):
+    """Status outcomes for metrics comparison in diff."""
+
+    COMPLETED = "completed"
+    SKIPPED = "skipped"
+    UNAVAILABLE = "unavailable"
+
+
 CONTRACT_CHECK_REASON_CODE_BLOCKING = MappingProxyType(
     {
         ContractCheckReasonCode.ENV_MISMATCH: False,
@@ -78,6 +87,16 @@ _MONITORING_RUN_REFERENCE_KINDS = frozenset(
         DiffReferenceKind.PREVIOUS,
         DiffReferenceKind.LKG,
         DiffReferenceKind.CUSTOM,
+    )
+)
+
+_METRIC_UNAVAILABLITY_REASONS = frozenset(
+    (
+        "current_metric_missing",
+        "reference_metric_missing",
+        "current_metric_not_finite",
+        "reference_metric_not_finite",
+        "delta_not_finite",
     )
 )
 
@@ -286,6 +305,41 @@ class Diff:
     reference_value: float
     delta: float
 
+    def __post_init__(self) -> None:
+        """Validate Diff for atomic shape."""
+        for field_name in (
+            "diff_id",
+            "monitoring_run_id",
+            "source_run_id",
+            "metric_name",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"Diff requires a non-empty string for field {field_name!r}.")
+
+        if not isinstance(self.reference, DiffReference):
+            raise ValueError("Diff requires a valid DiffReference for the 'reference' field.")
+
+        for field_name in ("current_value", "reference_value", "delta"):
+            value = getattr(self, field_name)
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+            ):
+                raise ValueError(f"Diff requires a finite float for field {field_name!r}.")
+
+            if isinstance(value, int):
+                object.__setattr__(self, field_name, float(value))
+
+        expected_delta = self.current_value - self.reference_value
+
+        if not math.isfinite(expected_delta):
+            raise ValueError("Diff computed delta must be a finite float.")
+
+        if self.delta != expected_delta:
+            raise ValueError("Diff delta must equal current_value - reference_value.")
+
 
 @dataclass(frozen=True, slots=True)
 class Finding:
@@ -377,3 +431,53 @@ class Timeline:
     monitoring_run_ids: list[str]
     active_lkg_monitoring_run_id: str | None
     active_contract: Contract
+
+
+@dataclass(frozen=True, slots=True)
+class MetricComparisonUnavailable:
+    """Information about a metric that could not be compared in a diff.
+
+    Attributes:
+        metric_name: The name of the metric that is unavailable for comparison.
+        reason: The reason why the metric comparison is unavailable.
+    """
+
+    metric_name: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        """Validate MetricComparisonUnavailable for atomic shape."""
+        for field_name in ("metric_name", "reason"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"MetricComparisonUnavailable requires a non-empty string for "
+                    f"field {field_name!r}."
+                )
+        metric_level_reason = self.reason
+        if metric_level_reason not in _METRIC_UNAVAILABLITY_REASONS:
+            raise ValueError(
+                f"MetricComparisonUnavailable 'reason' must be one of "
+                f"{_METRIC_UNAVAILABLITY_REASONS}, got {metric_level_reason!r}."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceComparisonCoverage:
+    """Coverage information for a specific reference kind in a diff comparison.
+
+    Attributes:
+        reference_kind: The kind of reference (e.g., baseline, previous, lkg, custom).
+        reference: The specific reference instance being compared, if applicable.
+        status: The status of the reference comparison (e.g., completed, skipped, unavailable).
+        diff_ids: A tuple of diff IDs associated with this reference comparison.
+        metric_unavailability: A tuple of MetricComparisonUnavailable instances indicating metrics that could not be compared.
+        reason: An optional human-readable reason explaining the status of the reference comparison.
+    """  # noqa: E501
+
+    reference_kind: DiffReferenceKind
+    reference: DiffReference | None
+    status: ReferenceComparisonStatus
+    diff_ids: tuple[str, ...]
+    metric_unavailability: tuple[MetricComparisonUnavailable, ...]
+    reason: str | None

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -499,7 +499,14 @@ class ReferenceComparisonCoverage:
 
     def __post_init__(self) -> None:
         """Validate ReferenceComparisonCoverage for atomic shape."""
+        if self.reference_kind not in DiffReferenceKind:
+            raise ValueError(
+                f"ReferenceComparisonCoverage has an unrecognized reference_kind: {self.reference_kind!r}."
+            )
+
         if self.reference:
+            if not isinstance(self.reference, DiffReference):
+                raise ValueError("Coverage reference must be a DiffReference.")
             if self.reference_kind != self.reference.kind:
                 raise ValueError(
                     "ReferenceComparisonCoverage 'reference_kind' must match the kind of the provided 'reference'."
@@ -555,34 +562,30 @@ class ReferenceComparisonCoverage:
         if self.diff_ids or self.metric_unavailability:
             raise ValueError("Unavailable coverage cannot contain metric results.")
 
-        # Global resolved-reference invariant.
-        if self.reference is not None:
-            if not isinstance(self.reference, DiffReference):
-                raise ValueError("Coverage reference must be a DiffReference.")
-            if self.reference.kind is not self.reference_kind:
-                raise ValueError("Coverage reference kind must match reference_kind.")
+        if self.reason is None or self.reason not in _UNAVAILABILITY_REFERENCE_COMPARISON_REASONS:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status UNAVAILABLE must have a reason code "
+                f"from {_UNAVAILABILITY_REFERENCE_COMPARISON_REASONS}."
+            )
 
-        if self.reason == "previous_reference_missing":
-            if self.reference_kind is not DiffReferenceKind.PREVIOUS:
+        elif self.reason == "previous_reference_missing":
+            if self.reference_kind != DiffReferenceKind.PREVIOUS:
                 raise ValueError("previous_reference_missing requires reference_kind='previous'.")
             if self.reference is not None:
                 raise ValueError("previous_reference_missing requires reference=None.")
 
         elif self.reason == "lkg_not_selected":
-            if self.reference_kind is not DiffReferenceKind.LKG:
+            if self.reference_kind != DiffReferenceKind.LKG:
                 raise ValueError("lkg_not_selected requires reference_kind='lkg'.")
             if self.reference is not None:
                 raise ValueError("lkg_not_selected requires reference=None.")
 
         elif self.reason == "lkg_selection_inconsistent":
-            if self.reference_kind is not DiffReferenceKind.LKG:
+            if self.reference_kind != DiffReferenceKind.LKG:
                 raise ValueError("lkg_selection_inconsistent requires reference_kind='lkg'.")
             if self.reference is not None:
                 raise ValueError("lkg_selection_inconsistent requires reference=None.")
 
-        elif self.reason == "reference_source_run_missing":
+        else:
             if self.reference is None:
                 raise ValueError("reference_source_run_missing requires a retained reference.")
-
-        else:
-            raise ValueError(f"Unknown unavailable coverage reason {self.reason!r}.")

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -90,7 +90,7 @@ _MONITORING_RUN_REFERENCE_KINDS = frozenset(
     )
 )
 
-_METRIC_UNAVAILABLITY_REASONS = frozenset(
+_METRIC_UNAVAILABILITY_REASONS = frozenset(
     (
         "current_metric_missing",
         "reference_metric_missing",
@@ -98,6 +98,21 @@ _METRIC_UNAVAILABLITY_REASONS = frozenset(
         "reference_metric_not_finite",
         "delta_not_finite",
     )
+)
+
+_SKIPPED_REFERENCE_COMPARISON_REASONS = frozenset(
+    {
+        "current_not_comparable",
+    }
+)
+
+_UNAVAILABILITY_REFERENCE_COMPARISON_REASONS = frozenset(
+    {
+        "previous_reference_missing",
+        "lkg_not_selected",
+        "lkg_selection_inconsistent",
+        "reference_source_run_missing",
+    }
 )
 
 
@@ -455,10 +470,10 @@ class MetricComparisonUnavailable:
                     f"field {field_name!r}."
                 )
         metric_level_reason = self.reason
-        if metric_level_reason not in _METRIC_UNAVAILABLITY_REASONS:
+        if metric_level_reason not in _METRIC_UNAVAILABILITY_REASONS:
             raise ValueError(
                 f"MetricComparisonUnavailable 'reason' must be one of "
-                f"{_METRIC_UNAVAILABLITY_REASONS}, got {metric_level_reason!r}."
+                f"{_METRIC_UNAVAILABILITY_REASONS}, got {metric_level_reason!r}."
             )
 
 
@@ -481,3 +496,93 @@ class ReferenceComparisonCoverage:
     diff_ids: tuple[str, ...]
     metric_unavailability: tuple[MetricComparisonUnavailable, ...]
     reason: str | None
+
+    def __post_init__(self) -> None:
+        """Validate ReferenceComparisonCoverage for atomic shape."""
+        if self.reference:
+            if self.reference_kind != self.reference.kind:
+                raise ValueError(
+                    "ReferenceComparisonCoverage 'reference_kind' must match the kind of the provided 'reference'."
+                )
+
+        if self.status == ReferenceComparisonStatus.COMPLETED:
+            self._validate_completed_coverage()
+
+        elif self.status == ReferenceComparisonStatus.SKIPPED:
+            self._validate_skipped_coverage()
+
+        elif self.status == ReferenceComparisonStatus.UNAVAILABLE:
+            self._validate_unavailable_coverage()
+        else:
+            raise ValueError(
+                f"ReferenceComparisonCoverage has an unrecognized status: {self.status!r}."
+            )
+
+    def _validate_completed_coverage(self) -> None:
+        if self.reference is None:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status COMPLETED must have a valid reference."
+            )
+        if self.reason is not None:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status COMPLETED must not have a reason code."
+            )
+
+    def _validate_skipped_coverage(self) -> None:
+        if self.reference is None:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status SKIPPED must have a valid reference."
+            )
+        if self.diff_ids:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status SKIPPED must not have any diff IDs."
+            )
+
+        if self.metric_unavailability:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status SKIPPED must not have any "
+                "metric unavailability entries."
+            )
+
+        if self.reason is None or self.reason not in _SKIPPED_REFERENCE_COMPARISON_REASONS:
+            raise ValueError(
+                "ReferenceComparisonCoverage with status SKIPPED must have a reason code "
+                f"from {_SKIPPED_REFERENCE_COMPARISON_REASONS}."
+            )
+
+    def _validate_unavailable_coverage(self) -> None:
+        """Validate an unavailable reference-comparison group."""
+        if self.diff_ids or self.metric_unavailability:
+            raise ValueError("Unavailable coverage cannot contain metric results.")
+
+        # Global resolved-reference invariant.
+        if self.reference is not None:
+            if not isinstance(self.reference, DiffReference):
+                raise ValueError("Coverage reference must be a DiffReference.")
+            if self.reference.kind is not self.reference_kind:
+                raise ValueError("Coverage reference kind must match reference_kind.")
+
+        if self.reason == "previous_reference_missing":
+            if self.reference_kind is not DiffReferenceKind.PREVIOUS:
+                raise ValueError("previous_reference_missing requires reference_kind='previous'.")
+            if self.reference is not None:
+                raise ValueError("previous_reference_missing requires reference=None.")
+
+        elif self.reason == "lkg_not_selected":
+            if self.reference_kind is not DiffReferenceKind.LKG:
+                raise ValueError("lkg_not_selected requires reference_kind='lkg'.")
+            if self.reference is not None:
+                raise ValueError("lkg_not_selected requires reference=None.")
+
+        elif self.reason == "lkg_selection_inconsistent":
+            if self.reference_kind is not DiffReferenceKind.LKG:
+                raise ValueError("lkg_selection_inconsistent requires reference_kind='lkg'.")
+            if self.reference is not None:
+                raise ValueError("lkg_selection_inconsistent requires reference=None.")
+
+        elif self.reason == "reference_source_run_missing":
+            if self.reference is None:
+                raise ValueError("reference_source_run_missing requires a retained reference.")
+
+        else:
+            raise ValueError(f"Unknown unavailable coverage reason {self.reason!r}.")

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -13,6 +13,9 @@ from dataclasses import dataclass
 from enum import StrEnum
 from types import MappingProxyType
 
+RELATIVE_DELTA_TOLERANCE = 1e-6
+ABSOLUTE_DELTA_TOLERANCE = 1e-6
+
 
 class LifecycleStatus(StrEnum):
     """Lifecycle states for a monitoring run.
@@ -256,7 +259,7 @@ class DiffReference:
     Attributes:
         kind: The reference kind for this diff (e.g., baseline, previous, lkg).
         monitoring_run_id: Referenced monitoring run identifier, or None for the
-            source-only baseline and legacy structural references.
+            source-only baseline.
         source_run_id: Immutable source run identifier for the reference. This is
             temporarily optional only for the legacy structural kind removed by
             V0-003.
@@ -352,8 +355,16 @@ class Diff:
         if not math.isfinite(expected_delta):
             raise ValueError("Diff computed delta must be a finite float.")
 
-        if self.delta != expected_delta:
-            raise ValueError("Diff delta must equal current_value - reference_value.")
+        if not math.isclose(
+            self.delta,
+            expected_delta,
+            rel_tol=RELATIVE_DELTA_TOLERANCE,
+            abs_tol=ABSOLUTE_DELTA_TOLERANCE,
+        ):
+            raise ValueError(
+                "Diff delta must equal current_value - reference_value within "
+                f"rel_tol={RELATIVE_DELTA_TOLERANCE}, abs_tol={ABSOLUTE_DELTA_TOLERANCE}."
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -487,7 +498,7 @@ class ReferenceComparisonCoverage:
         status: The status of the reference comparison (e.g., completed, skipped, unavailable).
         diff_ids: A tuple of diff IDs associated with this reference comparison.
         metric_unavailability: A tuple of MetricComparisonUnavailable instances indicating metrics that could not be compared.
-        reason: An optional human-readable reason explaining the status of the reference comparison.
+        reason: An optional reason code constrained by the reference comparison status.
     """  # noqa: E501
 
     reference_kind: DiffReferenceKind
@@ -499,6 +510,13 @@ class ReferenceComparisonCoverage:
 
     def __post_init__(self) -> None:
         """Validate ReferenceComparisonCoverage for atomic shape."""
+        # defensive conversion to tuples for immutability
+        diff_ids_tuple = tuple(self.diff_ids)
+        metric_unavailability_tuple = tuple(self.metric_unavailability)
+
+        object.__setattr__(self, "diff_ids", diff_ids_tuple)
+        object.__setattr__(self, "metric_unavailability", metric_unavailability_tuple)
+
         if self.reference_kind not in DiffReferenceKind:
             raise ValueError(
                 "ReferenceComparisonCoverage has an unrecognized "

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -43,7 +43,6 @@ class DiffReferenceKind(StrEnum):
     PREVIOUS = "previous"
     LKG = "lkg"
     CUSTOM = "custom"
-    STRUCTURAL = "structural"
 
 
 class FindingSeverity(StrEnum):
@@ -235,11 +234,6 @@ class DiffReference:
 
     def __post_init__(self) -> None:
         """Validate that reference identity presence matches the reference kind."""
-        if self.kind is DiffReferenceKind.STRUCTURAL:
-            if self.monitoring_run_id is not None or self.source_run_id is not None:
-                raise ValueError("DiffReference with kind='structural' must not set run identity.")
-            return
-
         _validate_reference_identity(
             entity="DiffReference",
             kind=self.kind,
@@ -275,16 +269,22 @@ class Diff:
     Attributes:
         diff_id: Unique identifier for the diff record.
         monitoring_run_id: The ID of the monitoring run this diff is associated with.
+        source_run_id: The immutable source training run ID of the monitoring run.
         reference: Reference descriptor containing both reference kind and reference id.
-        metric_deltas: A mapping of metric names to their delta values compared to the reference.
-        metadata: A mapping of additional metadata keys to values providing context for the diff.
+        metric_name: The name of the metric being compared.
+        current_value: The value of the metric for the current run.
+        reference_value: The value of the metric for the reference run.
+        delta: current_value - reference_value.
     """
 
     diff_id: str
     monitoring_run_id: str
+    source_run_id: str
     reference: DiffReference
-    metric_deltas: dict[str, float]
-    metadata: dict[str, str]
+    metric_name: str
+    current_value: float
+    reference_value: float
+    delta: float
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_diff_domain_models.py
+++ b/tests/test_diff_domain_models.py
@@ -38,6 +38,14 @@ def _previous_reference() -> DiffReference:
     )
 
 
+def _lkg_reference() -> DiffReference:
+    return DiffReference(
+        kind=DiffReferenceKind.LKG,
+        monitoring_run_id="monitoring-run-lkg",
+        source_run_id="train-run-lkg",
+    )
+
+
 def _diff(**overrides: object) -> Diff:
     values: dict[str, object] = {
         "diff_id": "diff-accuracy-baseline",
@@ -264,6 +272,10 @@ def test_coverage_is_immutable() -> None:
 @pytest.mark.parametrize(
     ("status_name", "overrides"),
     [
+        (
+            "COMPLETED",
+            {"reference_kind": DiffReferenceKind.LKG, "reference": _baseline_reference()},
+        ),
         ("COMPLETED", {"reference": None}),
         ("COMPLETED", {"reason": "current_not_comparable"}),
         ("SKIPPED", {"reference": None, "reason": "current_not_comparable"}),
@@ -296,6 +308,37 @@ def test_coverage_is_immutable() -> None:
                 "reference": None,
                 "reason": "previous_reference_missing",
                 "metric_unavailability": _ONE_METRIC_UNAVAILABILITY,
+            },
+        ),
+        (
+            "UNAVAILABLE",
+            {
+                "reference_kind": DiffReferenceKind.PREVIOUS,
+                "reference": _previous_reference(),
+                "reason": "lkg_not_selected",
+            },
+        ),
+        (
+            "UNAVAILABLE",
+            {
+                "reference_kind": DiffReferenceKind.PREVIOUS,
+                "reference": _previous_reference(),
+                "reason": "lkg_selection_inconsistent",
+            },
+        ),
+        (
+            "UNAVAILABLE",
+            {
+                "reference_kind": DiffReferenceKind.LKG,
+                "reference": _lkg_reference(),
+                "reason": "previous_reference_missing",
+            },
+        ),
+        (
+            "UNAVAILABLE",
+            {
+                "reference": _lkg_reference(),
+                "reason": "lkg_not_selected",
             },
         ),
     ],

--- a/tests/test_diff_domain_models.py
+++ b/tests/test_diff_domain_models.py
@@ -1,0 +1,352 @@
+"""Specifications for atomic metric Diffs and reference coverage."""
+
+from dataclasses import FrozenInstanceError, fields
+from typing import Any
+
+import pytest
+
+import mlflow_monitor.domain as domain
+
+METRIC_UNAVAILABILITY_REASONS = (
+    "current_metric_missing",
+    "reference_metric_missing",
+    "current_metric_not_finite",
+    "reference_metric_not_finite",
+    "delta_not_finite",
+)
+_ONE_METRIC_UNAVAILABILITY = object()
+
+
+def _domain_type(name: str) -> Any:
+    return getattr(domain, name)
+
+
+def _baseline_reference() -> domain.DiffReference:
+    return domain.DiffReference(
+        kind=domain.DiffReferenceKind.BASELINE,
+        monitoring_run_id=None,
+        source_run_id="train-run-baseline",
+    )
+
+
+def _previous_reference() -> domain.DiffReference:
+    return domain.DiffReference(
+        kind=domain.DiffReferenceKind.PREVIOUS,
+        monitoring_run_id="monitoring-run-previous",
+        source_run_id="train-run-previous",
+    )
+
+
+def _diff(**overrides: object) -> domain.Diff:
+    values: dict[str, object] = {
+        "diff_id": "diff-accuracy-baseline",
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "reference": _baseline_reference(),
+        "metric_name": "accuracy",
+        "current_value": 0.75,
+        "reference_value": 0.5,
+        "delta": 0.25,
+    }
+    values.update(overrides)
+    return domain.Diff(**values)  # type: ignore[arg-type]
+
+
+def _metric_unavailability(**overrides: object) -> Any:
+    values: dict[str, object] = {
+        "metric_name": "precision",
+        "reason": "reference_metric_missing",
+    }
+    values.update(overrides)
+    model_type = _domain_type("MetricComparisonUnavailable")
+    return model_type(**values)
+
+
+def _coverage(**overrides: object) -> Any:
+    status_type = _domain_type("ReferenceComparisonStatus")
+    values: dict[str, object] = {
+        "reference_kind": domain.DiffReferenceKind.BASELINE,
+        "reference": _baseline_reference(),
+        "status": status_type.COMPLETED,
+        "diff_ids": (),
+        "metric_unavailability": (),
+        "reason": None,
+    }
+    values.update(overrides)
+    model_type = _domain_type("ReferenceComparisonCoverage")
+    return model_type(**values)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "MetricComparisonUnavailable",
+        "ReferenceComparisonCoverage",
+        "ReferenceComparisonStatus",
+    ],
+)
+def test_diff_and_coverage_domain_types_are_exported(name: str) -> None:
+    assert hasattr(domain, name)
+
+
+def test_diff_reference_kind_contains_only_metric_reference_kinds() -> None:
+    assert {kind.value for kind in domain.DiffReferenceKind} == {
+        "baseline",
+        "previous",
+        "lkg",
+        "custom",
+    }
+
+
+def test_diff_has_one_atomic_metric_shape() -> None:
+    assert tuple(field.name for field in fields(domain.Diff)) == (
+        "diff_id",
+        "monitoring_run_id",
+        "source_run_id",
+        "reference",
+        "metric_name",
+        "current_value",
+        "reference_value",
+        "delta",
+    )
+
+    diff = _diff()
+
+    assert diff.source_run_id == "train-run-current"
+    assert diff.reference == _baseline_reference()
+    assert diff.metric_name == "accuracy"
+    assert diff.current_value == 0.75
+    assert diff.reference_value == 0.5
+    assert diff.delta == 0.25
+
+
+def test_diff_is_immutable() -> None:
+    diff = _diff()
+
+    with pytest.raises(FrozenInstanceError):
+        diff.delta = 1.0  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["diff_id", "monitoring_run_id", "source_run_id", "metric_name"],
+)
+def test_diff_rejects_empty_identity_and_metric_fields(field: str) -> None:
+    with pytest.raises(ValueError):
+        _diff(**{field: " "})
+
+
+def test_diff_requires_a_typed_reference() -> None:
+    with pytest.raises(ValueError):
+        _diff(reference=None)
+
+
+@pytest.mark.parametrize("field", ["current_value", "reference_value", "delta"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_diff_rejects_non_finite_numeric_evidence(field: str, value: float) -> None:
+    with pytest.raises(ValueError):
+        _diff(**{field: value})
+
+
+def test_diff_rejects_delta_that_does_not_equal_current_minus_reference() -> None:
+    with pytest.raises(ValueError):
+        _diff(delta=0.5)
+
+
+def test_reference_comparison_status_vocabulary_is_fixed() -> None:
+    status_type = _domain_type("ReferenceComparisonStatus")
+
+    assert {status.value for status in status_type} == {
+        "completed",
+        "skipped",
+        "unavailable",
+    }
+
+
+@pytest.mark.parametrize("reason", METRIC_UNAVAILABILITY_REASONS)
+def test_metric_comparison_unavailability_accepts_only_metric_reasons(reason: str) -> None:
+    unavailable = _metric_unavailability(reason=reason)
+
+    assert tuple(field.name for field in fields(unavailable)) == ("metric_name", "reason")
+    assert unavailable.metric_name == "precision"
+    assert unavailable.reason == reason
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"metric_name": " "},
+        {"reason": "unknown_reason"},
+    ],
+)
+def test_metric_comparison_unavailability_rejects_invalid_shape(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _metric_unavailability(**overrides)
+
+
+def test_metric_comparison_unavailability_is_immutable() -> None:
+    unavailable = _metric_unavailability()
+
+    with pytest.raises(FrozenInstanceError):
+        unavailable.reason = "current_metric_missing"
+
+
+def test_completed_coverage_accepts_diff_and_metric_unavailability_outcomes() -> None:
+    unavailable = _metric_unavailability()
+    coverage = _coverage(
+        diff_ids=("diff-accuracy-baseline",),
+        metric_unavailability=(unavailable,),
+    )
+
+    assert tuple(field.name for field in fields(coverage)) == (
+        "reference_kind",
+        "reference",
+        "status",
+        "diff_ids",
+        "metric_unavailability",
+        "reason",
+    )
+    assert coverage.diff_ids == ("diff-accuracy-baseline",)
+    assert coverage.metric_unavailability == (unavailable,)
+    assert coverage.reason is None
+
+
+def test_completed_coverage_allows_an_empty_metric_selection() -> None:
+    coverage = _coverage()
+
+    assert coverage.diff_ids == ()
+    assert coverage.metric_unavailability == ()
+
+
+def test_skipped_coverage_requires_a_resolved_reference_and_exact_reason() -> None:
+    status_type = _domain_type("ReferenceComparisonStatus")
+
+    coverage = _coverage(
+        status=status_type.SKIPPED,
+        reason="current_not_comparable",
+    )
+
+    assert coverage.reference == _baseline_reference()
+    assert coverage.diff_ids == ()
+    assert coverage.metric_unavailability == ()
+
+
+@pytest.mark.parametrize(
+    ("reference_kind", "reference", "reason"),
+    [
+        (domain.DiffReferenceKind.PREVIOUS, None, "previous_reference_missing"),
+        (domain.DiffReferenceKind.LKG, None, "lkg_not_selected"),
+        (domain.DiffReferenceKind.LKG, None, "lkg_selection_inconsistent"),
+        (
+            domain.DiffReferenceKind.PREVIOUS,
+            _previous_reference(),
+            "reference_source_run_missing",
+        ),
+    ],
+)
+def test_unavailable_coverage_accepts_each_reference_reason(
+    reference_kind: domain.DiffReferenceKind,
+    reference: domain.DiffReference | None,
+    reason: str,
+) -> None:
+    status_type = _domain_type("ReferenceComparisonStatus")
+
+    coverage = _coverage(
+        reference_kind=reference_kind,
+        reference=reference,
+        status=status_type.UNAVAILABLE,
+        reason=reason,
+    )
+
+    assert coverage.reason == reason
+    assert coverage.diff_ids == ()
+    assert coverage.metric_unavailability == ()
+
+
+def test_coverage_is_immutable() -> None:
+    coverage = _coverage()
+
+    with pytest.raises(FrozenInstanceError):
+        coverage.reason = "current_not_comparable"
+
+
+@pytest.mark.parametrize(
+    ("status_name", "overrides"),
+    [
+        ("COMPLETED", {"reference": None}),
+        ("COMPLETED", {"reason": "current_not_comparable"}),
+        ("SKIPPED", {"reference": None, "reason": "current_not_comparable"}),
+        ("SKIPPED", {"reason": None}),
+        ("SKIPPED", {"reason": "unknown_reason"}),
+        (
+            "SKIPPED",
+            {"reason": "current_not_comparable", "diff_ids": ("diff-1",)},
+        ),
+        (
+            "SKIPPED",
+            {
+                "reason": "current_not_comparable",
+                "metric_unavailability": _ONE_METRIC_UNAVAILABILITY,
+            },
+        ),
+        ("UNAVAILABLE", {"reference": None, "reason": None}),
+        ("UNAVAILABLE", {"reference": None, "reason": "unknown_reason"}),
+        (
+            "UNAVAILABLE",
+            {
+                "reference": None,
+                "reason": "previous_reference_missing",
+                "diff_ids": ("diff-1",),
+            },
+        ),
+        (
+            "UNAVAILABLE",
+            {
+                "reference": None,
+                "reason": "previous_reference_missing",
+                "metric_unavailability": _ONE_METRIC_UNAVAILABILITY,
+            },
+        ),
+    ],
+)
+def test_coverage_rejects_status_inconsistent_shapes(
+    status_name: str,
+    overrides: dict[str, object],
+) -> None:
+    status_type = _domain_type("ReferenceComparisonStatus")
+    overrides = dict(overrides)
+    if overrides.get("metric_unavailability") is _ONE_METRIC_UNAVAILABILITY:
+        overrides["metric_unavailability"] = (_metric_unavailability(),)
+
+    with pytest.raises(ValueError):
+        _coverage(status=getattr(status_type, status_name), **overrides)
+
+
+def test_coverage_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError):
+        _coverage(status="partial")
+
+
+@pytest.mark.parametrize(
+    ("status_name", "reason"),
+    [
+        ("COMPLETED", None),
+        ("SKIPPED", "current_not_comparable"),
+        ("UNAVAILABLE", "reference_source_run_missing"),
+    ],
+)
+def test_coverage_reference_kind_must_match_resolved_reference(
+    status_name: str,
+    reason: str | None,
+) -> None:
+    status_type = _domain_type("ReferenceComparisonStatus")
+
+    with pytest.raises(ValueError):
+        _coverage(
+            reference_kind=domain.DiffReferenceKind.PREVIOUS,
+            reference=_baseline_reference(),
+            status=getattr(status_type, status_name),
+            reason=reason,
+        )

--- a/tests/test_diff_domain_models.py
+++ b/tests/test_diff_domain_models.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import mlflow_monitor.domain as domain
+from mlflow_monitor.domain import Diff, DiffReference, DiffReferenceKind
 
 METRIC_UNAVAILABILITY_REASONS = (
     "current_metric_missing",
@@ -21,23 +22,23 @@ def _domain_type(name: str) -> Any:
     return getattr(domain, name)
 
 
-def _baseline_reference() -> domain.DiffReference:
-    return domain.DiffReference(
-        kind=domain.DiffReferenceKind.BASELINE,
+def _baseline_reference() -> DiffReference:
+    return DiffReference(
+        kind=DiffReferenceKind.BASELINE,
         monitoring_run_id=None,
         source_run_id="train-run-baseline",
     )
 
 
-def _previous_reference() -> domain.DiffReference:
-    return domain.DiffReference(
-        kind=domain.DiffReferenceKind.PREVIOUS,
+def _previous_reference() -> DiffReference:
+    return DiffReference(
+        kind=DiffReferenceKind.PREVIOUS,
         monitoring_run_id="monitoring-run-previous",
         source_run_id="train-run-previous",
     )
 
 
-def _diff(**overrides: object) -> domain.Diff:
+def _diff(**overrides: object) -> Diff:
     values: dict[str, object] = {
         "diff_id": "diff-accuracy-baseline",
         "monitoring_run_id": "monitoring-run-current",
@@ -49,7 +50,7 @@ def _diff(**overrides: object) -> domain.Diff:
         "delta": 0.25,
     }
     values.update(overrides)
-    return domain.Diff(**values)  # type: ignore[arg-type]
+    return Diff(**values)  # type: ignore[arg-type]
 
 
 def _metric_unavailability(**overrides: object) -> Any:
@@ -65,7 +66,7 @@ def _metric_unavailability(**overrides: object) -> Any:
 def _coverage(**overrides: object) -> Any:
     status_type = _domain_type("ReferenceComparisonStatus")
     values: dict[str, object] = {
-        "reference_kind": domain.DiffReferenceKind.BASELINE,
+        "reference_kind": DiffReferenceKind.BASELINE,
         "reference": _baseline_reference(),
         "status": status_type.COMPLETED,
         "diff_ids": (),
@@ -77,20 +78,8 @@ def _coverage(**overrides: object) -> Any:
     return model_type(**values)
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        "MetricComparisonUnavailable",
-        "ReferenceComparisonCoverage",
-        "ReferenceComparisonStatus",
-    ],
-)
-def test_diff_and_coverage_domain_types_are_exported(name: str) -> None:
-    assert hasattr(domain, name)
-
-
 def test_diff_reference_kind_contains_only_metric_reference_kinds() -> None:
-    assert {kind.value for kind in domain.DiffReferenceKind} == {
+    assert {kind.value for kind in DiffReferenceKind} == {
         "baseline",
         "previous",
         "lkg",
@@ -236,19 +225,19 @@ def test_skipped_coverage_requires_a_resolved_reference_and_exact_reason() -> No
 @pytest.mark.parametrize(
     ("reference_kind", "reference", "reason"),
     [
-        (domain.DiffReferenceKind.PREVIOUS, None, "previous_reference_missing"),
-        (domain.DiffReferenceKind.LKG, None, "lkg_not_selected"),
-        (domain.DiffReferenceKind.LKG, None, "lkg_selection_inconsistent"),
+        (DiffReferenceKind.PREVIOUS, None, "previous_reference_missing"),
+        (DiffReferenceKind.LKG, None, "lkg_not_selected"),
+        (DiffReferenceKind.LKG, None, "lkg_selection_inconsistent"),
         (
-            domain.DiffReferenceKind.PREVIOUS,
+            DiffReferenceKind.PREVIOUS,
             _previous_reference(),
             "reference_source_run_missing",
         ),
     ],
 )
 def test_unavailable_coverage_accepts_each_reference_reason(
-    reference_kind: domain.DiffReferenceKind,
-    reference: domain.DiffReference | None,
+    reference_kind: DiffReferenceKind,
+    reference: DiffReference | None,
     reason: str,
 ) -> None:
     status_type = _domain_type("ReferenceComparisonStatus")
@@ -345,7 +334,7 @@ def test_coverage_reference_kind_must_match_resolved_reference(
 
     with pytest.raises(ValueError):
         _coverage(
-            reference_kind=domain.DiffReferenceKind.PREVIOUS,
+            reference_kind=DiffReferenceKind.PREVIOUS,
             reference=_baseline_reference(),
             status=getattr(status_type, status_name),
             reason=reason,

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -64,13 +64,16 @@ def test_canonical_entities_can_be_constructed() -> None:
     diff = Diff(
         diff_id="diff-1",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-2",
         reference=DiffReference(
             kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-0",
         ),
-        metric_deltas={"f1": -0.02},
-        metadata={"window": "full"},
+        metric_name="f1",
+        current_value=0.75,
+        reference_value=0.5,
+        delta=0.25,
     )
     finding = Finding(
         finding_id="finding-1",
@@ -250,16 +253,6 @@ def test_diff_requires_source_run_id_for_baseline_reference() -> None:
             kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="",
-        )
-
-
-def test_diff_structural_reference_kind_temporarily_forbids_run_identity() -> None:
-    """Legacy structural references should remain identity-free until V0-003 removes them."""
-    with pytest.raises(ValueError, match="must not set run identity"):
-        DiffReference(
-            kind=DiffReferenceKind.STRUCTURAL,
-            monitoring_run_id=None,
-            source_run_id="train-run-0",
         )
 
 

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -94,13 +94,16 @@ FINDING = Finding(
 DIFF = Diff(
     diff_id="diff-1",
     monitoring_run_id="monitoring-run-2",
+    source_run_id="train-run-2",
     reference=DiffReference(
         kind=DiffReferenceKind.BASELINE,
         monitoring_run_id=None,
         source_run_id="training-run-1",
     ),
-    metric_deltas={"kl": -0.05},
-    metadata={"feature": "age"},
+    metric_name="kl",
+    current_value=0.25,
+    reference_value=0.5,
+    delta=-0.25,
 )
 
 
@@ -269,13 +272,16 @@ class TestInvariantFindingToDiffEvidence:
         mismatch_monitoring_run_id_diff = Diff(
             diff_id="diff-1",
             monitoring_run_id="monitoring-run-3",
+            source_run_id="train-run-3",
             reference=DiffReference(
                 kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id="train-run-3",
             ),
-            metric_deltas={"kl": -0.05},
-            metadata={"feature": "age"},
+            metric_name="kl",
+            current_value=0.25,
+            reference_value=0.5,
+            delta=-0.25,
         )
 
         monitoring_run_id = FINDING.monitoring_run_id
@@ -299,13 +305,16 @@ class TestInvariantFindingToDiffEvidence:
         non_evidence_diff = Diff(
             diff_id="diff-3",  # diff_id not in FINDING.evidence_diff_ids to trigger violation
             monitoring_run_id="monitoring-run-2",
+            source_run_id="train-run-2",
             reference=DiffReference(
                 kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id="train-run-1",
             ),
-            metric_deltas={"kl": -0.05},
-            metadata={"feature": "age"},
+            metric_name="kl",
+            current_value=0.25,
+            reference_value=0.5,
+            delta=-0.25,
         )
 
         diff_ids = [diff_id for diff_id in FINDING.evidence_diff_ids]


### PR DESCRIPTION
## What changed

* introduced a few domain models and invariants: 
  * `ReferenceComparisonStatus` - suggests the comparison status
  *  `ReferenceComparisonCoverage` - stores the coverage
  *  each `Diff` is atomic, i.e., only for one metric
  * explicit unavailability of metric comparison in `MetricComparisonUnavailable`
  * removed `"structural"` from `DiffReferenceKind`

## Why

This PR introduced immutable reference coverage and Diff models.

## Impact


## Validation

- [x ] `uv sync --extra dev`
- [ x] `uv run pytest`
- [ x] `uv run ruff check .`
- [ x] `uv run ruff format --check .`
- [ x] `uv run pyright`
- [ x] `uv build`
- [ x] Update `docs/v0/`
- [ x] Update `docs/site/`

- updated post mvp design doc to reconcile `metric_unavailability_reason` and `unavailability_reference_comparison_coverage_reasons`