### PR TITLE
[V0-005] Replace Finding models and define the policy protocol

### DIFF
--- a/docs/site/source/cast.rst
+++ b/docs/site/source/cast.rst
@@ -28,3 +28,10 @@ Identity
 .. automodule:: mlflow_monitor.identity
    :members:
    :show-inheritance:
+
+Finding Policy
+--------------
+
+.. automodule:: mlflow_monitor.finding_policy
+   :members:
+   :show-inheritance:

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -410,26 +410,141 @@ class Diff:
 
 
 @dataclass(frozen=True, slots=True)
-class Finding:
-    """Interpreted issue derived from one or more supporting diffs.
+class FindingDraft:
+    """Transient policy conclusion awaiting package-owned materialization.
 
     Attributes:
-        finding_id: Unique identifier for the finding record.
-        monitoring_run_id: The ID of the monitoring_run this finding is associated with.
-        severity: The severity level of the finding (e.g., low, medium, high, critical).
-        category: A string categorizing the type of issue this finding represents.
-        summary: A human-readable summary describing the finding.
-        evidence_diff_ids: A tuple of diff IDs that provide evidence supporting this finding.
-        recommendation: A human-readable rec for addressing the issue described by this finding.
+        finding_rule_id: Stable rule identity within the Finding policy.
+        severity: Priority assigned by the Finding policy.
+        category: Category assigned by the Finding policy.
+        summary: Human-readable conclusion produced by the Finding policy.
+        recommendation: Human-readable recommended response.
+        evidence_diff_ids: Diff identities supporting the conclusion.
+        evidence_compatibility_ids: Compatibility Evidence identities supporting
+            the conclusion.
+    """
+
+    finding_rule_id: str
+    severity: FindingSeverity
+    category: str
+    summary: str
+    recommendation: str
+    evidence_diff_ids: tuple[str, ...]
+    evidence_compatibility_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Validate and freeze the transient Finding conclusion."""
+        _validate_finding_text_fields(
+            entity="FindingDraft",
+            value=self,
+            field_names=(
+                "finding_rule_id",
+                "category",
+                "summary",
+                "recommendation",
+            ),
+        )
+        _validate_finding_severity(entity="FindingDraft", severity=self.severity)
+        _freeze_finding_evidence(self)
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """Immutable policy conclusion for one Monitoring Run.
+
+    Attributes:
+        finding_id: Deterministic identity for the Finding.
+        monitoring_run_id: Monitoring Run that owns the Finding.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        finding_policy_id: Identifier of the Finding policy that emitted the draft.
+        finding_policy_version: Version of the Finding policy that emitted the draft.
+        finding_rule_id: Stable rule identity within the Finding policy.
+        severity: Priority assigned by the Finding policy.
+        category: Category assigned by the Finding policy.
+        summary: Human-readable conclusion produced by the Finding policy.
+        recommendation: Human-readable recommended response.
+        evidence_diff_ids: Diff identities supporting the conclusion.
+        evidence_compatibility_ids: Compatibility Evidence identities supporting
+            the conclusion.
     """
 
     finding_id: str
     monitoring_run_id: str
+    source_run_id: str
+    finding_policy_id: str
+    finding_policy_version: str
+    finding_rule_id: str
     severity: FindingSeverity
     category: str
     summary: str
-    evidence_diff_ids: tuple[str, ...]
     recommendation: str
+    evidence_diff_ids: tuple[str, ...]
+    evidence_compatibility_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Validate and freeze the materialized Finding conclusion."""
+        _validate_finding_text_fields(
+            entity="Finding",
+            value=self,
+            field_names=(
+                "finding_id",
+                "monitoring_run_id",
+                "source_run_id",
+                "finding_policy_id",
+                "finding_policy_version",
+                "finding_rule_id",
+                "category",
+                "summary",
+                "recommendation",
+            ),
+        )
+        _validate_finding_severity(entity="Finding", severity=self.severity)
+        _freeze_finding_evidence(self)
+
+
+def _validate_finding_text_fields(
+    *,
+    entity: str,
+    value: object,
+    field_names: tuple[str, ...],
+) -> None:
+    """Validate required Finding text and identity fields."""
+    for field_name in field_names:
+        field_value = getattr(value, field_name)
+        if not isinstance(field_value, str) or not field_value.strip():
+            raise ValueError(f"{entity} requires a non-empty string for field {field_name!r}.")
+
+
+def _validate_finding_severity(*, entity: str, severity: object) -> None:
+    """Validate that Finding severity uses the canonical enum."""
+    if not isinstance(severity, FindingSeverity):
+        raise ValueError(f"{entity} requires a FindingSeverity for field 'severity'.")
+
+
+def _freeze_finding_evidence(value: FindingDraft | Finding) -> None:
+    """Defensively freeze and validate both Finding evidence collections."""
+    entity = type(value).__name__
+    evidence_collections: dict[str, tuple[str, ...]] = {}
+    for field_name in ("evidence_diff_ids", "evidence_compatibility_ids"):
+        supplied_ids = getattr(value, field_name)
+        if isinstance(supplied_ids, str):
+            raise ValueError(f"{entity} requires a collection for field {field_name!r}.")
+        try:
+            evidence_ids = tuple(supplied_ids)
+        except TypeError as exc:
+            raise ValueError(f"{entity} requires a collection for field {field_name!r}.") from exc
+        if any(
+            not isinstance(evidence_id, str) or not evidence_id.strip()
+            for evidence_id in evidence_ids
+        ):
+            raise ValueError(
+                f"{entity} requires non-empty string identities in field {field_name!r}."
+            )
+        evidence_collections[field_name] = evidence_ids
+        object.__setattr__(value, field_name, evidence_ids)
+
+    if not any(evidence_collections.values()):
+        raise ValueError(f"{entity} requires at least one evidence identity.")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mlflow_monitor/finding_policy.py
+++ b/src/mlflow_monitor/finding_policy.py
@@ -1,0 +1,100 @@
+"""Finding policy boundary and package-owned Finding materialization."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from mlflow_monitor.domain import CompatibilityEvidence, Diff, Finding, FindingDraft
+from mlflow_monitor.errors import InvariantViolation
+from mlflow_monitor.identity import make_finding_id
+from mlflow_monitor.invariant import (
+    validate_compatibility_evidence_identity_consistency,
+    validate_diff_identity_consistency,
+    validate_finding_evidence,
+    validate_finding_identity,
+)
+
+
+def materialize_finding_drafts(
+    *,
+    monitoring_run_id: str,
+    source_run_id: str,
+    finding_policy_id: str,
+    finding_policy_version: str,
+    drafts: Sequence[FindingDraft],
+    diffs: Sequence[Diff],
+    compatibility_evidence: Sequence[CompatibilityEvidence],
+) -> tuple[Finding, ...]:
+    """Validate policy drafts and attach package-owned Finding identity.
+
+    Args:
+        monitoring_run_id: Monitoring Run that owns the Findings.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        finding_policy_id: Identifier of the policy that emitted the drafts.
+        finding_policy_version: Version of the policy that emitted the drafts.
+        drafts: Transient Finding conclusions emitted by the policy.
+        diffs: Complete Diff records supplied to the policy.
+        compatibility_evidence: Complete Compatibility Evidence records supplied
+            to the policy.
+
+    Returns:
+        Canonically ordered materialized Findings with identical retries removed.
+
+    Raises:
+        InvariantViolation: If a draft is invalid, references invalid evidence, or
+            conflicts with another draft under one deterministic identity.
+    """
+    validate_diff_identity_consistency(diffs)
+    validate_compatibility_evidence_identity_consistency(compatibility_evidence)
+
+    findings_by_id: dict[str, Finding] = {}
+    for draft in drafts:
+        if not isinstance(draft, FindingDraft):
+            raise InvariantViolation(
+                code="finding_draft_invalid",
+                message="Finding policy output must contain only FindingDraft values.",
+                entity="FindingDraft",
+            )
+
+        evidence_diff_ids = tuple(sorted(draft.evidence_diff_ids))
+        evidence_compatibility_ids = tuple(sorted(draft.evidence_compatibility_ids))
+        finding = Finding(
+            finding_id=make_finding_id(
+                monitoring_run_id=monitoring_run_id,
+                source_run_id=source_run_id,
+                finding_policy_id=finding_policy_id,
+                finding_policy_version=finding_policy_version,
+                finding_rule_id=draft.finding_rule_id,
+                evidence_diff_ids=evidence_diff_ids,
+                evidence_compatibility_ids=evidence_compatibility_ids,
+            ),
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            finding_policy_id=finding_policy_id,
+            finding_policy_version=finding_policy_version,
+            finding_rule_id=draft.finding_rule_id,
+            severity=draft.severity,
+            category=draft.category,
+            summary=draft.summary,
+            recommendation=draft.recommendation,
+            evidence_diff_ids=evidence_diff_ids,
+            evidence_compatibility_ids=evidence_compatibility_ids,
+        )
+        validate_finding_evidence(
+            finding,
+            diffs=diffs,
+            compatibility_evidence=compatibility_evidence,
+        )
+        validate_finding_identity(finding)
+
+        existing = findings_by_id.get(finding.finding_id)
+        if existing is not None and existing != finding:
+            raise InvariantViolation(
+                code="finding_identity_content_conflict",
+                message=f"Finding identity {finding.finding_id!r} maps to conflicting content.",
+                entity="Finding",
+                field="finding_id",
+            )
+        findings_by_id[finding.finding_id] = finding
+
+    return tuple(findings_by_id[finding_id] for finding_id in sorted(findings_by_id))

--- a/src/mlflow_monitor/finding_policy.py
+++ b/src/mlflow_monitor/finding_policy.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from typing import Protocol
 
-from mlflow_monitor.domain import CompatibilityEvidence, Diff, Finding, FindingDraft
+from mlflow_monitor.domain import (
+    CompatibilityEvidence,
+    Diff,
+    Finding,
+    FindingDraft,
+    ReferenceComparisonCoverage,
+)
 from mlflow_monitor.errors import InvariantViolation
 from mlflow_monitor.identity import make_finding_id
 from mlflow_monitor.invariant import (
@@ -13,6 +20,56 @@ from mlflow_monitor.invariant import (
     validate_finding_evidence,
     validate_finding_identity,
 )
+
+type JSONScalar = str | int | float | bool | None
+type JSONValue = JSONScalar | list[JSONValue] | Mapping[str, JSONValue]
+type FrozenJSONValue = JSONScalar | tuple[FrozenJSONValue, ...] | Mapping[str, FrozenJSONValue]
+type FrozenFindingPolicyParameters = Mapping[str, FrozenJSONValue]
+
+
+class FindingPolicy(Protocol):
+    """Registered extension point for versioned Finding interpretation."""
+
+    finding_policy_id: str
+    finding_policy_version: str
+
+    def validate_parameters(
+        self,
+        parameters: Mapping[str, JSONValue],
+    ) -> FrozenFindingPolicyParameters:
+        """Validate and freeze one Recipe policy-parameter mapping.
+
+        Args:
+            parameters: JSON-compatible parameters from one Recipe binding.
+
+        Returns:
+            Validated parameters frozen for later policy evaluation.
+        """
+        ...
+
+    def evaluate(
+        self,
+        *,
+        parameters: FrozenFindingPolicyParameters,
+        diffs: tuple[Diff, ...],
+        compatibility_evidence: tuple[CompatibilityEvidence, ...],
+        reference_comparison_coverage: tuple[ReferenceComparisonCoverage, ...],
+    ) -> tuple[FindingDraft, ...]:
+        """Propose transient Finding Drafts from immutable Analyze inputs.
+
+        Args:
+            parameters: Validated frozen parameters for this policy binding.
+            diffs: Immutable atomic metric Diffs from the current Analyze output.
+            compatibility_evidence: Immutable Compatibility Evidence from the
+                current Analyze output.
+            reference_comparison_coverage: Immutable coverage groups from the
+                current Analyze output.
+
+        Returns:
+            Transient Finding Drafts for package-owned validation and
+            materialization.
+        """
+        ...
 
 
 def materialize_finding_drafts(

--- a/src/mlflow_monitor/finding_policy.py
+++ b/src/mlflow_monitor/finding_policy.py
@@ -17,7 +17,7 @@ from mlflow_monitor.identity import make_finding_id
 from mlflow_monitor.invariant import (
     validate_compatibility_evidence_identity_consistency,
     validate_diff_identity_consistency,
-    validate_finding_evidence,
+    validate_finding_evidence_references,
     validate_finding_identity,
 )
 
@@ -95,7 +95,8 @@ def materialize_finding_drafts(
             to the policy.
 
     Returns:
-        Canonically ordered materialized Findings with identical retries removed.
+        Canonically ordered materialized Findings with evidence identities sorted
+        and deduplicated and identical retries removed.
 
     Raises:
         InvariantViolation: If a draft is invalid, references invalid evidence, or
@@ -103,6 +104,10 @@ def materialize_finding_drafts(
     """
     validate_diff_identity_consistency(diffs)
     validate_compatibility_evidence_identity_consistency(compatibility_evidence)
+    diffs_by_id = {diff.diff_id: diff for diff in diffs}
+    compatibility_evidence_by_id = {
+        evidence.compatibility_evidence_id: evidence for evidence in compatibility_evidence
+    }
 
     findings_by_id: dict[str, Finding] = {}
     for draft in drafts:
@@ -113,8 +118,8 @@ def materialize_finding_drafts(
                 entity="FindingDraft",
             )
 
-        evidence_diff_ids = tuple(sorted(draft.evidence_diff_ids))
-        evidence_compatibility_ids = tuple(sorted(draft.evidence_compatibility_ids))
+        evidence_diff_ids = tuple(sorted(set(draft.evidence_diff_ids)))
+        evidence_compatibility_ids = tuple(sorted(set(draft.evidence_compatibility_ids)))
         finding = Finding(
             finding_id=make_finding_id(
                 monitoring_run_id=monitoring_run_id,
@@ -137,10 +142,10 @@ def materialize_finding_drafts(
             evidence_diff_ids=evidence_diff_ids,
             evidence_compatibility_ids=evidence_compatibility_ids,
         )
-        validate_finding_evidence(
+        validate_finding_evidence_references(
             finding,
-            diffs=diffs,
-            compatibility_evidence=compatibility_evidence,
+            diffs_by_id=diffs_by_id,
+            compatibility_evidence_by_id=compatibility_evidence_by_id,
         )
         validate_finding_identity(finding)
 

--- a/src/mlflow_monitor/identity.py
+++ b/src/mlflow_monitor/identity.py
@@ -104,8 +104,8 @@ class _FindingIdentity:
             "finding_policy_id": self.finding_policy_id,
             "finding_policy_version": self.finding_policy_version,
             "finding_rule_id": self.finding_rule_id,
-            "evidence_diff_ids": sorted(self.evidence_diff_ids),
-            "evidence_compatibility_ids": sorted(self.evidence_compatibility_ids),
+            "evidence_diff_ids": sorted(set(self.evidence_diff_ids)),
+            "evidence_compatibility_ids": sorted(set(self.evidence_compatibility_ids)),
         }
 
 

--- a/src/mlflow_monitor/identity.py
+++ b/src/mlflow_monitor/identity.py
@@ -1,4 +1,4 @@
-"""Deterministic identity helpers for objective monitoring evidence."""
+"""Deterministic identity helpers for monitoring records."""
 
 from __future__ import annotations
 
@@ -73,6 +73,42 @@ class _CompatibilityEvidenceIdentity:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class _FindingIdentity:
+    """Deterministic identity for one policy Finding.
+
+    Attributes:
+        monitoring_run_id: Monitoring Run that owns the Finding.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        finding_policy_id: Identifier of the Finding policy.
+        finding_policy_version: Version of the Finding policy.
+        finding_rule_id: Stable rule identity within the Finding policy.
+        evidence_diff_ids: Diff identities supporting the Finding.
+        evidence_compatibility_ids: Compatibility Evidence identities supporting
+            the Finding.
+    """
+
+    monitoring_run_id: str
+    source_run_id: str
+    finding_policy_id: str
+    finding_policy_version: str
+    finding_rule_id: str
+    evidence_diff_ids: tuple[str, ...]
+    evidence_compatibility_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Convert the identity to a canonical dictionary representation."""
+        return {
+            "monitoring_run_id": self.monitoring_run_id,
+            "source_run_id": self.source_run_id,
+            "finding_policy_id": self.finding_policy_id,
+            "finding_policy_version": self.finding_policy_version,
+            "finding_rule_id": self.finding_rule_id,
+            "evidence_diff_ids": sorted(self.evidence_diff_ids),
+            "evidence_compatibility_ids": sorted(self.evidence_compatibility_ids),
+        }
+
+
 def make_diff_id(
     *,
     monitoring_run_id: str,
@@ -139,11 +175,51 @@ def make_compatibility_evidence_id(
     )
 
 
+def make_finding_id(
+    *,
+    monitoring_run_id: str,
+    source_run_id: str,
+    finding_policy_id: str,
+    finding_policy_version: str,
+    finding_rule_id: str,
+    evidence_diff_ids: tuple[str, ...],
+    evidence_compatibility_ids: tuple[str, ...],
+) -> str:
+    """Build the stable identity for one policy Finding.
+
+    Args:
+        monitoring_run_id: Monitoring Run that owns the Finding.
+        source_run_id: Source Training Run evaluated by the Monitoring Run.
+        finding_policy_id: Identifier of the Finding policy.
+        finding_policy_version: Version of the Finding policy.
+        finding_rule_id: Stable rule identity within the Finding policy.
+        evidence_diff_ids: Diff identities supporting the Finding.
+        evidence_compatibility_ids: Compatibility Evidence identities supporting
+            the Finding.
+
+    Returns:
+        A versioned SHA-256 Finding identifier.
+    """
+    return _make_identity(
+        entity_type="finding",
+        prefix="finding",
+        payload=_FindingIdentity(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            finding_policy_id=finding_policy_id,
+            finding_policy_version=finding_policy_version,
+            finding_rule_id=finding_rule_id,
+            evidence_diff_ids=evidence_diff_ids,
+            evidence_compatibility_ids=evidence_compatibility_ids,
+        ),
+    )
+
+
 def _make_identity(
     *,
     entity_type: str,
     prefix: str,
-    payload: _DiffIdentity | _CompatibilityEvidenceIdentity,
+    payload: _DiffIdentity | _CompatibilityEvidenceIdentity | _FindingIdentity,
 ) -> str:
     """Hash one canonical versioned identity payload."""
     canonical_payload = {

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -135,41 +135,92 @@ def validate_lkg_membership(timeline: Timeline, lkg: LKG) -> None:
     return None
 
 
-def validate_finding_to_diff_evidence(finding: Finding, diff: Diff) -> None:
-    """Validate that the provided diff record corresponds to one of the finding's evidence diff IDs.
+def validate_finding_evidence(
+    finding: Finding,
+    *,
+    diffs: Sequence[Diff],
+    compatibility_evidence: Sequence[CompatibilityEvidence],
+) -> None:
+    """Validate every evidence identity referenced by one Finding.
 
     Args:
-        finding: The finding record to validate.
-        diff: The diff record to check for evidence membership.
+        finding: Finding whose evidence references should be validated.
+        diffs: Complete Diff records available to the Finding.
+        compatibility_evidence: Complete Compatibility Evidence records available
+            to the Finding.
 
     Raises:
-        InvariantViolation: If any evidence diff ID does not correspond to a provided diff.
+        InvariantViolation: If supplied evidence is inconsistent, a referenced ID
+            is missing, or referenced evidence belongs to another current pair.
 
     Returns:
-        None if all evidence diff IDs are valid.
+        None if every evidence reference is valid.
     """
-    evidence_diff_ids = [evidence_diff_id for evidence_diff_id in finding.evidence_diff_ids]
+    validate_diff_identity_consistency(diffs)
+    validate_compatibility_evidence_identity_consistency(compatibility_evidence)
 
-    if diff.diff_id not in evidence_diff_ids:
-        raise InvariantViolation(
-            code="finding_diff_evidence_violation",
-            message=f"Diff diff_id {diff.diff_id} is not in Finding evidence {evidence_diff_ids}",
+    diffs_by_id = {diff.diff_id: diff for diff in diffs}
+    compatibility_evidence_by_id = {
+        evidence.compatibility_evidence_id: evidence for evidence in compatibility_evidence
+    }
+
+    for diff_id in finding.evidence_diff_ids:
+        diff = diffs_by_id.get(diff_id)
+        if diff is None:
+            raise InvariantViolation(
+                code="finding_diff_evidence_violation",
+                message=f"Finding references unknown Diff identity {diff_id!r}.",
+                entity="Finding",
+                field="evidence_diff_ids",
+            )
+        _validate_finding_evidence_pair(
+            finding=finding,
+            evidence=diff,
             entity="Diff",
-            field="diff_id",
+            code="finding_diff_evidence_violation",
         )
 
-    if diff.monitoring_run_id != finding.monitoring_run_id:
-        raise InvariantViolation(
-            code="finding_diff_evidence_violation",
-            message=(
-                f"Diff monitoring_run_id {diff.monitoring_run_id} does not "
-                f"match Finding monitoring_run_id {finding.monitoring_run_id}"
-            ),
-            entity="Diff",
-            field="monitoring_run_id",
+    for compatibility_evidence_id in finding.evidence_compatibility_ids:
+        evidence = compatibility_evidence_by_id.get(compatibility_evidence_id)
+        if evidence is None:
+            raise InvariantViolation(
+                code="finding_compatibility_evidence_violation",
+                message=(
+                    "Finding references unknown Compatibility Evidence identity "
+                    f"{compatibility_evidence_id!r}."
+                ),
+                entity="Finding",
+                field="evidence_compatibility_ids",
+            )
+        _validate_finding_evidence_pair(
+            finding=finding,
+            evidence=evidence,
+            entity="CompatibilityEvidence",
+            code="finding_compatibility_evidence_violation",
         )
 
-    return None
+
+def _validate_finding_evidence_pair(
+    *,
+    finding: Finding,
+    evidence: Diff | CompatibilityEvidence,
+    entity: str,
+    code: str,
+) -> None:
+    """Validate one evidence record against its Finding's current pair."""
+    for field_name in ("monitoring_run_id", "source_run_id"):
+        finding_value = getattr(finding, field_name)
+        evidence_value = getattr(evidence, field_name)
+        if evidence_value != finding_value:
+            raise InvariantViolation(
+                code=code,
+                message=(
+                    f"{entity} {field_name} {evidence_value!r} does not match "
+                    f"Finding {field_name} {finding_value!r}."
+                ),
+                entity=entity,
+                field=field_name,
+            )
 
 
 def validate_diff_identity(diff: Diff) -> None:

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -18,7 +18,11 @@ from mlflow_monitor.domain import (
     Timeline,
 )
 from mlflow_monitor.errors import InvariantViolation
-from mlflow_monitor.identity import make_compatibility_evidence_id, make_diff_id
+from mlflow_monitor.identity import (
+    make_compatibility_evidence_id,
+    make_diff_id,
+    make_finding_id,
+)
 
 
 def validate_timeline_ownership(
@@ -221,6 +225,62 @@ def _validate_finding_evidence_pair(
                 entity=entity,
                 field=field_name,
             )
+
+
+def validate_finding_identity(finding: Finding) -> None:
+    """Validate that a Finding carries its derived deterministic identity.
+
+    Args:
+        finding: Finding whose identity should be validated.
+
+    Raises:
+        InvariantViolation: If the supplied Finding identity is not canonical.
+
+    Returns:
+        None if the Finding identity is canonical.
+    """
+    expected_finding_id = make_finding_id(
+        monitoring_run_id=finding.monitoring_run_id,
+        source_run_id=finding.source_run_id,
+        finding_policy_id=finding.finding_policy_id,
+        finding_policy_version=finding.finding_policy_version,
+        finding_rule_id=finding.finding_rule_id,
+        evidence_diff_ids=finding.evidence_diff_ids,
+        evidence_compatibility_ids=finding.evidence_compatibility_ids,
+    )
+    if finding.finding_id != expected_finding_id:
+        raise InvariantViolation(
+            code="finding_identity_mismatch",
+            message=f"Finding identity {finding.finding_id!r} does not match its derived identity.",
+            entity="Finding",
+            field="finding_id",
+        )
+
+
+def validate_finding_identity_consistency(findings: Sequence[Finding]) -> None:
+    """Reject conflicting Finding content under one deterministic identity.
+
+    Args:
+        findings: Finding records to validate together.
+
+    Raises:
+        InvariantViolation: If an identity is invalid or maps to different content.
+
+    Returns:
+        None if all Finding identities and content are consistent.
+    """
+    findings_by_id: dict[str, Finding] = {}
+    for finding in findings:
+        validate_finding_identity(finding)
+        existing = findings_by_id.get(finding.finding_id)
+        if existing is not None and existing != finding:
+            raise InvariantViolation(
+                code="finding_identity_content_conflict",
+                message=f"Finding identity {finding.finding_id!r} maps to conflicting content.",
+                entity="Finding",
+                field="finding_id",
+            )
+        findings_by_id[finding.finding_id] = finding
 
 
 def validate_diff_identity(diff: Diff) -> None:

--- a/src/mlflow_monitor/invariant.py
+++ b/src/mlflow_monitor/invariant.py
@@ -1,6 +1,6 @@
 """Invariant checks for the MLflow-Monitor runtime."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from mlflow_monitor.contract_checker import CONTRACT_CHECK_REASON_MESSAGE
 from mlflow_monitor.domain import (
@@ -168,6 +168,34 @@ def validate_finding_evidence(
         evidence.compatibility_evidence_id: evidence for evidence in compatibility_evidence
     }
 
+    validate_finding_evidence_references(
+        finding,
+        diffs_by_id=diffs_by_id,
+        compatibility_evidence_by_id=compatibility_evidence_by_id,
+    )
+
+
+def validate_finding_evidence_references(
+    finding: Finding,
+    *,
+    diffs_by_id: Mapping[str, Diff],
+    compatibility_evidence_by_id: Mapping[str, CompatibilityEvidence],
+) -> None:
+    """Validate Finding references against prevalidated evidence indexes.
+
+    Args:
+        finding: Finding whose evidence references should be validated.
+        diffs_by_id: Identity-consistent Diff records indexed by identity.
+        compatibility_evidence_by_id: Identity-consistent Compatibility Evidence
+            records indexed by identity.
+
+    Raises:
+        InvariantViolation: If a referenced identity is missing or its evidence
+            belongs to another current pair.
+
+    Returns:
+        None if every evidence reference is valid.
+    """
     for diff_id in finding.evidence_diff_ids:
         diff = diffs_by_id.get(diff_id)
         if diff is None:

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -78,11 +78,16 @@ def test_canonical_entities_can_be_constructed() -> None:
     finding = Finding(
         finding_id="finding-1",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-2",
+        finding_policy_id="relative-regression",
+        finding_policy_version="1",
+        finding_rule_id="quality.f1_regression",
         severity=FindingSeverity.HIGH,
         category="performance_regression",
         summary="F1 regressed against baseline",
-        evidence_diff_ids=("diff-1",),
         recommendation="Investigate feature changes before promotion.",
+        evidence_diff_ids=("diff-1",),
+        evidence_compatibility_ids=(),
     )
     run = Run(
         monitoring_run_id="monitoring-run-1",
@@ -176,11 +181,16 @@ def test_finding_references_one_or_more_diffs() -> None:
     finding = Finding(
         finding_id="finding-1",
         monitoring_run_id="monitoring-run-1",
+        source_run_id="train-run-2",
+        finding_policy_id="relative-regression",
+        finding_policy_version="1",
+        finding_rule_id="quality.regression",
         severity=FindingSeverity.MEDIUM,
         category="quality",
         summary="Regression detected",
-        evidence_diff_ids=("diff-1", "diff-2"),
         recommendation="Review the latest run.",
+        evidence_diff_ids=("diff-1", "diff-2"),
+        evidence_compatibility_ids=(),
     )
 
     assert finding.evidence_diff_ids == ("diff-1", "diff-2")

--- a/tests/test_finding_domain_models.py
+++ b/tests/test_finding_domain_models.py
@@ -1,0 +1,177 @@
+"""Specifications for Finding Drafts and final Findings."""
+
+from dataclasses import FrozenInstanceError, fields
+from typing import Any
+
+import pytest
+
+import mlflow_monitor.domain as domain
+
+
+def _draft(**overrides: object) -> Any:
+    values: dict[str, object] = {
+        "finding_rule_id": "quality.accuracy_regression",
+        "severity": domain.FindingSeverity.HIGH,
+        "category": "quality",
+        "summary": "Accuracy regressed against the baseline.",
+        "recommendation": "Review the model and input changes.",
+        "evidence_diff_ids": ("diff-v1-example",),
+        "evidence_compatibility_ids": (),
+    }
+    values.update(overrides)
+    return domain.FindingDraft(**values)  # type: ignore[arg-type]
+
+
+def _finding(**overrides: object) -> domain.Finding:
+    values: dict[str, object] = {
+        "finding_id": "finding-v1-example",
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "finding_policy_id": "relative-regression",
+        "finding_policy_version": "1",
+        "finding_rule_id": "quality.accuracy_regression",
+        "severity": domain.FindingSeverity.HIGH,
+        "category": "quality",
+        "summary": "Accuracy regressed against the baseline.",
+        "recommendation": "Review the model and input changes.",
+        "evidence_diff_ids": ("diff-v1-example",),
+        "evidence_compatibility_ids": (),
+    }
+    values.update(overrides)
+    return domain.Finding(**values)  # type: ignore[arg-type]
+
+
+def test_finding_models_have_the_approved_shapes() -> None:
+    finding_draft_type = domain.FindingDraft
+
+    assert tuple(field.name for field in fields(finding_draft_type)) == (
+        "finding_rule_id",
+        "severity",
+        "category",
+        "summary",
+        "recommendation",
+        "evidence_diff_ids",
+        "evidence_compatibility_ids",
+    )
+    assert tuple(field.name for field in fields(domain.Finding)) == (
+        "finding_id",
+        "monitoring_run_id",
+        "source_run_id",
+        "finding_policy_id",
+        "finding_policy_version",
+        "finding_rule_id",
+        "severity",
+        "category",
+        "summary",
+        "recommendation",
+        "evidence_diff_ids",
+        "evidence_compatibility_ids",
+    )
+
+
+@pytest.mark.parametrize("factory", [_draft, _finding])
+def test_finding_models_are_immutable(factory: Any) -> None:
+    value = factory()
+
+    with pytest.raises(FrozenInstanceError):
+        value.summary = "Changed"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("factory", [_draft, _finding])
+def test_finding_models_defensively_freeze_evidence_collections(factory: Any) -> None:
+    diff_ids = ["diff-v1-example"]
+    compatibility_ids = ["compatibility-evidence-v1-example"]
+
+    value = factory(
+        evidence_diff_ids=diff_ids,
+        evidence_compatibility_ids=compatibility_ids,
+    )
+    diff_ids.append("diff-v1-changed")
+    compatibility_ids.append("compatibility-evidence-v1-changed")
+
+    assert value.evidence_diff_ids == ("diff-v1-example",)
+    assert value.evidence_compatibility_ids == ("compatibility-evidence-v1-example",)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "finding_rule_id",
+        "category",
+        "summary",
+        "recommendation",
+    ],
+)
+def test_finding_draft_rejects_empty_text_fields(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _draft(**{field: " "})
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "finding_id",
+        "monitoring_run_id",
+        "source_run_id",
+        "finding_policy_id",
+        "finding_policy_version",
+        "finding_rule_id",
+        "category",
+        "summary",
+        "recommendation",
+    ],
+)
+def test_finding_rejects_empty_text_fields(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _finding(**{field: " "})
+
+
+@pytest.mark.parametrize("factory", [_draft, _finding])
+def test_finding_models_require_typed_severity(factory: Any) -> None:
+    with pytest.raises(ValueError, match="severity"):
+        factory(severity="high")
+
+
+@pytest.mark.parametrize("factory", [_draft, _finding])
+def test_finding_models_require_combined_evidence(factory: Any) -> None:
+    with pytest.raises(ValueError, match="evidence"):
+        factory(evidence_diff_ids=(), evidence_compatibility_ids=())
+
+
+@pytest.mark.parametrize("factory", [_draft, _finding])
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"evidence_diff_ids": (" ",)},
+        {"evidence_compatibility_ids": (" ",), "evidence_diff_ids": ()},
+        {"evidence_diff_ids": (1,)},
+        {"evidence_compatibility_ids": (1,), "evidence_diff_ids": ()},
+    ],
+)
+def test_finding_models_require_nonempty_string_evidence_ids(
+    factory: Any,
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="evidence"):
+        factory(**overrides)
+
+
+@pytest.mark.parametrize(
+    ("evidence_diff_ids", "evidence_compatibility_ids"),
+    [
+        (("diff-v1-example",), ()),
+        ((), ("compatibility-evidence-v1-example",)),
+        (("diff-v1-example",), ("compatibility-evidence-v1-example",)),
+    ],
+)
+def test_finding_draft_accepts_diff_compatibility_or_combined_evidence(
+    evidence_diff_ids: tuple[str, ...],
+    evidence_compatibility_ids: tuple[str, ...],
+) -> None:
+    draft = _draft(
+        evidence_diff_ids=evidence_diff_ids,
+        evidence_compatibility_ids=evidence_compatibility_ids,
+    )
+
+    assert draft.evidence_diff_ids == evidence_diff_ids
+    assert draft.evidence_compatibility_ids == evidence_compatibility_ids

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -105,6 +105,22 @@ def test_finding_id_is_independent_of_evidence_order() -> None:
     )
 
 
+def test_finding_id_is_independent_of_repeated_evidence_identities() -> None:
+    values = _identity_values()
+    repeated = {
+        **values,
+        "evidence_diff_ids": (*values["evidence_diff_ids"], "diff-v1-a"),  # type: ignore[misc]
+        "evidence_compatibility_ids": (
+            *values["evidence_compatibility_ids"],  # type: ignore[misc]
+            "compatibility-evidence-v1-a",
+        ),
+    }
+
+    assert identity.make_finding_id(**values) == identity.make_finding_id(  # type: ignore[arg-type]
+        **repeated  # type: ignore[arg-type]
+    )
+
+
 def test_finding_id_keeps_diff_and_compatibility_evidence_separate() -> None:
     first = identity.make_finding_id(
         monitoring_run_id="monitoring-run-current",

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -1,0 +1,244 @@
+"""Specifications for deterministic Finding identities."""
+
+import os
+import subprocess
+import sys
+from dataclasses import replace
+
+import pytest
+
+import mlflow_monitor.identity as identity
+import mlflow_monitor.invariant as invariant
+from mlflow_monitor.domain import Finding, FindingSeverity
+from mlflow_monitor.errors import InvariantViolation
+
+FINDING_ID_FIXTURE = "finding-v1-aff16cb86b7d6bd262be4d52f1c9efaff92360afeed5220b161cd77d1589f84f"
+
+
+def _identity_values() -> dict[str, object]:
+    return {
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "finding_policy_id": "relative-regression",
+        "finding_policy_version": "1",
+        "finding_rule_id": "quality.accuracy_regression",
+        "evidence_diff_ids": ("diff-v1-b", "diff-v1-a"),
+        "evidence_compatibility_ids": (
+            "compatibility-evidence-v1-b",
+            "compatibility-evidence-v1-a",
+        ),
+    }
+
+
+def _finding(**overrides: object) -> Finding:
+    values = {
+        **_identity_values(),
+        "finding_id": FINDING_ID_FIXTURE,
+        "severity": FindingSeverity.HIGH,
+        "category": "quality",
+        "summary": "Accuracy regressed against the baseline.",
+        "recommendation": "Review the model and input changes.",
+    }
+    values.update(overrides)
+    return Finding(**values)  # type: ignore[arg-type]
+
+
+def test_finding_identity_container_serializes_sorted_semantic_components() -> None:
+    finding_identity = identity._FindingIdentity(**_identity_values())  # type: ignore[arg-type]
+
+    assert finding_identity.to_dict() == {
+        "monitoring_run_id": "monitoring-run-current",
+        "source_run_id": "train-run-current",
+        "finding_policy_id": "relative-regression",
+        "finding_policy_version": "1",
+        "finding_rule_id": "quality.accuracy_regression",
+        "evidence_diff_ids": ["diff-v1-a", "diff-v1-b"],
+        "evidence_compatibility_ids": [
+            "compatibility-evidence-v1-a",
+            "compatibility-evidence-v1-b",
+        ],
+    }
+
+
+def test_finding_id_matches_fixed_fixture() -> None:
+    assert identity.make_finding_id(**_identity_values()) == FINDING_ID_FIXTURE  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("monitoring_run_id", "monitoring-run-other"),
+        ("source_run_id", "train-run-other"),
+        ("finding_policy_id", "absolute-threshold"),
+        ("finding_policy_version", "2"),
+        ("finding_rule_id", "quality.precision_regression"),
+        ("evidence_diff_ids", ("diff-v1-c",)),
+        (
+            "evidence_compatibility_ids",
+            ("compatibility-evidence-v1-c",),
+        ),
+    ],
+)
+def test_finding_id_changes_with_every_semantic_component(
+    field: str,
+    replacement: object,
+) -> None:
+    values = _identity_values()
+    original_id = identity.make_finding_id(**values)  # type: ignore[arg-type]
+    values[field] = replacement
+
+    assert identity.make_finding_id(**values) != original_id  # type: ignore[arg-type]
+
+
+def test_finding_id_is_independent_of_evidence_order() -> None:
+    values = _identity_values()
+    reordered = {
+        **values,
+        "evidence_diff_ids": tuple(reversed(values["evidence_diff_ids"])),  # type: ignore[arg-type]
+        "evidence_compatibility_ids": tuple(
+            reversed(values["evidence_compatibility_ids"])  # type: ignore[arg-type]
+        ),
+    }
+
+    assert identity.make_finding_id(**values) == identity.make_finding_id(  # type: ignore[arg-type]
+        **reordered  # type: ignore[arg-type]
+    )
+
+
+def test_finding_id_keeps_diff_and_compatibility_evidence_separate() -> None:
+    first = identity.make_finding_id(
+        monitoring_run_id="monitoring-run-current",
+        source_run_id="train-run-current",
+        finding_policy_id="policy",
+        finding_policy_version="1",
+        finding_rule_id="rule",
+        evidence_diff_ids=("shared-id",),
+        evidence_compatibility_ids=(),
+    )
+    second = identity.make_finding_id(
+        monitoring_run_id="monitoring-run-current",
+        source_run_id="train-run-current",
+        finding_policy_id="policy",
+        finding_policy_version="1",
+        finding_rule_id="rule",
+        evidence_diff_ids=(),
+        evidence_compatibility_ids=("shared-id",),
+    )
+
+    assert first != second
+
+
+def test_finding_id_encoding_is_delimiter_safe() -> None:
+    first = identity.make_finding_id(
+        monitoring_run_id="monitoring|source",
+        source_run_id="training",
+        finding_policy_id="policy",
+        finding_policy_version="1",
+        finding_rule_id="rule",
+        evidence_diff_ids=("diff",),
+        evidence_compatibility_ids=(),
+    )
+    second = identity.make_finding_id(
+        monitoring_run_id="monitoring",
+        source_run_id="source|training",
+        finding_policy_id="policy",
+        finding_policy_version="1",
+        finding_rule_id="rule",
+        evidence_diff_ids=("diff",),
+        evidence_compatibility_ids=(),
+    )
+
+    assert first != second
+
+
+@pytest.mark.parametrize("hash_seed", ["1", "8675309"])
+def test_finding_id_fixture_is_stable_across_processes(hash_seed: str) -> None:
+    script = """
+from mlflow_monitor.identity import make_finding_id
+
+print(make_finding_id(
+    monitoring_run_id="monitoring-run-current",
+    source_run_id="train-run-current",
+    finding_policy_id="relative-regression",
+    finding_policy_version="1",
+    finding_rule_id="quality.accuracy_regression",
+    evidence_diff_ids=("diff-v1-b", "diff-v1-a"),
+    evidence_compatibility_ids=(
+        "compatibility-evidence-v1-b",
+        "compatibility-evidence-v1-a",
+    ),
+))
+"""
+    environment = dict(os.environ)
+    environment["PYTHONHASHSEED"] = hash_seed
+
+    output = subprocess.check_output(  # noqa: S603
+        [sys.executable, "-c", script],
+        env=environment,
+        text=True,
+    )
+
+    assert output.strip() == FINDING_ID_FIXTURE
+
+
+def test_finding_identity_validation_accepts_the_derived_id() -> None:
+    invariant.validate_finding_identity(_finding())
+
+
+def test_finding_identity_validation_rejects_an_incorrect_id() -> None:
+    finding = replace(_finding(), finding_id="finding-v1-incorrect")
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_identity(finding)
+
+    error = exc_info.value
+    assert error.code == "finding_identity_mismatch"
+    assert error.entity == "Finding"
+    assert error.field == "finding_id"
+
+
+def test_finding_identity_excludes_rendered_content() -> None:
+    original = _finding()
+    changed = replace(
+        original,
+        severity=FindingSeverity.CRITICAL,
+        category="performance",
+        summary="Changed summary under the same semantic identity.",
+        recommendation="Changed recommendation.",
+    )
+
+    assert _make_finding_id_for(original) == _make_finding_id_for(changed)
+
+
+def test_finding_identity_consistency_accepts_identical_retries() -> None:
+    finding = _finding()
+
+    invariant.validate_finding_identity_consistency((finding, finding))
+
+
+def test_finding_identity_consistency_rejects_changed_rendered_content() -> None:
+    original = _finding()
+    changed = replace(
+        original,
+        summary="Changed summary under the same semantic identity.",
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_identity_consistency((original, changed))
+
+    error = exc_info.value
+    assert error.code == "finding_identity_content_conflict"
+    assert error.entity == "Finding"
+    assert error.field == "finding_id"
+
+
+def _make_finding_id_for(finding: Finding) -> str:
+    return identity.make_finding_id(
+        monitoring_run_id=finding.monitoring_run_id,
+        source_run_id=finding.source_run_id,
+        finding_policy_id=finding.finding_policy_id,
+        finding_policy_version=finding.finding_policy_version,
+        finding_rule_id=finding.finding_rule_id,
+        evidence_diff_ids=finding.evidence_diff_ids,
+        evidence_compatibility_ids=finding.evidence_compatibility_ids,
+    )

--- a/tests/test_finding_invariant.py
+++ b/tests/test_finding_invariant.py
@@ -1,0 +1,258 @@
+"""Specifications for Finding evidence invariants."""
+
+from dataclasses import replace
+
+import pytest
+
+import mlflow_monitor.invariant as invariant
+from mlflow_monitor.domain import (
+    CompatibilityEvidence,
+    ContractCheckReason,
+    Diff,
+    DiffReference,
+    DiffReferenceKind,
+    Finding,
+    FindingSeverity,
+)
+from mlflow_monitor.errors import InvariantViolation
+from mlflow_monitor.identity import make_compatibility_evidence_id, make_diff_id
+
+MONITORING_RUN_ID = "monitoring-run-current"
+SOURCE_RUN_ID = "train-run-current"
+
+
+def _diff(
+    *,
+    monitoring_run_id: str = MONITORING_RUN_ID,
+    source_run_id: str = SOURCE_RUN_ID,
+) -> Diff:
+    reference = DiffReference(
+        kind=DiffReferenceKind.BASELINE,
+        monitoring_run_id=None,
+        source_run_id="train-run-baseline",
+    )
+    return Diff(
+        diff_id=make_diff_id(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            reference=reference,
+            metric_name="accuracy",
+        ),
+        monitoring_run_id=monitoring_run_id,
+        source_run_id=source_run_id,
+        reference=reference,
+        metric_name="accuracy",
+        current_value=0.75,
+        reference_value=0.5,
+        delta=0.25,
+    )
+
+
+def _compatibility_evidence(
+    *,
+    monitoring_run_id: str = MONITORING_RUN_ID,
+    source_run_id: str = SOURCE_RUN_ID,
+) -> CompatibilityEvidence:
+    reason = ContractCheckReason(
+        code="environment_mismatch",
+        message="Execution environment does not match the baseline.",
+        blocking=False,
+    )
+    return CompatibilityEvidence(
+        compatibility_evidence_id=make_compatibility_evidence_id(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            baseline_source_run_id="train-run-baseline",
+            contract_id="default_permissive",
+            contract_version="v0",
+            reason_code=reason.code,
+        ),
+        monitoring_run_id=monitoring_run_id,
+        source_run_id=source_run_id,
+        baseline_source_run_id="train-run-baseline",
+        contract_id="default_permissive",
+        contract_version="v0",
+        reason=reason,
+    )
+
+
+def _finding(
+    *,
+    evidence_diff_ids: tuple[str, ...],
+    evidence_compatibility_ids: tuple[str, ...],
+) -> Finding:
+    return Finding(
+        finding_id="finding-v1-example",
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id="relative-regression",
+        finding_policy_version="1",
+        finding_rule_id="quality.accuracy_regression",
+        severity=FindingSeverity.HIGH,
+        category="quality",
+        summary="Accuracy regressed against the baseline.",
+        recommendation="Review the model and input changes.",
+        evidence_diff_ids=evidence_diff_ids,
+        evidence_compatibility_ids=evidence_compatibility_ids,
+    )
+
+
+def test_finding_evidence_accepts_supplied_records_from_the_current_pair() -> None:
+    diff = _diff()
+    compatibility_evidence = _compatibility_evidence()
+    finding = _finding(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(compatibility_evidence.compatibility_evidence_id,),
+    )
+
+    invariant.validate_finding_evidence(
+        finding,
+        diffs=(diff,),
+        compatibility_evidence=(compatibility_evidence,),
+    )
+
+
+def test_finding_evidence_rejects_an_unknown_diff_identity() -> None:
+    finding = _finding(
+        evidence_diff_ids=("diff-v1-unknown",),
+        evidence_compatibility_ids=(),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_evidence(
+            finding,
+            diffs=(),
+            compatibility_evidence=(),
+        )
+
+    error = exc_info.value
+    assert error.code == "finding_diff_evidence_violation"
+    assert error.entity == "Finding"
+    assert error.field == "evidence_diff_ids"
+
+
+def test_finding_evidence_rejects_an_unknown_compatibility_identity() -> None:
+    finding = _finding(
+        evidence_diff_ids=(),
+        evidence_compatibility_ids=("compatibility-evidence-v1-unknown",),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_evidence(
+            finding,
+            diffs=(),
+            compatibility_evidence=(),
+        )
+
+    error = exc_info.value
+    assert error.code == "finding_compatibility_evidence_violation"
+    assert error.entity == "Finding"
+    assert error.field == "evidence_compatibility_ids"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("monitoring_run_id", "monitoring-run-other"),
+        ("source_run_id", "train-run-other"),
+    ],
+)
+def test_finding_evidence_rejects_a_cross_pair_diff(field: str, value: str) -> None:
+    diff = _diff(**{field: value})
+    finding = _finding(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_evidence(
+            finding,
+            diffs=(diff,),
+            compatibility_evidence=(),
+        )
+
+    error = exc_info.value
+    assert error.code == "finding_diff_evidence_violation"
+    assert error.entity == "Diff"
+    assert error.field == field
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("monitoring_run_id", "monitoring-run-other"),
+        ("source_run_id", "train-run-other"),
+    ],
+)
+def test_finding_evidence_rejects_cross_pair_compatibility_evidence(
+    field: str,
+    value: str,
+) -> None:
+    compatibility_evidence = _compatibility_evidence(**{field: value})
+    finding = _finding(
+        evidence_diff_ids=(),
+        evidence_compatibility_ids=(compatibility_evidence.compatibility_evidence_id,),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_evidence(
+            finding,
+            diffs=(),
+            compatibility_evidence=(compatibility_evidence,),
+        )
+
+    error = exc_info.value
+    assert error.code == "finding_compatibility_evidence_violation"
+    assert error.entity == "CompatibilityEvidence"
+    assert error.field == field
+
+
+def test_finding_evidence_validates_the_supplied_diff_identity() -> None:
+    diff = replace(_diff(), diff_id="diff-v1-incorrect")
+    finding = _finding(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_evidence(
+            finding,
+            diffs=(diff,),
+            compatibility_evidence=(),
+        )
+
+    assert exc_info.value.code == "diff_identity_mismatch"
+
+
+def test_finding_evidence_validates_the_supplied_compatibility_identity() -> None:
+    evidence = replace(
+        _compatibility_evidence(),
+        compatibility_evidence_id="compatibility-evidence-v1-incorrect",
+    )
+    finding = _finding(
+        evidence_diff_ids=(),
+        evidence_compatibility_ids=(evidence.compatibility_evidence_id,),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        invariant.validate_finding_evidence(
+            finding,
+            diffs=(),
+            compatibility_evidence=(evidence,),
+        )
+
+    assert exc_info.value.code == "compatibility_evidence_identity_mismatch"
+
+
+def test_finding_evidence_accepts_identical_evidence_retries() -> None:
+    diff = _diff()
+    finding = _finding(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+
+    invariant.validate_finding_evidence(
+        finding,
+        diffs=(diff, diff),
+        compatibility_evidence=(),
+    )

--- a/tests/test_finding_materialization.py
+++ b/tests/test_finding_materialization.py
@@ -1,0 +1,327 @@
+"""Specifications for package-owned Finding materialization."""
+
+from dataclasses import replace
+
+import pytest
+
+from mlflow_monitor.domain import (
+    CompatibilityEvidence,
+    ContractCheckReason,
+    Diff,
+    DiffReference,
+    DiffReferenceKind,
+    FindingDraft,
+    FindingSeverity,
+)
+from mlflow_monitor.errors import InvariantViolation
+from mlflow_monitor.finding_policy import materialize_finding_drafts
+from mlflow_monitor.identity import (
+    make_compatibility_evidence_id,
+    make_diff_id,
+    make_finding_id,
+)
+
+MONITORING_RUN_ID = "monitoring-run-current"
+SOURCE_RUN_ID = "train-run-current"
+FINDING_POLICY_ID = "relative-regression"
+FINDING_POLICY_VERSION = "1"
+
+
+def _diff(
+    *,
+    metric_name: str = "accuracy",
+    monitoring_run_id: str = MONITORING_RUN_ID,
+    source_run_id: str = SOURCE_RUN_ID,
+) -> Diff:
+    reference = DiffReference(
+        kind=DiffReferenceKind.BASELINE,
+        monitoring_run_id=None,
+        source_run_id="train-run-baseline",
+    )
+    return Diff(
+        diff_id=make_diff_id(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            reference=reference,
+            metric_name=metric_name,
+        ),
+        monitoring_run_id=monitoring_run_id,
+        source_run_id=source_run_id,
+        reference=reference,
+        metric_name=metric_name,
+        current_value=0.75,
+        reference_value=0.5,
+        delta=0.25,
+    )
+
+
+def _compatibility_evidence(*, code: str = "environment_mismatch") -> CompatibilityEvidence:
+    reason_by_code = {
+        "environment_mismatch": ContractCheckReason(
+            code="environment_mismatch",
+            message="Execution environment does not match the baseline.",
+            blocking=False,
+        ),
+        "schema_mismatch": ContractCheckReason(
+            code="schema_mismatch",
+            message="Data schema does not match the baseline.",
+            blocking=True,
+        ),
+    }
+    reason = reason_by_code[code]
+    return CompatibilityEvidence(
+        compatibility_evidence_id=make_compatibility_evidence_id(
+            monitoring_run_id=MONITORING_RUN_ID,
+            source_run_id=SOURCE_RUN_ID,
+            baseline_source_run_id="train-run-baseline",
+            contract_id="default_permissive",
+            contract_version="v0",
+            reason_code=reason.code,
+        ),
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        baseline_source_run_id="train-run-baseline",
+        contract_id="default_permissive",
+        contract_version="v0",
+        reason=reason,
+    )
+
+
+def _draft(**overrides: object) -> FindingDraft:
+    values: dict[str, object] = {
+        "finding_rule_id": "quality.accuracy_regression",
+        "severity": FindingSeverity.HIGH,
+        "category": "quality",
+        "summary": "Accuracy regressed against the baseline.",
+        "recommendation": "Review the model and input changes.",
+        "evidence_diff_ids": (),
+        "evidence_compatibility_ids": ("compatibility-evidence-v1-placeholder",),
+    }
+    values.update(overrides)
+    return FindingDraft(**values)  # type: ignore[arg-type]
+
+
+def test_materialization_attaches_package_owned_identity() -> None:
+    diff = _diff()
+    draft = _draft(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+
+    findings = materialize_finding_drafts(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        drafts=(draft,),
+        diffs=(diff,),
+        compatibility_evidence=(),
+    )
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.finding_id == make_finding_id(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        finding_rule_id=draft.finding_rule_id,
+        evidence_diff_ids=draft.evidence_diff_ids,
+        evidence_compatibility_ids=draft.evidence_compatibility_ids,
+    )
+    assert finding.monitoring_run_id == MONITORING_RUN_ID
+    assert finding.source_run_id == SOURCE_RUN_ID
+    assert finding.finding_policy_id == FINDING_POLICY_ID
+    assert finding.finding_policy_version == FINDING_POLICY_VERSION
+    assert finding.finding_rule_id == draft.finding_rule_id
+
+
+def test_materialization_canonicalizes_each_evidence_collection() -> None:
+    diffs = (_diff(metric_name="accuracy"), _diff(metric_name="precision"))
+    compatibility_evidence = (
+        _compatibility_evidence(code="environment_mismatch"),
+        _compatibility_evidence(code="schema_mismatch"),
+    )
+    draft = _draft(
+        evidence_diff_ids=tuple(diff.diff_id for diff in reversed(diffs)),
+        evidence_compatibility_ids=tuple(
+            evidence.compatibility_evidence_id for evidence in reversed(compatibility_evidence)
+        ),
+    )
+
+    (finding,) = materialize_finding_drafts(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        drafts=(draft,),
+        diffs=diffs,
+        compatibility_evidence=compatibility_evidence,
+    )
+
+    assert finding.evidence_diff_ids == tuple(sorted(draft.evidence_diff_ids))
+    assert finding.evidence_compatibility_ids == tuple(sorted(draft.evidence_compatibility_ids))
+
+
+def test_materialization_accepts_empty_draft_output() -> None:
+    assert (
+        materialize_finding_drafts(
+            monitoring_run_id=MONITORING_RUN_ID,
+            source_run_id=SOURCE_RUN_ID,
+            finding_policy_id=FINDING_POLICY_ID,
+            finding_policy_version=FINDING_POLICY_VERSION,
+            drafts=(),
+            diffs=(),
+            compatibility_evidence=(),
+        )
+        == ()
+    )
+
+
+def test_materialization_deduplicates_identical_drafts() -> None:
+    diff = _diff()
+    draft = _draft(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+
+    findings = materialize_finding_drafts(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        drafts=(draft, draft),
+        diffs=(diff,),
+        compatibility_evidence=(),
+    )
+
+    assert len(findings) == 1
+
+
+def test_materialization_deduplicates_identity_equivalent_evidence_order() -> None:
+    diffs = (_diff(metric_name="accuracy"), _diff(metric_name="precision"))
+    draft = _draft(
+        evidence_diff_ids=tuple(diff.diff_id for diff in diffs),
+        evidence_compatibility_ids=(),
+    )
+    reordered = replace(draft, evidence_diff_ids=tuple(reversed(draft.evidence_diff_ids)))
+
+    findings = materialize_finding_drafts(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        drafts=(draft, reordered),
+        diffs=diffs,
+        compatibility_evidence=(),
+    )
+
+    assert len(findings) == 1
+
+
+def test_materialization_rejects_conflicting_content_under_one_identity() -> None:
+    diff = _diff()
+    draft = _draft(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+    changed = replace(draft, summary="Changed summary under the same identity.")
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        materialize_finding_drafts(
+            monitoring_run_id=MONITORING_RUN_ID,
+            source_run_id=SOURCE_RUN_ID,
+            finding_policy_id=FINDING_POLICY_ID,
+            finding_policy_version=FINDING_POLICY_VERSION,
+            drafts=(draft, changed),
+            diffs=(diff,),
+            compatibility_evidence=(),
+        )
+
+    error = exc_info.value
+    assert error.code == "finding_identity_content_conflict"
+    assert error.entity == "Finding"
+    assert error.field == "finding_id"
+
+
+def test_materialization_rejects_unknown_draft_evidence() -> None:
+    draft = _draft(
+        evidence_diff_ids=("diff-v1-unknown",),
+        evidence_compatibility_ids=(),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        materialize_finding_drafts(
+            monitoring_run_id=MONITORING_RUN_ID,
+            source_run_id=SOURCE_RUN_ID,
+            finding_policy_id=FINDING_POLICY_ID,
+            finding_policy_version=FINDING_POLICY_VERSION,
+            drafts=(draft,),
+            diffs=(),
+            compatibility_evidence=(),
+        )
+
+    assert exc_info.value.code == "finding_diff_evidence_violation"
+
+
+def test_materialization_rejects_cross_pair_draft_evidence() -> None:
+    diff = _diff(source_run_id="train-run-other")
+    draft = _draft(
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+
+    with pytest.raises(InvariantViolation) as exc_info:
+        materialize_finding_drafts(
+            monitoring_run_id=MONITORING_RUN_ID,
+            source_run_id=SOURCE_RUN_ID,
+            finding_policy_id=FINDING_POLICY_ID,
+            finding_policy_version=FINDING_POLICY_VERSION,
+            drafts=(draft,),
+            diffs=(diff,),
+            compatibility_evidence=(),
+        )
+
+    assert exc_info.value.code == "finding_diff_evidence_violation"
+    assert exc_info.value.field == "source_run_id"
+
+
+def test_materialization_rejects_a_non_draft_policy_value() -> None:
+    with pytest.raises(InvariantViolation) as exc_info:
+        materialize_finding_drafts(
+            monitoring_run_id=MONITORING_RUN_ID,
+            source_run_id=SOURCE_RUN_ID,
+            finding_policy_id=FINDING_POLICY_ID,
+            finding_policy_version=FINDING_POLICY_VERSION,
+            drafts=(object(),),  # type: ignore[arg-type]
+            diffs=(),
+            compatibility_evidence=(),
+        )
+
+    error = exc_info.value
+    assert error.code == "finding_draft_invalid"
+    assert error.entity == "FindingDraft"
+
+
+def test_materialization_orders_distinct_findings_by_identity() -> None:
+    diff = _diff()
+    first = _draft(
+        finding_rule_id="quality.z_rule",
+        evidence_diff_ids=(diff.diff_id,),
+        evidence_compatibility_ids=(),
+    )
+    second = replace(first, finding_rule_id="quality.a_rule")
+
+    findings = materialize_finding_drafts(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        drafts=(first, second),
+        diffs=(diff,),
+        compatibility_evidence=(),
+    )
+
+    assert tuple(finding.finding_id for finding in findings) == tuple(
+        sorted(finding.finding_id for finding in findings)
+    )

--- a/tests/test_finding_materialization.py
+++ b/tests/test_finding_materialization.py
@@ -163,6 +163,31 @@ def test_materialization_canonicalizes_each_evidence_collection() -> None:
     assert finding.evidence_compatibility_ids == tuple(sorted(draft.evidence_compatibility_ids))
 
 
+def test_materialization_deduplicates_repeated_evidence_identities() -> None:
+    diff = _diff()
+    compatibility_evidence = _compatibility_evidence()
+    draft = _draft(
+        evidence_diff_ids=(diff.diff_id, diff.diff_id),
+        evidence_compatibility_ids=(
+            compatibility_evidence.compatibility_evidence_id,
+            compatibility_evidence.compatibility_evidence_id,
+        ),
+    )
+
+    (finding,) = materialize_finding_drafts(
+        monitoring_run_id=MONITORING_RUN_ID,
+        source_run_id=SOURCE_RUN_ID,
+        finding_policy_id=FINDING_POLICY_ID,
+        finding_policy_version=FINDING_POLICY_VERSION,
+        drafts=(draft,),
+        diffs=(diff,),
+        compatibility_evidence=(compatibility_evidence,),
+    )
+
+    assert finding.evidence_diff_ids == (diff.diff_id,)
+    assert finding.evidence_compatibility_ids == (compatibility_evidence.compatibility_evidence_id,)
+
+
 def test_materialization_accepts_empty_draft_output() -> None:
     assert (
         materialize_finding_drafts(

--- a/tests/test_finding_policy.py
+++ b/tests/test_finding_policy.py
@@ -1,0 +1,101 @@
+"""Specifications for the Finding policy extension boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from inspect import signature
+from types import MappingProxyType
+
+import pytest
+
+from mlflow_monitor.domain import (
+    CompatibilityEvidence,
+    Diff,
+    FindingDraft,
+    FindingSeverity,
+    ReferenceComparisonCoverage,
+)
+from mlflow_monitor.finding_policy import (
+    FindingPolicy,
+    FrozenFindingPolicyParameters,
+    JSONValue,
+)
+
+
+class _ExamplePolicy:
+    finding_policy_id = "relative-regression"
+    finding_policy_version = "1"
+
+    def validate_parameters(
+        self,
+        parameters: Mapping[str, JSONValue],
+    ) -> FrozenFindingPolicyParameters:
+        threshold = parameters.get("threshold", 0.05)
+        return MappingProxyType({"threshold": threshold})
+
+    def evaluate(
+        self,
+        *,
+        parameters: FrozenFindingPolicyParameters,
+        diffs: tuple[Diff, ...],
+        compatibility_evidence: tuple[CompatibilityEvidence, ...],
+        reference_comparison_coverage: tuple[ReferenceComparisonCoverage, ...],
+    ) -> tuple[FindingDraft, ...]:
+        assert parameters["threshold"] == 0.1
+        assert diffs == ()
+        assert compatibility_evidence == ()
+        assert reference_comparison_coverage == ()
+        return (
+            FindingDraft(
+                finding_rule_id="quality.accuracy_regression",
+                severity=FindingSeverity.HIGH,
+                category="quality",
+                summary="Accuracy regressed against the baseline.",
+                recommendation="Review the model and input changes.",
+                evidence_diff_ids=("diff-v1-example",),
+                evidence_compatibility_ids=(),
+            ),
+        )
+
+
+def _accept_policy(policy: FindingPolicy) -> FindingPolicy:
+    return policy
+
+
+def test_finding_policy_exposes_identity_and_parameter_validation() -> None:
+    policy = _accept_policy(_ExamplePolicy())
+
+    parameters = policy.validate_parameters({"threshold": 0.1})
+
+    assert policy.finding_policy_id == "relative-regression"
+    assert policy.finding_policy_version == "1"
+    assert parameters == {"threshold": 0.1}
+    with pytest.raises(TypeError):
+        parameters["threshold"] = 0.2  # type: ignore[index]
+
+
+def test_finding_policy_evaluates_frozen_inputs_into_drafts() -> None:
+    policy = _accept_policy(_ExamplePolicy())
+    parameters = policy.validate_parameters({"threshold": 0.1})
+
+    drafts = policy.evaluate(
+        parameters=parameters,
+        diffs=(),
+        compatibility_evidence=(),
+        reference_comparison_coverage=(),
+    )
+
+    assert isinstance(parameters, Mapping)
+    assert isinstance(drafts, tuple)
+    assert len(drafts) == 1
+    assert isinstance(drafts[0], FindingDraft)
+
+
+def test_finding_policy_evaluate_signature_names_every_immutable_input() -> None:
+    assert tuple(signature(FindingPolicy.evaluate).parameters) == (
+        "self",
+        "parameters",
+        "diffs",
+        "compatibility_evidence",
+        "reference_comparison_coverage",
+    )

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -9,11 +9,6 @@ from mlflow_monitor.domain import (
     Contract,
     ContractCheckReason,
     ContractCheckResult,
-    Diff,
-    DiffReference,
-    DiffReferenceKind,
-    Finding,
-    FindingSeverity,
     LifecycleStatus,
     Run,
     Timeline,
@@ -22,7 +17,6 @@ from mlflow_monitor.errors import InvariantViolation
 from mlflow_monitor.invariant import (
     validate_baseline_immutability,
     validate_contract_check_result,
-    validate_finding_to_diff_evidence,
     validate_lkg_membership,
     validate_timeline_ownership,
 )
@@ -76,34 +70,6 @@ RUN = Run(
     contract_check_result=None,
     diff_ids=("diff_1",),
     finding_ids=("finding_1",),
-)
-
-FINDING = Finding(
-    finding_id="finding-1",
-    monitoring_run_id="monitoring-run-2",
-    severity=FindingSeverity.HIGH,
-    category="data_drift",
-    summary="Significant data drift detected in feature 'age'",
-    evidence_diff_ids=(
-        "diff-1",
-        "diff-2",
-    ),
-    recommendation="Investigate recent changes",
-)
-
-DIFF = Diff(
-    diff_id="diff-1",
-    monitoring_run_id="monitoring-run-2",
-    source_run_id="train-run-2",
-    reference=DiffReference(
-        kind=DiffReferenceKind.BASELINE,
-        monitoring_run_id=None,
-        source_run_id="training-run-1",
-    ),
-    metric_name="kl",
-    current_value=0.25,
-    reference_value=0.5,
-    delta=-0.25,
 )
 
 
@@ -258,78 +224,6 @@ class TestInvariantLKGMembership:
         assert error.field == "active_lkg_monitoring_run_id"
         assert error.entity == "LKG"
         assert error.message == f"LKG {non_active_lkg} does not belong to Timeline {TIMELINE}"
-
-
-class TestInvariantFindingToDiffEvidence:
-    def test_finding_to_diff_evidence_valid(self) -> None:
-        """Finding with all evidence diff_ids present in the timeline should pass validation."""
-
-        validate_finding_to_diff_evidence(FINDING, DIFF)
-
-    def test_finding_to_diff_evidence_different_monitoring_run_id_invalid(self) -> None:
-        """Diff with monitoring_run_id different from Finding's monitoring_run_id should raise InvariantViolation."""  # noqa: E501
-
-        mismatch_monitoring_run_id_diff = Diff(
-            diff_id="diff-1",
-            monitoring_run_id="monitoring-run-3",
-            source_run_id="train-run-3",
-            reference=DiffReference(
-                kind=DiffReferenceKind.BASELINE,
-                monitoring_run_id=None,
-                source_run_id="train-run-3",
-            ),
-            metric_name="kl",
-            current_value=0.25,
-            reference_value=0.5,
-            delta=-0.25,
-        )
-
-        monitoring_run_id = FINDING.monitoring_run_id
-
-        with pytest.raises(InvariantViolation) as exc_info:
-            validate_finding_to_diff_evidence(FINDING, mismatch_monitoring_run_id_diff)
-
-        error = exc_info.value
-        assert error.code == "finding_diff_evidence_violation"
-        assert error.field == "monitoring_run_id"
-        assert error.entity == "Diff"
-        assert (
-            error.message
-            == f"Diff monitoring_run_id {mismatch_monitoring_run_id_diff.monitoring_run_id} "
-            f"does not match Finding monitoring_run_id {monitoring_run_id}"
-        )
-
-    def test_finding_to_diff_evidence_diff_id_not_in_evidence_invalid(self) -> None:
-        """Diff with diff_id not in Finding's evidence_diff_ids should raise InvariantViolation."""
-
-        non_evidence_diff = Diff(
-            diff_id="diff-3",  # diff_id not in FINDING.evidence_diff_ids to trigger violation
-            monitoring_run_id="monitoring-run-2",
-            source_run_id="train-run-2",
-            reference=DiffReference(
-                kind=DiffReferenceKind.BASELINE,
-                monitoring_run_id=None,
-                source_run_id="train-run-1",
-            ),
-            metric_name="kl",
-            current_value=0.25,
-            reference_value=0.5,
-            delta=-0.25,
-        )
-
-        diff_ids = [diff_id for diff_id in FINDING.evidence_diff_ids]
-
-        with pytest.raises(InvariantViolation) as exc_info:
-            validate_finding_to_diff_evidence(FINDING, non_evidence_diff)
-
-        error = exc_info.value
-        assert error.code == "finding_diff_evidence_violation"
-        assert error.field == "diff_id"
-        assert error.entity == "Diff"
-        assert (
-            error.message
-            == f"Diff diff_id {non_evidence_diff.diff_id} is not in Finding evidence {diff_ids}"
-        )
 
 
 class TestInvariantContractCheckResult:


### PR DESCRIPTION
## Summary

- replace the legacy Diff-only Finding with the approved Finding Draft and final Finding domain models
- add deterministic, versioned Finding identity generation and consistency validation
- validate Diff and Compatibility Evidence references against the complete current Monitoring Run pair
- add package-owned draft materialization with canonical ordering, idempotent deduplication, and fail-closed content conflicts
- define the Finding policy protocol over frozen parameters and immutable evidence and coverage inputs

## Why

V0-005 establishes the only v0 interpretation extension point while keeping authoritative run lineage, evidence validation, and Finding identity under package ownership.

## Scope

This remains a pure domain and policy-boundary change. It does not add Analyze execution, Recipe or component-registry integration, a built-in Finding policy, gateway persistence, or public facade changes. The existing `create -> prepare -> check` behavior is preserved.

## Validation

- `uv sync --extra dev`
- `uv run pytest` — 468 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright` — 0 errors
- `uv build`
