### PR TITLE
V0-008: Complete custom Finding-policy Recipe compilation

### DIFF
--- a/docs/site/source/recipe.rst
+++ b/docs/site/source/recipe.rst
@@ -61,9 +61,11 @@ parser. Compilation expands defaults, canonicalizes ordering, resolves the exact
 Contract and Finding-policy bindings, validates policy parameters, and returns an
 immutable ``CompiledRecipe`` with a JSON-serializable effective plan.
 
-The current ``ComponentRegistry`` intentionally contains only the packaged system
-Contract and ``system-compatibility-findings@v0`` policy. It accepts no user
-components; custom Contracts are outside the v0 boundary.
+``ComponentRegistry`` always includes the packaged system Contract and
+``system-compatibility-findings@v0`` policy. It may also receive additional
+Finding policies, each registered by its exact ID and version; duplicate
+identities, including the packaged policy identity, are rejected. Custom
+Contracts remain outside the v0 boundary.
 
 
 Recipe Compiler

--- a/src/mlflow_monitor/finding_policy.py
+++ b/src/mlflow_monitor/finding_policy.py
@@ -30,8 +30,15 @@ type FrozenFindingPolicyParameters = Mapping[str, FrozenJSONValue]
 class FindingPolicy(Protocol):
     """Registered extension point for versioned Finding interpretation."""
 
-    finding_policy_id: str
-    finding_policy_version: str
+    @property
+    def finding_policy_id(self) -> str:
+        """Return the stable policy identifier."""
+        ...
+
+    @property
+    def finding_policy_version(self) -> str:
+        """Return the exact policy version."""
+        ...
 
     def validate_parameters(
         self,

--- a/src/mlflow_monitor/recipe_compiler.py
+++ b/src/mlflow_monitor/recipe_compiler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
 
@@ -192,19 +192,43 @@ class CompiledRecipe:
 
 @dataclass(frozen=True, slots=True, init=False)
 class ComponentRegistry:
-    """Minimal immutable registry containing the v0 system components.
+    """Immutable registry containing system components and custom Finding policies.
 
     Attributes:
         contracts: System Contracts indexed by exact identity and version.
-        finding_policies: System policies indexed by exact identity and version.
+        finding_policies: System and custom policies indexed by exact identity and
+            version.
     """
 
     contracts: Mapping[tuple[str, str], Contract]
     finding_policies: Mapping[tuple[str, str], FindingPolicy]
 
-    def __init__(self) -> None:
-        """Construct the fixed system-only component registry."""
+    def __init__(self, *, finding_policies: Sequence[FindingPolicy] = ()) -> None:
+        """Construct the registry with optional custom Finding policies.
+
+        Args:
+            finding_policies: Additional policies to register by exact ID and
+                version. Duplicate identities, including system identities, are
+                rejected.
+
+        Raises:
+            ValueError: If more than one policy has the same ID and version.
+        """
         contract = resolve_contract_v0(SYSTEM_DEFAULT_CONTRACT_ID)
+        policies: dict[tuple[str, str], FindingPolicy] = {
+            (
+                SYSTEM_COMPATIBILITY_FINDING_POLICY_ID,
+                SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION,
+            ): SYSTEM_COMPATIBILITY_FINDING_POLICY
+        }
+        for policy in finding_policies:
+            identity = (policy.finding_policy_id, policy.finding_policy_version)
+            if identity in policies:
+                policy_identity = f"{policy.finding_policy_id}@{policy.finding_policy_version}"
+                raise ValueError(
+                    f"Finding policy identity {policy_identity} is already registered."
+                )
+            policies[identity] = policy
         object.__setattr__(
             self,
             "contracts",
@@ -213,14 +237,7 @@ class ComponentRegistry:
         object.__setattr__(
             self,
             "finding_policies",
-            MappingProxyType(
-                {
-                    (
-                        SYSTEM_COMPATIBILITY_FINDING_POLICY_ID,
-                        SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION,
-                    ): SYSTEM_COMPATIBILITY_FINDING_POLICY
-                }
-            ),
+            MappingProxyType(policies),
         )
 
 

--- a/tests/test_recipe_compiler.py
+++ b/tests/test_recipe_compiler.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import FrozenInstanceError, replace
+from types import MappingProxyType
 
 import pytest
 
 from mlflow_monitor.builtins import SYSTEM_DEFAULT_CONTRACT_ID
+from mlflow_monitor.domain import (
+    CompatibilityEvidence,
+    Diff,
+    FindingDraft,
+    ReferenceComparisonCoverage,
+)
 from mlflow_monitor.errors import RecipeValidationError
+from mlflow_monitor.finding_policy import (
+    FrozenFindingPolicyParameters,
+    JSONValue,
+)
 from mlflow_monitor.recipe import build_system_default_recipe, parse_recipe
 from mlflow_monitor.recipe_compiler import (
     SYSTEM_COMPATIBILITY_FINDING_POLICY_ID,
@@ -20,8 +32,38 @@ from mlflow_monitor.recipe_compiler import (
 )
 
 
-def test_component_registry_contains_only_immutable_system_components() -> None:
-    registry = ComponentRegistry()
+class _CustomFindingPolicy:
+    finding_policy_id = "custom-regression"
+    finding_policy_version = "v1"
+
+    def validate_parameters(
+        self,
+        parameters: Mapping[str, JSONValue],
+    ) -> FrozenFindingPolicyParameters:
+        maximum_decrease = parameters.get("maximum_decrease", 0.1)
+        if not isinstance(maximum_decrease, float) or not 0 <= maximum_decrease <= 1:
+            raise ValueError("maximum_decrease must be a float between zero and one")
+        return MappingProxyType({"maximum_decrease": maximum_decrease, "severity": "high"})
+
+    def evaluate(
+        self,
+        *,
+        parameters: FrozenFindingPolicyParameters,
+        diffs: tuple[Diff, ...],
+        compatibility_evidence: tuple[CompatibilityEvidence, ...],
+        reference_comparison_coverage: tuple[ReferenceComparisonCoverage, ...],
+    ) -> tuple[FindingDraft, ...]:
+        return ()
+
+
+class _SystemPolicyOverride(_CustomFindingPolicy):
+    finding_policy_id = SYSTEM_COMPATIBILITY_FINDING_POLICY_ID
+    finding_policy_version = SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION
+
+
+def test_component_registry_adds_immutable_custom_finding_policies() -> None:
+    policy = _CustomFindingPolicy()
+    registry = ComponentRegistry(finding_policies=(policy,))
 
     assert tuple(registry.contracts) == ((SYSTEM_DEFAULT_CONTRACT_ID, "v0"),)
     assert tuple(registry.finding_policies) == (
@@ -29,6 +71,7 @@ def test_component_registry_contains_only_immutable_system_components() -> None:
             SYSTEM_COMPATIBILITY_FINDING_POLICY_ID,
             SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION,
         ),
+        (policy.finding_policy_id, policy.finding_policy_version),
     )
     with pytest.raises(TypeError):
         registry.contracts[("custom", "1")] = registry.contracts[  # type: ignore[index]
@@ -41,6 +84,106 @@ def test_component_registry_contains_only_immutable_system_components() -> None:
                 SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION,
             )
         ]
+
+
+def test_component_registry_rejects_duplicate_policy_identity() -> None:
+    policy = _CustomFindingPolicy()
+
+    with pytest.raises(ValueError, match="custom-regression@v1"):
+        ComponentRegistry(finding_policies=(policy, policy))
+
+    with pytest.raises(ValueError, match="system-compatibility-findings@v0"):
+        ComponentRegistry(finding_policies=(_SystemPolicyOverride(),))
+
+
+def test_compile_recipe_resolves_custom_finding_policy_and_its_parameters() -> None:
+    policy = _CustomFindingPolicy()
+    raw = build_system_default_recipe()
+    raw["analysis"] = {
+        "finding_policy_bindings": [
+            {
+                "finding_policy_id": policy.finding_policy_id,
+                "finding_policy_version": policy.finding_policy_version,
+                "parameters": {"maximum_decrease": 0.2},
+            }
+        ]
+    }
+
+    compiled = compile_recipe(raw, component_registry=ComponentRegistry(finding_policies=(policy,)))
+
+    assert compiled.finding_policy_bindings[0].policy is policy
+    assert compiled.effective_plan.analysis.finding_policy_bindings[0].parameters == {
+        "maximum_decrease": 0.2,
+        "severity": "high",
+    }
+    assert (
+        json.loads(json.dumps(compiled.effective_plan.to_dict()))
+        == compiled.effective_plan.to_dict()
+    )
+
+
+def test_compile_recipe_keeps_custom_policy_opt_in_and_orders_explicit_bindings() -> None:
+    policy = _CustomFindingPolicy()
+    registry = ComponentRegistry(finding_policies=(policy,))
+
+    assert compile_recipe(
+        component_registry=registry
+    ).effective_plan.analysis.finding_policy_bindings == (
+        SYSTEM_DEFAULT_COMPILED_RECIPE.effective_plan.analysis.finding_policy_bindings
+    )
+
+    raw = build_system_default_recipe()
+    raw["analysis"] = {
+        "finding_policy_bindings": [
+            {
+                "finding_policy_id": SYSTEM_COMPATIBILITY_FINDING_POLICY_ID,
+                "finding_policy_version": SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION,
+            },
+            {
+                "finding_policy_id": policy.finding_policy_id,
+                "finding_policy_version": policy.finding_policy_version,
+            },
+        ]
+    }
+
+    compiled = compile_recipe(raw, component_registry=registry)
+
+    assert [
+        (binding.finding_policy_id, binding.finding_policy_version)
+        for binding in compiled.effective_plan.analysis.finding_policy_bindings
+    ] == [
+        (policy.finding_policy_id, policy.finding_policy_version),
+        (
+            SYSTEM_COMPATIBILITY_FINDING_POLICY_ID,
+            SYSTEM_COMPATIBILITY_FINDING_POLICY_VERSION,
+        ),
+    ]
+
+
+def test_compile_recipe_rejects_custom_policy_invalid_parameters_and_unknown_version() -> None:
+    policy = _CustomFindingPolicy()
+    registry = ComponentRegistry(finding_policies=(policy,))
+    raw = build_system_default_recipe()
+    raw["analysis"] = {
+        "finding_policy_bindings": [
+            {
+                "finding_policy_id": policy.finding_policy_id,
+                "finding_policy_version": policy.finding_policy_version,
+                "parameters": {"maximum_decrease": 2.0},
+            }
+        ]
+    }
+
+    with pytest.raises(RecipeValidationError) as exc_info:
+        compile_recipe(raw, component_registry=registry)
+
+    assert exc_info.value.issues[0].code == "invalid_policy_parameters"
+
+    raw["analysis"]["finding_policy_bindings"][0]["finding_policy_version"] = "v2"
+    with pytest.raises(RecipeValidationError) as exc_info:
+        compile_recipe(raw, component_registry=registry)
+
+    assert exc_info.value.issues[0].code == "unknown_component"
 
 
 def test_compile_recipe_zero_configuration_expands_system_defaults() -> None:


### PR DESCRIPTION
## What changed

- Allow `ComponentRegistry` to accept immutable, process-local custom Finding policies while retaining the packaged system Contract and Finding policy.
- Reject duplicate custom policy identities and attempts to override the system policy identity.
- Compile custom policy bindings by exact ID/version, validate and freeze their parameters, preserve system-default behavior, and canonically order explicit bindings.
- Document custom Finding-policy registration and add focused compiler coverage.

## Why

V0-008 completes the approved custom Finding-policy Recipe compilation boundary. Users need to register policy implementations separately from declarative Recipe data and resolve them during side-effect-free compilation without making Contracts customizable.

## Review context

- Relevant public docs: [Recipe authoring and compilation](docs/site/source/recipe.rst)
- Required behavior: The immutable registry always contains the system Contract and policy, accepts additional uniquely identified Finding policies, rejects system overrides and duplicate identities, and lets compilation resolve exact policy versions, validate parameters, emit a JSON-serializable effective plan, and preserve zero-configuration defaults without Gateway or MLflow operations.
- Out of scope: Custom Contracts or checkers, global/plugin discovery, persistence of policy objects or the registry, monitoring-run allocation, and execution of compiled custom policies at the run boundary.

## Impact

Developers can now construct a `ComponentRegistry` with custom Finding-policy implementations and compile Recipes that bind them. Existing zero-configuration and system-only compilation behavior is unchanged; no migration is required.

## Validation

- [x] `uv sync --extra dev --group doc`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Matching `docs/site/` content is updated, or no developer-doc change is required
- [x] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
- [x] `uv build`

Validation omissions: None.
