### PR TITLE
Workflow now require doc updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,8 +19,8 @@
 - [ ] `uv run ruff check .`
 - [ ] `uv run ruff format --check .`
 - [ ] `uv run pyright`
-- [ ] `uv build`
 - [ ] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
+- [ ] `uv build`
 - [ ] Update `docs/v0/`
 
 <!-- Validation omissions, if any: -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ## Validation
 
-<!-- Check only commands that were run successfully. Explain any omissions below. -->
+<!-- Check only commands that were run successfully (do not change the commands). Explain any omissions below. -->
 
 - [ ] `uv sync --extra dev --group doc`
 - [ ] `uv run pytest`
@@ -20,7 +20,7 @@
 - [ ] `uv run ruff format --check .`
 - [ ] `uv run pyright`
 - [ ] `uv build`
+- [ ] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
 - [ ] Update `docs/v0/`
-- [ ] Update `docs/site/`
 
 <!-- Validation omissions, if any: -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ Prefer architectural correctness, explicit behavior, and small reviewable change
 
 - Use Google-style docstrings for public runtime modules, classes, and functions under `src/mlflow_monitor/`.
 - Keep docstrings concise and focused on purpose, inputs, returns, and important failure behavior.
+- Developer documentation is published on Read the Docs from `docs/site/`; treat
+  it as a maintained product surface.
+- Every implementation ticket must update the corresponding `docs/site/` content
+  in the same branch and pull request. The implementation is incomplete until the
+  developer documentation matches the delivered behavior.
 
 ## Validation
 
@@ -55,11 +60,12 @@ each green ticket commit, run focused tests plus the applicable Ruff and Pyright
 checks. Before closing a ticket, run the complete gate:
 
 ```bash
-uv sync --extra dev
+uv sync --extra dev --group doc
 uv run pytest
 uv run ruff check .
 uv run ruff format --check .
 uv run pyright
+uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html
 uv build
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,10 @@ Prefer architectural correctness, explicit behavior, and small reviewable change
 - Keep docstrings concise and focused on purpose, inputs, returns, and important failure behavior.
 - Developer documentation is published on Read the Docs from `docs/site/`; treat
   it as a maintained product surface.
-- Every implementation ticket must update the corresponding `docs/site/` content
-  in the same branch and pull request. The implementation is incomplete until the
+- Every implementation ticket must assess its `docs/site/` impact. When an
+  implementation adds, removes, or changes behavior that requires corresponding
+  developer documentation, add, remove, or edit the matching `.rst` content in
+  the same branch and pull request. The implementation is incomplete until the
   developer documentation matches the delivered behavior.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ read-only.
 
 ## Choose a Track
 
-| Track | Use it for | Starting point |
-| --- | --- | --- |
-| **MVP Release (`v0.1.0`)** | A stable portfolio artifact, the shipped `create -> prepare -> check` workflow, and the executable fraud-monitoring demo | [Release](https://github.com/shizheng-rlfresh/mlflow-monitor/releases/tag/v0.1.0) · [README](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/v0.1.0/README.md) · [Demo](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/v0.1.0/demo/README.md) |
-| **Active development (`main`)** | Following or contributing to the evolving v0 implementation | This README and the source at the current revision |
+| Track                                   | Use it for                                                                                                                | Starting point                                                                                                                                                                                                                                                |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MVP Release (`v0.1.0`)**      | A stable portfolio artifact, the shipped`create -> prepare -> check` workflow, and the executable fraud-monitoring demo | [Release](https://github.com/shizheng-rlfresh/mlflow-monitor/releases/tag/v0.1.0) · [README](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/v0.1.0/README.md) · [Demo](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/v0.1.0/demo/README.md) |
+| **Active development (`main`)** | Following or contributing to the evolving v0 implementation                                                               | This README and the source at the current revision                                                                                                                                                                                                            |
 
 The active development line remains green as capabilities are added, but it does
 not carry the MVP Release's stability promise. Public documentation on `main`
@@ -89,11 +89,12 @@ documents.
 Use Python 3.12 or newer and `uv`:
 
 ```bash
-uv sync --extra dev
+uv sync --extra dev --group doc
 uv run pytest
 uv run ruff check .
 uv run ruff format --check .
 uv run pyright
+uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html
 uv build
 ```
 


### PR DESCRIPTION
## What changed

Updated `AGENTS.md` and pr template to enforce docs updating for developer doc site https://mlflow-monitor.readthedocs.io/en/latest/

## Why

Ensure docs site is consistent throughout the development.

## Impact

Added an extra step in validation to ensure doc is working fine.

## Validation

<!-- Check only commands that were run successfully. Explain any omissions below. -->

- [ ] `uv sync --extra dev --group doc`
- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run pyright`
- [ ] `uv build`
- [ ] Update `docs/v0/`
- [x] Update `docs/site/`

<!-- Validation omissions, if any: -->
