### PR TITLE
Add readthedoc yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - doc
+
+sphinx:
+  configuration: docs/site/source/conf.py
+  fail_on_warning: true

--- a/docs/site/source/conf.py
+++ b/docs/site/source/conf.py
@@ -9,7 +9,8 @@ sys.path.insert(0, str(ROOT / "src"))
 project = "mlflow-monitor"
 copyright = "2026, Zheng Shi"
 author = "Zheng Shi"
-release = "0.1.0"
+release = "0.2.0.dev0"
+version = "0.2.0"
 
 autodoc_mock_imports = ["haystack"]
 


### PR DESCRIPTION
## What changed

Add `.readthedocs.yaml` for read the docs hostig
## Why

Having a persistent hosted doc site would make the development easier and communications easier across team.
## Impact


## Validation

- [ ] `uv sync --extra dev --group doc`
- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run pyright`
- [ ] `uv build`
- [ ] Update `docs/v0/`
- [x] Update `docs/site/`

<!-- Validation omissions, if any: -->
no validation was run because there was no changes in addition to docs 