### PR TITLE
[V0-004] Add Compatibility Evidence and Deterministic Identities

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,6 @@
 
 <!-- Summarize the concrete changes in this pull request. -->
 
--
-
 ## Why
 
 <!-- Explain the problem, requirement, or ticket outcome this change addresses. -->

--- a/docs/site/source/cast.rst
+++ b/docs/site/source/cast.rst
@@ -21,3 +21,10 @@ Result Contract
 .. automodule:: mlflow_monitor.result_contract
    :members:
    :show-inheritance:
+
+Identity
+---------
+
+.. automodule:: mlflow_monitor.identity
+   :members:
+   :show-inheritance:

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -148,6 +148,48 @@ class ContractCheckResult:
 
 
 @dataclass(frozen=True, slots=True)
+class CompatibilityEvidence:
+    """Run-scoped compatibility observation materialized from a Check reason.
+
+    Attributes:
+        compatibility_evidence_id: Deterministic identifier for this evidence.
+        monitoring_run_id: Monitoring Run that owns this evidence.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        baseline_source_run_id: Baseline Source Run used by the Contract check.
+        contract_id: Identifier of the resolved Contract.
+        contract_version: Version of the resolved Contract.
+        reason: Complete Contract Check reason represented by this evidence.
+    """
+
+    compatibility_evidence_id: str
+    monitoring_run_id: str
+    source_run_id: str
+    baseline_source_run_id: str
+    contract_id: str
+    contract_version: str
+    reason: ContractCheckReason
+
+    def __post_init__(self) -> None:
+        """Validate the immutable Compatibility Evidence shape."""
+        for field_name in (
+            "compatibility_evidence_id",
+            "monitoring_run_id",
+            "source_run_id",
+            "baseline_source_run_id",
+            "contract_id",
+            "contract_version",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"CompatibilityEvidence requires a non-empty string for field {field_name!r}."
+                )
+
+        if not isinstance(self.reason, ContractCheckReason):
+            raise ValueError("CompatibilityEvidence requires a ContractCheckReason for 'reason'.")
+
+
+@dataclass(frozen=True, slots=True)
 class Contract:
     """Resolved versioned comparability contract bound to a timeline.
 

--- a/src/mlflow_monitor/identity.py
+++ b/src/mlflow_monitor/identity.py
@@ -12,7 +12,7 @@ IDENTITY_SCHEME_VERSION = "v1"
 
 
 @dataclass(frozen=True, slots=True)
-class DiffIdentity:
+class _DiffIdentity:
     """Deterministic identity for one atomic metric Diff.
 
     Attributes:
@@ -42,7 +42,7 @@ class DiffIdentity:
 
 
 @dataclass(frozen=True, slots=True)
-class CompatibilityEvidenceIdentity:
+class _CompatibilityEvidenceIdentity:
     """Deterministic identity for one Compatibility Evidence record.
 
     Attributes:
@@ -94,7 +94,7 @@ def make_diff_id(
     return _make_identity(
         entity_type="diff",
         prefix="diff",
-        payload=DiffIdentity(
+        payload=_DiffIdentity(
             monitoring_run_id=monitoring_run_id,
             source_run_id=source_run_id,
             reference=reference,
@@ -128,7 +128,7 @@ def make_compatibility_evidence_id(
     return _make_identity(
         entity_type="compatibility_evidence",
         prefix="compatibility-evidence",
-        payload=CompatibilityEvidenceIdentity(
+        payload=_CompatibilityEvidenceIdentity(
             monitoring_run_id=monitoring_run_id,
             source_run_id=source_run_id,
             baseline_source_run_id=baseline_source_run_id,
@@ -143,7 +143,7 @@ def _make_identity(
     *,
     entity_type: str,
     prefix: str,
-    payload: DiffIdentity | CompatibilityEvidenceIdentity,
+    payload: _DiffIdentity | _CompatibilityEvidenceIdentity,
 ) -> str:
     """Hash one canonical versioned identity payload."""
     canonical_payload = {

--- a/src/mlflow_monitor/identity.py
+++ b/src/mlflow_monitor/identity.py
@@ -1,0 +1,104 @@
+"""Deterministic identity helpers for objective monitoring evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+from mlflow_monitor.domain import DiffReference
+
+IDENTITY_SCHEME_VERSION = "v1"
+
+
+def make_diff_id(
+    *,
+    monitoring_run_id: str,
+    source_run_id: str,
+    reference: DiffReference,
+    metric_name: str,
+) -> str:
+    """Build the stable identity for one atomic metric Diff.
+
+    Args:
+        monitoring_run_id: Monitoring Run that owns the Diff.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        reference: Complete comparison reference.
+        metric_name: Metric compared by the Diff.
+
+    Returns:
+        A versioned SHA-256 Diff identifier.
+    """
+    return _make_identity(
+        entity_type="diff",
+        prefix="diff",
+        payload={
+            "metric_name": metric_name,
+            "monitoring_run_id": monitoring_run_id,
+            "reference": {
+                "kind": reference.kind.value,
+                "monitoring_run_id": reference.monitoring_run_id,
+                "source_run_id": reference.source_run_id,
+            },
+            "source_run_id": source_run_id,
+        },
+    )
+
+
+def make_compatibility_evidence_id(
+    *,
+    monitoring_run_id: str,
+    source_run_id: str,
+    baseline_source_run_id: str,
+    contract_id: str,
+    contract_version: str,
+    reason_code: str,
+) -> str:
+    """Build the stable identity for one Compatibility Evidence record.
+
+    Args:
+        monitoring_run_id: Monitoring Run that owns the evidence.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        baseline_source_run_id: Baseline Source Run used by the Contract check.
+        contract_id: Identifier of the resolved Contract.
+        contract_version: Version of the resolved Contract.
+        reason_code: Machine-readable Contract Check reason code.
+
+    Returns:
+        A versioned SHA-256 Compatibility Evidence identifier.
+    """
+    return _make_identity(
+        entity_type="compatibility_evidence",
+        prefix="compatibility-evidence",
+        payload={
+            "baseline_source_run_id": baseline_source_run_id,
+            "contract_id": contract_id,
+            "contract_version": contract_version,
+            "monitoring_run_id": monitoring_run_id,
+            "reason_code": reason_code,
+            "source_run_id": source_run_id,
+        },
+    )
+
+
+def _make_identity(
+    *,
+    entity_type: str,
+    prefix: str,
+    payload: Mapping[str, object],
+) -> str:
+    """Hash one canonical versioned identity payload."""
+    canonical_payload = {
+        "entity_type": entity_type,
+        "identity_scheme_version": IDENTITY_SCHEME_VERSION,
+        **payload,
+    }
+    encoded = json.dumps(
+        canonical_payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return f"{prefix}-{IDENTITY_SCHEME_VERSION}-{digest}"

--- a/src/mlflow_monitor/identity.py
+++ b/src/mlflow_monitor/identity.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
-
-from attr import dataclass
+from dataclasses import dataclass
 
 from mlflow_monitor.domain import DiffReference
 
@@ -29,6 +27,19 @@ class DiffIdentity:
     reference: DiffReference
     metric_name: str
 
+    def to_dict(self) -> dict[str, object]:
+        """Convert the identity to a dictionary representation."""
+        return {
+            "monitoring_run_id": self.monitoring_run_id,
+            "source_run_id": self.source_run_id,
+            "reference": {
+                "kind": self.reference.kind.value,
+                "monitoring_run_id": self.reference.monitoring_run_id,
+                "source_run_id": self.reference.source_run_id,
+            },
+            "metric_name": self.metric_name,
+        }
+
 
 @dataclass(frozen=True, slots=True)
 class CompatibilityEvidenceIdentity:
@@ -49,6 +60,17 @@ class CompatibilityEvidenceIdentity:
     contract_id: str
     contract_version: str
     reason_code: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Convert the identity to a dictionary representation."""
+        return {
+            "monitoring_run_id": self.monitoring_run_id,
+            "source_run_id": self.source_run_id,
+            "baseline_source_run_id": self.baseline_source_run_id,
+            "contract_id": self.contract_id,
+            "contract_version": self.contract_version,
+            "reason_code": self.reason_code,
+        }
 
 
 def make_diff_id(
@@ -72,16 +94,12 @@ def make_diff_id(
     return _make_identity(
         entity_type="diff",
         prefix="diff",
-        payload={
-            "metric_name": metric_name,
-            "monitoring_run_id": monitoring_run_id,
-            "reference": {
-                "kind": reference.kind.value,
-                "monitoring_run_id": reference.monitoring_run_id,
-                "source_run_id": reference.source_run_id,
-            },
-            "source_run_id": source_run_id,
-        },
+        payload=DiffIdentity(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            reference=reference,
+            metric_name=metric_name,
+        ),
     )
 
 
@@ -110,14 +128,14 @@ def make_compatibility_evidence_id(
     return _make_identity(
         entity_type="compatibility_evidence",
         prefix="compatibility-evidence",
-        payload={
-            "baseline_source_run_id": baseline_source_run_id,
-            "contract_id": contract_id,
-            "contract_version": contract_version,
-            "monitoring_run_id": monitoring_run_id,
-            "reason_code": reason_code,
-            "source_run_id": source_run_id,
-        },
+        payload=CompatibilityEvidenceIdentity(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            baseline_source_run_id=baseline_source_run_id,
+            contract_id=contract_id,
+            contract_version=contract_version,
+            reason_code=reason_code,
+        ),
     )
 
 
@@ -125,13 +143,13 @@ def _make_identity(
     *,
     entity_type: str,
     prefix: str,
-    payload: Mapping[str, object],
+    payload: DiffIdentity | CompatibilityEvidenceIdentity,
 ) -> str:
     """Hash one canonical versioned identity payload."""
     canonical_payload = {
         "entity_type": entity_type,
         "identity_scheme_version": IDENTITY_SCHEME_VERSION,
-        **payload,
+        "payload": payload.to_dict(),
     }
     encoded = json.dumps(
         canonical_payload,

--- a/src/mlflow_monitor/identity.py
+++ b/src/mlflow_monitor/identity.py
@@ -6,9 +6,49 @@ import hashlib
 import json
 from collections.abc import Mapping
 
+from attr import dataclass
+
 from mlflow_monitor.domain import DiffReference
 
 IDENTITY_SCHEME_VERSION = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class DiffIdentity:
+    """Deterministic identity for one atomic metric Diff.
+
+    Attributes:
+        monitoring_run_id: Monitoring Run that owns the Diff.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        reference: Complete comparison reference.
+        metric_name: Metric compared by the Diff.
+    """
+
+    monitoring_run_id: str
+    source_run_id: str
+    reference: DiffReference
+    metric_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityEvidenceIdentity:
+    """Deterministic identity for one Compatibility Evidence record.
+
+    Attributes:
+        monitoring_run_id: Monitoring Run that owns the evidence.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        baseline_source_run_id: Baseline Source Run used by the Contract check.
+        contract_id: Identifier of the resolved Contract.
+        contract_version: Version of the resolved Contract.
+        reason_code: Machine-readable Contract Check reason code.
+    """
+
+    monitoring_run_id: str
+    source_run_id: str
+    baseline_source_run_id: str
+    contract_id: str
+    contract_version: str
+    reason_code: str
 
 
 def make_diff_id(

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -8,6 +8,7 @@ from mlflow_monitor.domain import (
     LKG,
     Baseline,
     ComparabilityStatus,
+    CompatibilityEvidence,
     ContractCheckReason,
     ContractCheckReasonCode,
     ContractCheckResult,
@@ -17,6 +18,7 @@ from mlflow_monitor.domain import (
     Timeline,
 )
 from mlflow_monitor.errors import InvariantViolation
+from mlflow_monitor.identity import make_compatibility_evidence_id, make_diff_id
 
 
 def validate_timeline_ownership(
@@ -168,6 +170,129 @@ def validate_finding_to_diff_evidence(finding: Finding, diff: Diff) -> None:
         )
 
     return None
+
+
+def validate_diff_identity(diff: Diff) -> None:
+    """Validate that a Diff carries its derived deterministic identity.
+
+    Args:
+        diff: Diff whose identity should be validated.
+
+    Raises:
+        InvariantViolation: If the supplied Diff identity is not canonical.
+
+    Returns:
+        None if the Diff identity is canonical.
+    """
+    expected_diff_id = make_diff_id(
+        monitoring_run_id=diff.monitoring_run_id,
+        source_run_id=diff.source_run_id,
+        reference=diff.reference,
+        metric_name=diff.metric_name,
+    )
+    if diff.diff_id != expected_diff_id:
+        raise InvariantViolation(
+            code="diff_identity_mismatch",
+            message=f"Diff identity {diff.diff_id!r} does not match its derived identity.",
+            entity="Diff",
+            field="diff_id",
+        )
+
+
+def validate_diff_identity_consistency(diffs: Sequence[Diff]) -> None:
+    """Reject conflicting Diff content under one deterministic identity.
+
+    Args:
+        diffs: Diff records to validate together.
+
+    Raises:
+        InvariantViolation: If an identity is invalid or maps to different content.
+
+    Returns:
+        None if all Diff identities and content are consistent.
+    """
+    diffs_by_id: dict[str, Diff] = {}
+    for diff in diffs:
+        validate_diff_identity(diff)
+        existing = diffs_by_id.get(diff.diff_id)
+        if existing is not None and existing != diff:
+            raise InvariantViolation(
+                code="diff_identity_content_conflict",
+                message=f"Diff identity {diff.diff_id!r} maps to conflicting content.",
+                entity="Diff",
+                field="diff_id",
+            )
+        diffs_by_id[diff.diff_id] = diff
+
+
+def validate_compatibility_evidence_identity(evidence: CompatibilityEvidence) -> None:
+    """Validate one Compatibility Evidence identity and reason.
+
+    Args:
+        evidence: Compatibility Evidence to validate.
+
+    Raises:
+        InvariantViolation: If its reason or supplied identity is invalid.
+
+    Returns:
+        None if the Compatibility Evidence identity and reason are valid.
+    """
+    _validate_compatibility_evidence_id(evidence)
+    validate_contract_check_reason(evidence.reason)
+
+
+def validate_compatibility_evidence_identity_consistency(
+    evidence_records: Sequence[CompatibilityEvidence],
+) -> None:
+    """Reject conflicting Compatibility Evidence under one identity.
+
+    Args:
+        evidence_records: Compatibility Evidence records to validate together.
+
+    Raises:
+        InvariantViolation: If an identity is invalid or maps to different content.
+
+    Returns:
+        None if all Compatibility Evidence identities and content are consistent.
+    """
+    evidence_by_id: dict[str, CompatibilityEvidence] = {}
+    for evidence in evidence_records:
+        _validate_compatibility_evidence_id(evidence)
+        existing = evidence_by_id.get(evidence.compatibility_evidence_id)
+        if existing is not None and existing != evidence:
+            raise InvariantViolation(
+                code="compatibility_evidence_identity_content_conflict",
+                message=(
+                    "Compatibility Evidence identity "
+                    f"{evidence.compatibility_evidence_id!r} maps to conflicting content."
+                ),
+                entity="CompatibilityEvidence",
+                field="compatibility_evidence_id",
+            )
+        validate_contract_check_reason(evidence.reason)
+        evidence_by_id[evidence.compatibility_evidence_id] = evidence
+
+
+def _validate_compatibility_evidence_id(evidence: CompatibilityEvidence) -> None:
+    """Validate only the deterministic portion of Compatibility Evidence."""
+    expected_evidence_id = make_compatibility_evidence_id(
+        monitoring_run_id=evidence.monitoring_run_id,
+        source_run_id=evidence.source_run_id,
+        baseline_source_run_id=evidence.baseline_source_run_id,
+        contract_id=evidence.contract_id,
+        contract_version=evidence.contract_version,
+        reason_code=evidence.reason.code,
+    )
+    if evidence.compatibility_evidence_id != expected_evidence_id:
+        raise InvariantViolation(
+            code="compatibility_evidence_identity_mismatch",
+            message=(
+                "Compatibility Evidence identity "
+                f"{evidence.compatibility_evidence_id!r} does not match its derived identity."
+            ),
+            entity="CompatibilityEvidence",
+            field="compatibility_evidence_id",
+        )
 
 
 def validate_contract_check_result(result: ContractCheckResult) -> None:

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -307,16 +307,17 @@ def validate_contract_check_result(result: ContractCheckResult) -> None:
     Returns:
         None if the contract-check result is valid.
     """
-    reason_codes: set[str] = set()
+    reason_codes: set[str] = set(
+        reason.code for reason in result.reasons if isinstance(reason.code, str)
+    )
+    if len(reason_codes) != len(result.reasons):
+        raise InvariantViolation(
+            code="contract_check_reason_code_duplicate",
+            message="Contract check reason codes must be unique.",
+            entity="ContractCheckResult",
+            field="reasons",
+        )
     for reason in result.reasons:
-        if reason.code in reason_codes:
-            raise InvariantViolation(
-                code="contract_check_reason_code_duplicate",
-                message=f"Contract check reason code {reason.code!r} must be unique.",
-                entity="ContractCheckResult",
-                field="reasons",
-            )
-        reason_codes.add(reason.code)
         validate_contract_check_reason(reason)
 
     _validate_contract_check_status(result)

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -182,8 +182,17 @@ def validate_contract_check_result(result: ContractCheckResult) -> None:
     Returns:
         None if the contract-check result is valid.
     """
+    reason_codes: set[str] = set()
     for reason in result.reasons:
         validate_contract_check_reason(reason)
+        if reason.code in reason_codes:
+            raise InvariantViolation(
+                code="contract_check_reason_code_duplicate",
+                message=f"Contract check reason code {reason.code!r} must be unique.",
+                entity="ContractCheckResult",
+                field="reasons",
+            )
+        reason_codes.add(reason.code)
 
     _validate_contract_check_status(result)
 

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -309,7 +309,6 @@ def validate_contract_check_result(result: ContractCheckResult) -> None:
     """
     reason_codes: set[str] = set()
     for reason in result.reasons:
-        validate_contract_check_reason(reason)
         if reason.code in reason_codes:
             raise InvariantViolation(
                 code="contract_check_reason_code_duplicate",
@@ -318,6 +317,7 @@ def validate_contract_check_result(result: ContractCheckResult) -> None:
                 field="reasons",
             )
         reason_codes.add(reason.code)
+        validate_contract_check_reason(reason)
 
     _validate_contract_check_status(result)
 

--- a/tests/test_compatibility_evidence.py
+++ b/tests/test_compatibility_evidence.py
@@ -1,0 +1,71 @@
+"""Specifications for run-scoped Compatibility Evidence."""
+
+from dataclasses import FrozenInstanceError, fields
+
+import pytest
+
+from mlflow_monitor.domain import CompatibilityEvidence, ContractCheckReason
+
+
+def _evidence(**overrides: object) -> CompatibilityEvidence:
+    values: dict[str, object] = {
+        "compatibility_evidence_id": "compatibility-evidence-v1-example",
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "baseline_source_run_id": "train-run-baseline",
+        "contract_id": "default_permissive",
+        "contract_version": "v0",
+        "reason": ContractCheckReason(
+            code="environment_mismatch",
+            message="Execution environment does not match the baseline.",
+            blocking=False,
+        ),
+    }
+    values.update(overrides)
+    return CompatibilityEvidence(**values)  # type: ignore[arg-type]
+
+
+def test_compatibility_evidence_has_approved_shape() -> None:
+    evidence = _evidence()
+
+    assert tuple(field.name for field in fields(evidence)) == (
+        "compatibility_evidence_id",
+        "monitoring_run_id",
+        "source_run_id",
+        "baseline_source_run_id",
+        "contract_id",
+        "contract_version",
+        "reason",
+    )
+
+
+def test_compatibility_evidence_is_immutable() -> None:
+    evidence = _evidence()
+
+    with pytest.raises(FrozenInstanceError):
+        evidence.reason = ContractCheckReason(  # type: ignore[misc]
+            code="schema_mismatch",
+            message="Data schema does not match the baseline.",
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "compatibility_evidence_id",
+        "monitoring_run_id",
+        "source_run_id",
+        "baseline_source_run_id",
+        "contract_id",
+        "contract_version",
+    ],
+)
+def test_compatibility_evidence_rejects_empty_identity_fields(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _evidence(**{field: " "})
+
+
+def test_compatibility_evidence_requires_a_contract_check_reason() -> None:
+    with pytest.raises(ValueError, match="reason"):
+        _evidence(reason=None)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,371 @@
+"""Specifications for deterministic evidence identities."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import replace
+
+import pytest
+
+from mlflow_monitor.domain import (
+    CompatibilityEvidence,
+    ContractCheckReason,
+    Diff,
+    DiffReference,
+    DiffReferenceKind,
+)
+from mlflow_monitor.errors import InvariantViolation
+from mlflow_monitor.identity import make_compatibility_evidence_id, make_diff_id
+from mlflow_monitor.invariant import (
+    validate_compatibility_evidence_identity,
+    validate_compatibility_evidence_identity_consistency,
+    validate_diff_identity,
+    validate_diff_identity_consistency,
+)
+
+DIFF_ID_FIXTURE = "diff-v1-ea16f63f7055927b29f5a1b14fc5fefb3b80326d682e327df49a0164d4f19db6"
+COMPATIBILITY_EVIDENCE_ID_FIXTURE = (
+    "compatibility-evidence-v1-6468a0e4e6cbde077484687bfd2e45b64e1d0ce196f41a69ae845f7ac836d1b5"
+)
+
+
+def _baseline_reference() -> DiffReference:
+    return DiffReference(
+        kind=DiffReferenceKind.BASELINE,
+        monitoring_run_id=None,
+        source_run_id="train-run-baseline",
+    )
+
+
+def _previous_reference() -> DiffReference:
+    return DiffReference(
+        kind=DiffReferenceKind.PREVIOUS,
+        monitoring_run_id="monitoring-run-previous",
+        source_run_id="train-run-previous",
+    )
+
+
+def _diff(**overrides: object) -> Diff:
+    values: dict[str, object] = {
+        "diff_id": DIFF_ID_FIXTURE,
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "reference": _baseline_reference(),
+        "metric_name": "accuracy",
+        "current_value": 0.75,
+        "reference_value": 0.5,
+        "delta": 0.25,
+    }
+    values.update(overrides)
+    return Diff(**values)  # type: ignore[arg-type]
+
+
+def _compatibility_evidence(
+    *,
+    reason: ContractCheckReason | None = None,
+) -> CompatibilityEvidence:
+    return CompatibilityEvidence(
+        compatibility_evidence_id=COMPATIBILITY_EVIDENCE_ID_FIXTURE,
+        monitoring_run_id="monitoring-run-current",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        contract_id="default_permissive",
+        contract_version="v0",
+        reason=reason
+        or ContractCheckReason(
+            code="environment_mismatch",
+            message="Execution environment does not match the baseline.",
+            blocking=False,
+        ),
+    )
+
+
+def test_diff_id_matches_fixed_fixture() -> None:
+    assert (
+        make_diff_id(
+            monitoring_run_id="monitoring-run-current",
+            source_run_id="train-run-current",
+            reference=_baseline_reference(),
+            metric_name="accuracy",
+        )
+        == DIFF_ID_FIXTURE
+    )
+
+
+def test_compatibility_evidence_id_matches_fixed_fixture() -> None:
+    assert (
+        make_compatibility_evidence_id(
+            monitoring_run_id="monitoring-run-current",
+            source_run_id="train-run-current",
+            baseline_source_run_id="train-run-baseline",
+            contract_id="default_permissive",
+            contract_version="v0",
+            reason_code="environment_mismatch",
+        )
+        == COMPATIBILITY_EVIDENCE_ID_FIXTURE
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"monitoring_run_id": "monitoring-run-other"},
+        {"source_run_id": "train-run-other"},
+        {"reference": _baseline_reference()},
+        {
+            "reference": DiffReference(
+                kind=DiffReferenceKind.PREVIOUS,
+                monitoring_run_id="monitoring-run-other",
+                source_run_id="train-run-previous",
+            )
+        },
+        {
+            "reference": DiffReference(
+                kind=DiffReferenceKind.PREVIOUS,
+                monitoring_run_id="monitoring-run-previous",
+                source_run_id="train-run-other",
+            )
+        },
+        {"metric_name": "precision"},
+    ],
+)
+def test_diff_id_changes_with_every_semantic_identity_component(
+    overrides: dict[str, object],
+) -> None:
+    values: dict[str, object] = {
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "reference": _previous_reference(),
+        "metric_name": "accuracy",
+    }
+    original_id = make_diff_id(**values)  # type: ignore[arg-type]
+    values.update(overrides)
+
+    assert make_diff_id(**values) != original_id  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "monitoring_run_id",
+        "source_run_id",
+        "baseline_source_run_id",
+        "contract_id",
+        "contract_version",
+        "reason_code",
+    ],
+)
+def test_compatibility_evidence_id_changes_with_every_semantic_component(field: str) -> None:
+    values = {
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "baseline_source_run_id": "train-run-baseline",
+        "contract_id": "default_permissive",
+        "contract_version": "v0",
+        "reason_code": "environment_mismatch",
+    }
+    original_id = make_compatibility_evidence_id(**values)
+    values[field] = f"different-{field}"
+
+    assert make_compatibility_evidence_id(**values) != original_id
+
+
+def test_diff_id_excludes_numeric_evidence_values() -> None:
+    original = _diff()
+    changed = replace(
+        original,
+        current_value=0.9,
+        reference_value=0.4,
+        delta=0.5,
+    )
+
+    assert _make_diff_id_for(original) == _make_diff_id_for(changed)
+
+
+def test_compatibility_evidence_id_excludes_reason_content() -> None:
+    original = _compatibility_evidence()
+    changed = _compatibility_evidence(
+        reason=ContractCheckReason(
+            code=original.reason.code,
+            message="Changed message under the same semantic identity.",
+            blocking=True,
+        )
+    )
+
+    assert _make_compatibility_evidence_id_for(original) == (
+        _make_compatibility_evidence_id_for(changed)
+    )
+
+
+def test_canonical_encoding_does_not_conflate_delimited_values() -> None:
+    first = make_compatibility_evidence_id(
+        monitoring_run_id="monitoring|source",
+        source_run_id="training",
+        baseline_source_run_id="baseline",
+        contract_id="contract",
+        contract_version="v0",
+        reason_code="environment_mismatch",
+    )
+    second = make_compatibility_evidence_id(
+        monitoring_run_id="monitoring",
+        source_run_id="source|training",
+        baseline_source_run_id="baseline",
+        contract_id="contract",
+        contract_version="v0",
+        reason_code="environment_mismatch",
+    )
+
+    assert first != second
+
+
+@pytest.mark.parametrize("hash_seed", ["1", "8675309"])
+def test_identity_fixtures_are_stable_across_processes(hash_seed: str) -> None:
+    script = """
+from mlflow_monitor.domain import DiffReference, DiffReferenceKind
+from mlflow_monitor.identity import make_compatibility_evidence_id, make_diff_id
+
+reference = DiffReference(
+    kind=DiffReferenceKind.BASELINE,
+    monitoring_run_id=None,
+    source_run_id="train-run-baseline",
+)
+print(make_diff_id(
+    monitoring_run_id="monitoring-run-current",
+    source_run_id="train-run-current",
+    reference=reference,
+    metric_name="accuracy",
+))
+print(make_compatibility_evidence_id(
+    monitoring_run_id="monitoring-run-current",
+    source_run_id="train-run-current",
+    baseline_source_run_id="train-run-baseline",
+    contract_id="default_permissive",
+    contract_version="v0",
+    reason_code="environment_mismatch",
+))
+"""
+    environment = dict(os.environ)
+    environment["PYTHONHASHSEED"] = hash_seed
+
+    output = subprocess.check_output(  # noqa: S603
+        [sys.executable, "-c", script],
+        env=environment,
+        text=True,
+    )
+
+    assert output.splitlines() == [DIFF_ID_FIXTURE, COMPATIBILITY_EVIDENCE_ID_FIXTURE]
+
+
+def test_diff_identity_validation_accepts_derived_id() -> None:
+    validate_diff_identity(_diff())
+
+
+def test_diff_identity_validation_rejects_incorrect_id() -> None:
+    with pytest.raises(InvariantViolation) as exc_info:
+        validate_diff_identity(_diff(diff_id="diff-v1-incorrect"))
+
+    error = exc_info.value
+    assert error.code == "diff_identity_mismatch"
+    assert error.entity == "Diff"
+    assert error.field == "diff_id"
+
+
+def test_compatibility_evidence_identity_validation_accepts_derived_id() -> None:
+    validate_compatibility_evidence_identity(_compatibility_evidence())
+
+
+def test_compatibility_evidence_identity_validation_rejects_incorrect_id() -> None:
+    evidence = replace(
+        _compatibility_evidence(),
+        compatibility_evidence_id="compatibility-evidence-v1-incorrect",
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        validate_compatibility_evidence_identity(evidence)
+
+    error = exc_info.value
+    assert error.code == "compatibility_evidence_identity_mismatch"
+    assert error.entity == "CompatibilityEvidence"
+    assert error.field == "compatibility_evidence_id"
+
+
+def test_diff_identity_consistency_accepts_identical_retries() -> None:
+    diff = _diff()
+
+    validate_diff_identity_consistency((diff, diff))
+
+
+def test_diff_identity_consistency_rejects_changed_numeric_content() -> None:
+    original = _diff()
+    changed = replace(
+        original,
+        current_value=0.9,
+        reference_value=0.4,
+        delta=0.5,
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        validate_diff_identity_consistency((original, changed))
+
+    error = exc_info.value
+    assert error.code == "diff_identity_content_conflict"
+    assert error.entity == "Diff"
+    assert error.field == "diff_id"
+
+
+def test_compatibility_evidence_identity_consistency_accepts_identical_retries() -> None:
+    evidence = _compatibility_evidence()
+
+    validate_compatibility_evidence_identity_consistency((evidence, evidence))
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        ContractCheckReason(
+            code="environment_mismatch",
+            message="Changed message under the same semantic identity.",
+            blocking=False,
+        ),
+        ContractCheckReason(
+            code="environment_mismatch",
+            message="Execution environment does not match the baseline.",
+            blocking=True,
+        ),
+    ],
+)
+def test_compatibility_evidence_identity_consistency_rejects_changed_reason_content(
+    reason: ContractCheckReason,
+) -> None:
+    original = _compatibility_evidence()
+    changed = _compatibility_evidence(reason=reason)
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        validate_compatibility_evidence_identity_consistency((original, changed))
+
+    error = exc_info.value
+    assert error.code == "compatibility_evidence_identity_content_conflict"
+    assert error.entity == "CompatibilityEvidence"
+    assert error.field == "compatibility_evidence_id"
+
+
+def _make_diff_id_for(diff: Diff) -> str:
+    return make_diff_id(
+        monitoring_run_id=diff.monitoring_run_id,
+        source_run_id=diff.source_run_id,
+        reference=diff.reference,
+        metric_name=diff.metric_name,
+    )
+
+
+def _make_compatibility_evidence_id_for(evidence: CompatibilityEvidence) -> str:
+    return make_compatibility_evidence_id(
+        monitoring_run_id=evidence.monitoring_run_id,
+        source_run_id=evidence.source_run_id,
+        baseline_source_run_id=evidence.baseline_source_run_id,
+        contract_id=evidence.contract_id,
+        contract_version=evidence.contract_version,
+        reason_code=evidence.reason.code,
+    )

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -17,7 +17,12 @@ from mlflow_monitor.domain import (
     DiffReferenceKind,
 )
 from mlflow_monitor.errors import InvariantViolation
-from mlflow_monitor.identity import make_compatibility_evidence_id, make_diff_id
+from mlflow_monitor.identity import (
+    CompatibilityEvidenceIdentity,
+    DiffIdentity,
+    make_compatibility_evidence_id,
+    make_diff_id,
+)
 from mlflow_monitor.invariant import (
     validate_compatibility_evidence_identity,
     validate_compatibility_evidence_identity_consistency,
@@ -25,9 +30,9 @@ from mlflow_monitor.invariant import (
     validate_diff_identity_consistency,
 )
 
-DIFF_ID_FIXTURE = "diff-v1-ea16f63f7055927b29f5a1b14fc5fefb3b80326d682e327df49a0164d4f19db6"
+DIFF_ID_FIXTURE = "diff-v1-6b7105add110bd5993e8eb644e7231d49b10ac8e638a454dd9020befcec736b7"
 COMPATIBILITY_EVIDENCE_ID_FIXTURE = (
-    "compatibility-evidence-v1-6468a0e4e6cbde077484687bfd2e45b64e1d0ce196f41a69ae845f7ac836d1b5"
+    "compatibility-evidence-v1-2d64d9f5989b9a16423f28e762454971f0a19b432735457c44efa144c8fc0525"
 )
 
 
@@ -80,6 +85,46 @@ def _compatibility_evidence(
             blocking=False,
         ),
     )
+
+
+def test_diff_identity_container_serializes_semantic_components() -> None:
+    identity = DiffIdentity(
+        monitoring_run_id="monitoring-run-current",
+        source_run_id="train-run-current",
+        reference=_baseline_reference(),
+        metric_name="accuracy",
+    )
+
+    assert identity.to_dict() == {
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "reference": {
+            "kind": "baseline",
+            "monitoring_run_id": None,
+            "source_run_id": "train-run-baseline",
+        },
+        "metric_name": "accuracy",
+    }
+
+
+def test_compatibility_evidence_identity_container_serializes_semantic_components() -> None:
+    identity = CompatibilityEvidenceIdentity(
+        monitoring_run_id="monitoring-run-current",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        contract_id="default_permissive",
+        contract_version="v0",
+        reason_code="environment_mismatch",
+    )
+
+    assert identity.to_dict() == {
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "baseline_source_run_id": "train-run-baseline",
+        "contract_id": "default_permissive",
+        "contract_version": "v0",
+        "reason_code": "environment_mismatch",
+    }
 
 
 def test_diff_id_matches_fixed_fixture() -> None:

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -18,8 +18,8 @@ from mlflow_monitor.domain import (
 )
 from mlflow_monitor.errors import InvariantViolation
 from mlflow_monitor.identity import (
-    CompatibilityEvidenceIdentity,
-    DiffIdentity,
+    _CompatibilityEvidenceIdentity,
+    _DiffIdentity,
     make_compatibility_evidence_id,
     make_diff_id,
 )
@@ -88,7 +88,7 @@ def _compatibility_evidence(
 
 
 def test_diff_identity_container_serializes_semantic_components() -> None:
-    identity = DiffIdentity(
+    identity = _DiffIdentity(
         monitoring_run_id="monitoring-run-current",
         source_run_id="train-run-current",
         reference=_baseline_reference(),
@@ -108,7 +108,7 @@ def test_diff_identity_container_serializes_semantic_components() -> None:
 
 
 def test_compatibility_evidence_identity_container_serializes_semantic_components() -> None:
-    identity = CompatibilityEvidenceIdentity(
+    identity = _CompatibilityEvidenceIdentity(
         monitoring_run_id="monitoring-run-current",
         source_run_id="train-run-current",
         baseline_source_run_id="train-run-baseline",

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -369,6 +369,25 @@ class TestInvariantContractCheckResult:
 
         validate_contract_check_result(result)
 
+    def test_contract_check_result_rejects_duplicate_reason_codes(self) -> None:
+        reason = ContractCheckReason(
+            code="environment_mismatch",
+            message="Execution environment does not match the baseline.",
+            blocking=False,
+        )
+        result = ContractCheckResult(
+            status=ComparabilityStatus.WARN,
+            reasons=(reason, reason),
+        )
+
+        with pytest.raises(InvariantViolation) as exc_info:
+            validate_contract_check_result(result)
+
+        error = exc_info.value
+        assert error.code == "contract_check_reason_code_duplicate"
+        assert error.entity == "ContractCheckResult"
+        assert error.field == "reasons"
+
     def test_contract_check_result_rejects_unknown_status(self) -> None:
         result = ContractCheckResult(
             status="unknown_status",  # type: ignore

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -388,6 +388,28 @@ class TestInvariantContractCheckResult:
         assert error.entity == "ContractCheckResult"
         assert error.field == "reasons"
 
+    def test_duplicate_reason_code_takes_precedence_over_changed_content(self) -> None:
+        result = ContractCheckResult(
+            status=ComparabilityStatus.WARN,
+            reasons=(
+                ContractCheckReason(
+                    code="environment_mismatch",
+                    message="Execution environment does not match the baseline.",
+                    blocking=False,
+                ),
+                ContractCheckReason(
+                    code="environment_mismatch",
+                    message="Changed duplicate content.",
+                    blocking=True,
+                ),
+            ),
+        )
+
+        with pytest.raises(InvariantViolation) as exc_info:
+            validate_contract_check_result(result)
+
+        assert exc_info.value.code == "contract_check_reason_code_duplicate"
+
     def test_contract_check_result_rejects_unknown_status(self) -> None:
         result = ContractCheckResult(
             status="unknown_status",  # type: ignore

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -252,6 +252,23 @@ class InvalidResultContractChecker:
         )
 
 
+class DuplicateReasonContractChecker:
+    """Test double returning duplicate Contract Check reason codes."""
+
+    def check(self, contract: Contract, context: object) -> ContractCheckResult:
+        """Return a result whose reason codes violate uniqueness."""
+        del contract, context
+        reason = ContractCheckReason(
+            code="environment_mismatch",
+            message="Execution environment does not match the baseline.",
+            blocking=False,
+        )
+        return ContractCheckResult(
+            status=ComparabilityStatus.WARN,
+            reasons=(reason, reason),
+        )
+
+
 def make_prepared_context(
     *,
     contract: Contract,
@@ -555,6 +572,32 @@ def test_execute_contract_check_rejects_invalid_checker_result() -> None:
             prepared_context=make_prepared_context(contract=CONTRACT),
             gateway=gateway,
             contract_checker=InvalidResultContractChecker(),
+        )
+
+    assert exc_info.value.code == "check_result_invalid"
+
+
+def test_execute_contract_check_rejects_duplicate_reason_codes() -> None:
+    """Check should reject checker results with duplicate reason codes."""
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+    for source_run_id in ("train-run-baseline", "train-run-123"):
+        gateway.add_source_run(
+            subject_id="churn_model",
+            source_run_id=source_run_id,
+            source_experiment="training/churn",
+            metrics={"f1": 0.91, "auc": 0.95},
+            artifacts=("metrics.json",),
+            environment={"python": "3.12"},
+            features=("age", "income"),
+            schema={"age": "int", "income": "float"},
+            data_scope="validation:2026-03-01",
+        )
+
+    with pytest.raises(CheckStageError) as exc_info:
+        execute_contract_check(
+            prepared_context=make_prepared_context(contract=CONTRACT),
+            gateway=gateway,
+            contract_checker=DuplicateReasonContractChecker(),
         )
 
     assert exc_info.value.code == "check_result_invalid"


### PR DESCRIPTION
## What changed

- Add immutable run-scoped Compatibility Evidence with paired Monitoring Run and Source Training Run identity.
- Reject duplicate Contract Check reason codes before content validation.
- Add canonical versioned SHA-256 identities for Diffs and Compatibility Evidence.
- Add fail-closed identity mismatch and conflicting-content validation with fixed cross-process fixtures.

## Why

V0-004 separates structural Contract observations from metric Diffs and establishes deterministic evidence identity before later Analyze and persistence tickets consume these records.

## Impact

This is a developer-facing domain foundation. The existing `create -> prepare -> check` runtime behavior and top-level package facade remain unchanged. Analyze materialization, artifact persistence, Finding identities, and gateway integration are intentionally deferred.

## Validation

- [x] `uv sync --extra dev -- group doc`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv build`
- [ ] Update `docs/v0/` — developer site
- [x] Update `docs/site/` — no public behavior or documentation change in this ticket