### PR TITLE
Update PR/Review rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,22 @@
 
 <!-- Explain the problem, requirement, or ticket outcome this change addresses. -->
 
+## Review context
+
+***Note: Please ensure including the context for agent reviewers. If human reviewers are requested, this could be skipped.***
+
+<!--
+Give reviewers only the context needed for this diff.
+- Link only the relevant public documents under docs/site/source/.
+- Summarize the required behavior in reviewable, externally safe terms.
+- State important behavior that is explicitly out of scope.
+- Do not link or quote the private design record.
+-->
+
+- Relevant public docs:
+- Required behavior:
+- Out of scope:
+
 ## Impact
 
 <!-- Describe user-facing or developer-facing behavior, compatibility, and migration impact. -->
@@ -21,6 +37,6 @@
 - [ ] `uv run pyright`
 - [ ] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
 - [ ] `uv build`
-- [ ] Update `docs/v0/`
+- [ ] Matching `docs/site/` content is updated, or no developer-doc change is required
 
 <!-- Validation omissions, if any: -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Prefer architectural correctness, explicit behavior, and small reviewable change
   plan when it is unavailable.
 - Never stage or publish files under `.agents/`.
 
-## Review rules
+## Code Review Rules
 
 - Default to a code review mindset when asked to review.
 - Prioritize correctness issues, behavioral regressions, edge cases, and missing tests.
@@ -40,6 +40,27 @@ Prefer architectural correctness, explicit behavior, and small reviewable change
 - Call out assumptions, unclear intent, or test gaps when they affect confidence.
 - If no findings are discovered, say so explicitly and note any residual risks or coverage gaps.
 - Do not focus on style-only feedback unless it affects correctness, maintainability, or project consistency.
+
+### Pull request context
+
+- Read the pull request's `Review context` before reviewing the diff.
+- Use only the public documents named there as ticket-specific design context.
+- Treat `Required behavior` and `Out of scope` as review boundaries, but flag any
+  conflict with repository guidance, shipped public behavior, code, or tests.
+- If the review context is absent or incomplete, do not invent intent. Review the
+  diff against the repository guidance, relevant public documentation, code, and
+  tests, and state the resulting uncertainty.
+
+### Monitoring boundaries
+
+- Flag any change that mutates a Source Training Run or stores monitoring-owned
+  state or artifacts on it. Source Training Runs are read-only; monitoring state
+  belongs to the subject's monitoring experiment or a Monitoring Run.
+- Flag any materialized domain value or public result that contains
+  `monitoring_run_id` without its immutable `source_run_id`, or that accepts a
+  conflicting pair. A Baseline Source Run is source-only and has no
+  `monitoring_run_id`; low-level MLflow adapters may use `run_id` only at the
+  upstream API boundary.
 
 ## Documentation
 


### PR DESCRIPTION
## What changed

Update `AGENTS.md` and PR template to enforce rules for having agent reviewing PRs.
## Why

Agent is not exposed to internal design docs or tickets, and not having appropriate amount of context has been repeatedly making agent PR review less relevant, sometimes could cause a big conflict with the design if blindly following the review.

## Impact

Composing PR comment would be more time consuming, but it is a high ROI action to take.

## Validation

<!-- Check only commands that were run successfully (do not change the commands). Explain any omissions below. -->

- [ ] `uv sync --extra dev --group doc`
- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run pyright`
- [ ] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
- [ ] `uv build`
- [x] Update `docs/v0/`

<!-- Validation omissions, if any: -->
