### PR TITLE
Add Timeline identity at monitoring run allocation time

### DIFF
--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -159,6 +159,13 @@ class CreateOrReuseMonitoringRunResult:
     existing_monitoring_run: MonitoringRunRecord | None
     allocated: bool
 
+    def __post_init__(self) -> None:
+        """Require the Timeline identity established by allocation."""
+        if not isinstance(self.timeline_id, str) or not self.timeline_id.strip():
+            raise ValueError(
+                "CreateOrReuseMonitoringRunResult.timeline_id must be a non-empty string."
+            )
+
 
 @dataclass(frozen=True, slots=True)
 class SourceRunRecord:

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -7,9 +7,9 @@ This module separates three kinds of state used by workflow:
    In the in-memory gateway, tests seed these with `add_source_run()`.
 
 2. Timeline state
-   Per-subject monitoring configuration anchored by a pinned
-   `baseline_source_run_id`. This is absent until the first monitoring run
-   being allocated. The baseline is then pinned by `pin_timeline_baseline()`.
+   Per-subject monitoring configuration created by the first Monitoring Run
+   allocation. Its `baseline_source_run_id` remains `None` until Prepare pins
+   the baseline through `pin_timeline_baseline()`.
 
 3. Monitoring runs
    Runs owned by the monitoring timeline itself. In the in-memory gateway,
@@ -22,9 +22,10 @@ Lifecycle sketch:
   - timeline state does not exist yet
   - monitoring runs do not exist yet
 
-- First prepare:
+- First Monitoring Run allocation and Prepare:
+  - allocation creates Timeline identity with no pinned baseline
   - workflow resolves the source run through the gateway
-  - if timeline state is missing, workflow may initialize it with a caller-supplied baseline
+  - Prepare pins a valid caller-supplied baseline
   - prepare then continues using the pinned timeline baseline
 
 - Later prepares:
@@ -111,10 +112,8 @@ class TimelineState:
             or None if not set yet.
 
     Note:
-        When first monitoring run is being allocated, the
-        `baseline_source_run_id` will typically be None. Only
-        when the baseline is bootstrapped, it will be set
-        to the source run id of the baseline run.
+        When the first Monitoring Run is allocated, `baseline_source_run_id`
+        is `None`. Successful bootstrap pins the Baseline Source Run identity.
     """
 
     timeline_id: str
@@ -201,7 +200,7 @@ class TimelinePinBaselineResult:
     """Result of pinning the timeline baseline attempt."""
 
     timeline_id: str
-    baseline_pinned: bool  # pinned baseline source run id
+    baseline_pinned: bool
 
 
 class MonitoringGateway(Protocol):
@@ -396,7 +395,7 @@ class InMemoryMonitoringGateway:
             baseline_source_run_id: Source training run id to pin as timeline baseline.
 
         Returns:
-            Timeline initialization result containing the timeline id and status.
+            Timeline identity and whether this call pinned the baseline.
         """
         if not baseline_source_run_id:
             raise GatewayNamespaceViolation(message="baseline_source_run_id must be non-empty.")
@@ -436,7 +435,8 @@ class InMemoryMonitoringGateway:
             subject_id: Monitored subject identifier.
 
         Returns:
-            The timeline state for the subject, or None if not initialized.
+            Timeline state after an allocation, or `None` when the subject has
+            no Monitoring Run allocation.
         """
         self._validate_subject_id(subject_id)
         return self._timeline_by_subject.get(subject_id)

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -8,8 +8,8 @@ This module separates three kinds of state used by workflow:
 
 2. Timeline state
    Per-subject monitoring configuration anchored by a pinned
-   `baseline_source_run_id`. This is absent before the first monitoring run
-   and is created by `initialize_timeline()`.
+   `baseline_source_run_id`. This is absent until the first monitoring run
+   being allocated. The baseline is then pinned by `pin_timeline_baseline()`.
 
 3. Monitoring runs
    Runs owned by the monitoring timeline itself. In the in-memory gateway,
@@ -197,11 +197,11 @@ class SourceRunRecord:
 
 
 @dataclass(frozen=True, slots=True)
-class TimelineInitializationResult:
-    """Result of timeline initialization attempt."""
+class TimelinePinBaselineResult:
+    """Result of pinning the timeline baseline attempt."""
 
     timeline_id: str
-    created: bool  # pinned baseline source run id
+    baseline_pinned: bool  # pinned baseline source run id
 
 
 class MonitoringGateway(Protocol):
@@ -218,10 +218,10 @@ class MonitoringGateway(Protocol):
         """
         ...
 
-    def initialize_timeline(
+    def pin_timeline_baseline(
         self, subject_id: str, baseline_source_run_id: str
-    ) -> TimelineInitializationResult:
-        """Initialize timeline state once for a subject and return timeline initialiation status."""
+    ) -> TimelinePinBaselineResult:
+        """Pin the timeline baseline for a subject and return the result."""
         ...
 
     def resolve_active_lkg_monitoring_run_id(self, subject_id: str) -> str | None:
@@ -386,10 +386,10 @@ class InMemoryMonitoringGateway:
             allocated=True,
         )
 
-    def initialize_timeline(
+    def pin_timeline_baseline(
         self, subject_id: str, baseline_source_run_id: str
-    ) -> TimelineInitializationResult:
-        """Initialize timeline state once for a subject and return timeline id.
+    ) -> TimelinePinBaselineResult:
+        """Pin the timeline baseline for a subject and return the result.
 
         Args:
             subject_id: Monitored subject identifier.
@@ -418,15 +418,15 @@ class InMemoryMonitoringGateway:
                 baseline_source_run_id=baseline_source_run_id,
             )
 
-            return TimelineInitializationResult(
+            return TimelinePinBaselineResult(
                 timeline_id=self._timeline_by_subject[subject_id].timeline_id,
-                created=True,
+                baseline_pinned=True,
             )
 
         # timeline already has a baseline source run id, nothing to do
-        return TimelineInitializationResult(
+        return TimelinePinBaselineResult(
             timeline_id=timeline_state.timeline_id,
-            created=False,
+            baseline_pinned=False,
         )
 
     def get_timeline_state(self, subject_id: str) -> TimelineState | None:

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -107,11 +107,18 @@ class TimelineState:
 
     Attributes:
         timeline_id: Stable timeline identifier.
-        baseline_source_run_id: Pinned baseline source run id.
+        baseline_source_run_id: Pinned baseline source run id
+            or None if not set yet.
+
+    Note:
+        When first monitoring run is being allocated, the
+        `baseline_source_run_id` will typically be None. Only
+        when the baseline is bootstrapped, it will be set
+        to the source run id of the baseline run.
     """
 
     timeline_id: str
-    baseline_source_run_id: str
+    baseline_source_run_id: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,7 +201,7 @@ class TimelineInitializationResult:
     """Result of timeline initialization attempt."""
 
     timeline_id: str
-    created: bool
+    created: bool  # pinned baseline source run id
 
 
 class MonitoringGateway(Protocol):
@@ -340,13 +347,16 @@ class InMemoryMonitoringGateway:
         """Create a new monitoring run allocation or return the existing idempotent one."""
         self._validate_subject_id(key.subject_id)
 
-        # get the existing timeline or init a new timeline if it doesn't exist
+        # get the existing timeline or create a new timeline if it doesn't exist
+        # if no timeline exists for the subject, that means this is the first
+        # monitoring run.
         timeline_state = self.get_timeline_state(key.subject_id)
         if timeline_state is None:
-            timeline_init_result = self.initialize_timeline(key.subject_id, key.source_run_id)
-            timeline_id = timeline_init_result.timeline_id
-        else:
-            timeline_id = timeline_state.timeline_id
+            timeline_state = TimelineState(
+                timeline_id=f"timeline-{key.subject_id}",
+                baseline_source_run_id=None,
+            )
+            self._timeline_by_subject[key.subject_id] = timeline_state
 
         existing_binding = self._idempotency_bindings.get(key)
         if existing_binding is not None:
@@ -357,7 +367,7 @@ class InMemoryMonitoringGateway:
             return CreateOrReuseMonitoringRunResult(
                 monitoring_run_id=existing_monitoring_run_id,
                 source_run_id=key.source_run_id,
-                timeline_id=timeline_id,
+                timeline_id=timeline_state.timeline_id,
                 sequence_index=sequence_index,
                 existing_monitoring_run=existing_monitoring_run,
                 allocated=False,
@@ -370,7 +380,7 @@ class InMemoryMonitoringGateway:
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=new_monitoring_run_id,
             source_run_id=key.source_run_id,
-            timeline_id=timeline_id,
+            timeline_id=timeline_state.timeline_id,
             sequence_index=sequence_index,
             existing_monitoring_run=None,
             allocated=True,
@@ -392,19 +402,31 @@ class InMemoryMonitoringGateway:
             raise GatewayNamespaceViolation(message="baseline_source_run_id must be non-empty.")
 
         self._validate_subject_id(subject_id)
-        if subject_id in self._timeline_by_subject:
+
+        timeline_state = self._timeline_by_subject.get(subject_id)
+        if timeline_state is None:
+            raise GatewayConsistencyViolation(
+                code="timeline_state_not_found_for_subject_id",
+                message=f"Timeline state for subject_id '{subject_id}' not found.",
+                details=(("subject_id", subject_id),),
+            )
+
+        # ready to bootstrap the timeline with the baseline source run id
+        if timeline_state.baseline_source_run_id is None:
+            self._timeline_by_subject[subject_id] = TimelineState(
+                timeline_id=timeline_state.timeline_id,
+                baseline_source_run_id=baseline_source_run_id,
+            )
+
             return TimelineInitializationResult(
                 timeline_id=self._timeline_by_subject[subject_id].timeline_id,
-                created=False,
+                created=True,
             )
-        timeline_state = TimelineState(
-            timeline_id=f"timeline-{subject_id}",
-            baseline_source_run_id=baseline_source_run_id,
-        )
-        self._timeline_by_subject[subject_id] = timeline_state
+
+        # timeline already has a baseline source run id, nothing to do
         return TimelineInitializationResult(
             timeline_id=timeline_state.timeline_id,
-            created=True,
+            created=False,
         )
 
     def get_timeline_state(self, subject_id: str) -> TimelineState | None:

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -139,6 +139,7 @@ class CreateOrReuseMonitoringRunResult:
         monitoring_run_id: Monitoring run identifier owned by the gateway.
         source_run_id: Immutable source training run identifier.
         sequence_index: Monotonic per-subject sequence index.
+        timeline_id: Stable timeline identifier associated with this monitoring run.
         existing_monitoring_run: Existing stored monitoring run record, if any. This may be
             None even when a prior idempotency binding already exists.
         allocated: Whether this call created a new idempotency binding / monitoring-run
@@ -147,6 +148,7 @@ class CreateOrReuseMonitoringRunResult:
 
     monitoring_run_id: str
     source_run_id: str
+    timeline_id: str
     sequence_index: int
     existing_monitoring_run: MonitoringRunRecord | None
     allocated: bool
@@ -337,6 +339,15 @@ class InMemoryMonitoringGateway:
     ) -> CreateOrReuseMonitoringRunResult:
         """Create a new monitoring run allocation or return the existing idempotent one."""
         self._validate_subject_id(key.subject_id)
+
+        # get the existing timeline or init a new timeline if it doesn't exist
+        timeline_state = self.get_timeline_state(key.subject_id)
+        if timeline_state is None:
+            timeline_init_result = self.initialize_timeline(key.subject_id, key.source_run_id)
+            timeline_id = timeline_init_result.timeline_id
+        else:
+            timeline_id = timeline_state.timeline_id
+
         existing_binding = self._idempotency_bindings.get(key)
         if existing_binding is not None:
             existing_monitoring_run_id, sequence_index = existing_binding
@@ -346,6 +357,7 @@ class InMemoryMonitoringGateway:
             return CreateOrReuseMonitoringRunResult(
                 monitoring_run_id=existing_monitoring_run_id,
                 source_run_id=key.source_run_id,
+                timeline_id=timeline_id,
                 sequence_index=sequence_index,
                 existing_monitoring_run=existing_monitoring_run,
                 allocated=False,
@@ -358,6 +370,7 @@ class InMemoryMonitoringGateway:
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=new_monitoring_run_id,
             source_run_id=key.source_run_id,
+            timeline_id=timeline_id,
             sequence_index=sequence_index,
             existing_monitoring_run=None,
             allocated=True,

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -209,18 +209,18 @@ class MLflowMonitoringGateway:
     def pin_timeline_baseline(
         self, subject_id: str, baseline_source_run_id: str
     ) -> TimelinePinBaselineResult:
-        """Initialize the experiment-backed timeline baseline once.
+        """Pin the experiment-backed Timeline baseline once.
 
-        The monitoring experiment doubles as the subject timeline. Timeline
-        initialization therefore means "ensure the experiment exists and pin the
-        baseline tag if it has not been pinned already."
+        The monitoring experiment backs the subject Timeline and already exists
+        because Monitoring Run allocation precedes this operation. This method
+        pins the baseline tag when it has not been pinned already.
 
         Args:
             subject_id: Monitored subject identifier.
             baseline_source_run_id: Source training run id to pin as baseline.
 
         Returns:
-            Timeline initialization status with the stable timeline id.
+            Timeline identity and whether this call pinned the baseline.
         """
         self._validate_subject_id(subject_id)
         if not baseline_source_run_id:
@@ -475,14 +475,15 @@ class MLflowMonitoringGateway:
         return tuple(records)
 
     def get_timeline_state(self, subject_id: str) -> TimelineState | None:
-        """Return timeline state after the first monitoring run being allocated for the subject_id.
+        """Return Timeline state after the subject's first Monitoring Run allocation.
 
         Args:
             subject_id: Monitored subject identifier.
 
         Returns:
-            Timeline state when the monitoring experiment exists and has a
-            pinned baseline; otherwise `None`.
+            Timeline state for an allocated subject. Its baseline is `None`
+            until bootstrap succeeds. Returns `None` when no Monitoring Run
+            allocation exists.
         """
         experiment_id = self._get_experiment_id(subject_id)
         if experiment_id is None:

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -53,7 +53,7 @@ from mlflow_monitor.gateway import (
     GatewayConfig,
     IdempotencyKey,
     MonitoringRunRecord,
-    TimelineInitializationResult,
+    TimelinePinBaselineResult,
     TimelineState,
 )
 from mlflow_monitor.mlflow_client import MonitoringRunTagSnapshot, MonitorMLflowClient
@@ -100,9 +100,9 @@ class _MonitoringRunAllocation:
 class MLflowMonitoringGateway:
     """Monitoring gateway backed by real MLflow experiments and runs.
 
-    The gateway translates protocol-level operations such as "initialize the
-    subject timeline" or "create or reuse the monitoring run for this training
-    run" into:
+    The gateway translates protocol-level operations such as "pin the
+    subject timeline with baseline" or "create or reuse the monitoring run
+    for this training run" into:
 
     - monitoring experiment creation/read
     - experiment-tag index maintenance
@@ -206,9 +206,9 @@ class MLflowMonitoringGateway:
             allocated=True,
         )
 
-    def initialize_timeline(
+    def pin_timeline_baseline(
         self, subject_id: str, baseline_source_run_id: str
-    ) -> TimelineInitializationResult:
+    ) -> TimelinePinBaselineResult:
         """Initialize the experiment-backed timeline baseline once.
 
         The monitoring experiment doubles as the subject timeline. Timeline
@@ -235,18 +235,18 @@ class MLflowMonitoringGateway:
             )
 
         if timeline_state.baseline_source_run_id is not None:
-            return TimelineInitializationResult(
+            return TimelinePinBaselineResult(
                 timeline_id=timeline_state.timeline_id,
-                created=False,
+                baseline_pinned=False,
             )
 
         experiment_id = timeline_state.timeline_id
         experiment_tags = self._mlflow.get_monitoring_experiment_tags(experiment_id)
         existing_baseline_source_run_id = experiment_tags.get(_BASELINE_TAG)
         if existing_baseline_source_run_id:
-            return TimelineInitializationResult(
+            return TimelinePinBaselineResult(
                 timeline_id=experiment_id,
-                created=False,
+                baseline_pinned=False,
             )
 
         self._set_experiment_tags(
@@ -256,9 +256,9 @@ class MLflowMonitoringGateway:
                 _NEXT_SEQUENCE_TAG: str(self._read_next_sequence_index(experiment_tags)),
             },
         )
-        return TimelineInitializationResult(
+        return TimelinePinBaselineResult(
             timeline_id=experiment_id,
-            created=True,
+            baseline_pinned=True,
         )
 
     def resolve_active_lkg_monitoring_run_id(self, subject_id: str) -> str | None:

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -475,15 +475,15 @@ class MLflowMonitoringGateway:
         return tuple(records)
 
     def get_timeline_state(self, subject_id: str) -> TimelineState | None:
-        """Return Timeline state after the subject's first Monitoring Run allocation.
+        """Return the recorded Timeline state for an allocated subject.
 
         Args:
             subject_id: Monitored subject identifier.
 
         Returns:
-            Timeline state for an allocated subject. Its baseline is `None`
-            until bootstrap succeeds. Returns `None` when no Monitoring Run
-            allocation exists.
+            Timeline state containing its stable identity and optional pinned
+            Baseline Source Run identity. Returns `None` when no durable
+            Monitoring Run allocation exists.
         """
         experiment_id = self._get_experiment_id(subject_id)
         if experiment_id is None:

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -165,6 +165,7 @@ class MLflowMonitoringGateway:
             return CreateOrReuseMonitoringRunResult(
                 monitoring_run_id=existing_allocation.monitoring_run_id,
                 source_run_id=existing_allocation.key.source_run_id,
+                timeline_id=experiment_id,
                 sequence_index=existing_allocation.sequence_index,
                 existing_monitoring_run=self.get_monitoring_run(
                     key.subject_id,
@@ -199,6 +200,7 @@ class MLflowMonitoringGateway:
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=monitoring_run_info.run_id,
             source_run_id=key.source_run_id,
+            timeline_id=experiment_id,
             sequence_index=sequence_index,
             existing_monitoring_run=None,
             allocated=True,
@@ -224,7 +226,21 @@ class MLflowMonitoringGateway:
         if not baseline_source_run_id:
             raise GatewayNamespaceViolation(message="baseline_source_run_id must be non-empty.")
 
-        experiment_id = self._get_or_create_experiment_id(subject_id)
+        timeline_state = self.get_timeline_state(subject_id)
+        if timeline_state is None:
+            raise GatewayConsistencyViolation(
+                code="timeline_state_not_found_for_subject_id",
+                message=f"Timeline state for subject_id '{subject_id}' not found.",
+                details=(("subject_id", subject_id),),
+            )
+
+        if timeline_state.baseline_source_run_id is not None:
+            return TimelineInitializationResult(
+                timeline_id=timeline_state.timeline_id,
+                created=False,
+            )
+
+        experiment_id = timeline_state.timeline_id
         experiment_tags = self._mlflow.get_monitoring_experiment_tags(experiment_id)
         existing_baseline_source_run_id = experiment_tags.get(_BASELINE_TAG)
         if existing_baseline_source_run_id:
@@ -474,8 +490,19 @@ class MLflowMonitoringGateway:
 
         experiment_tags = self._mlflow.get_monitoring_experiment_tags(experiment_id)
         baseline_source_run_id = experiment_tags.get(_BASELINE_TAG)
-        if not baseline_source_run_id:
+
+        allocation_snapshots = self._mlflow.list_monitoring_runs_with_tag(
+            experiment_id=experiment_id,
+            tag_key=_SOURCE_RUN_TAG,
+        )
+
+        if not allocation_snapshots:
             return None
+
+        # validate the records are actual durable snapshots
+        for snapshot in allocation_snapshots:
+            self._parse_monitoring_run_allocation(subject_id, snapshot)
+
         return TimelineState(
             timeline_id=experiment_id,
             baseline_source_run_id=baseline_source_run_id,

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -475,7 +475,7 @@ class MLflowMonitoringGateway:
         return tuple(records)
 
     def get_timeline_state(self, subject_id: str) -> TimelineState | None:
-        """Return timeline state once the baseline has been pinned.
+        """Return timeline state after the first monitoring run being allocated for the subject_id.
 
         Args:
             subject_id: Monitored subject identifier.

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -48,6 +48,7 @@ class OrchestrationState:
         source_run_id: The original run ID from the training system that produced this run.
         baseline_source_run_id: The source run ID of the baseline this run is compared against
         compiled_recipe: The execution-ready compiled Recipe for this run.
+        timeline_id: The Timeline identity returned by monitoring-run allocation.
         monitoring_run_id: The unique ID of the monitoring run to be executed.
         existing_monitoring_run: The existing monitoring run record, if any.
         is_new_monitoring_run: Whether this is a new monitoring run.
@@ -59,6 +60,7 @@ class OrchestrationState:
     source_run_id: str
     baseline_source_run_id: str | None
     compiled_recipe: CompiledRecipe
+    timeline_id: str
     monitoring_run_id: str
     existing_monitoring_run: MonitoringRunRecord | None
     is_new_monitoring_run: bool
@@ -135,6 +137,7 @@ def _resolve_orchestration_state(
         source_run_id=create_or_reuse_result.source_run_id,
         baseline_source_run_id=baseline_source_run_id,
         compiled_recipe=compiled_recipe,
+        timeline_id=create_or_reuse_result.timeline_id,
         monitoring_run_id=create_or_reuse_result.monitoring_run_id,
         existing_monitoring_run=create_or_reuse_result.existing_monitoring_run,
         is_new_monitoring_run=create_or_reuse_result.existing_monitoring_run is None,
@@ -155,12 +158,12 @@ def _short_circuit_existing_monitoring_run(
         result = _build_failure_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            timeline_id=state.timeline_id,
             stage="prepare",
             error=_build_terminal_failed_monitoring_run_rerun_error(
                 subject_id=state.subject_id,
                 monitoring_run_id=state.monitoring_run_id,
             ),
-            gateway=gateway,
         )
         gateway.finalize_monitoring_run_result(
             monitoring_run_id=state.monitoring_run_id,
@@ -181,16 +184,16 @@ def _short_circuit_existing_monitoring_run(
         return _build_failure_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            timeline_id=state.timeline_id,
             stage="prepare",
             error=replay_error,
-            gateway=gateway,
         )
 
     result = _build_existing_checked_monitoring_run_result(
         subject_id=state.subject_id,
         monitoring_run_id=state.monitoring_run_id,
+        timeline_id=state.timeline_id,
         existing_monitoring_run=state.existing_monitoring_run,
-        gateway=gateway,
     )
     gateway.finalize_monitoring_run_result(
         monitoring_run_id=state.monitoring_run_id,
@@ -233,9 +236,9 @@ def _run_prepare_monitoring_run_slice(
         result = _build_failure_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            timeline_id=state.timeline_id,
             stage="prepare",
             error=exc,
-            gateway=gateway,
         )
         gateway.finalize_monitoring_run_result(
             monitoring_run_id=state.monitoring_run_id,
@@ -271,8 +274,8 @@ def _run_check_monitoring_run_slice(
         result = _build_existing_checked_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            timeline_id=state.timeline_id,
             existing_monitoring_run=existing_run,
-            gateway=gateway,
         )
         gateway.finalize_monitoring_run_result(
             monitoring_run_id=state.monitoring_run_id,
@@ -297,9 +300,9 @@ def _run_check_monitoring_run_slice(
         result = _build_failure_monitoring_run_result(
             subject_id=state.subject_id,
             monitoring_run_id=state.monitoring_run_id,
+            timeline_id=state.timeline_id,
             stage="check",
             error=exc,
-            gateway=gateway,
         )
         gateway.finalize_monitoring_run_result(
             monitoring_run_id=state.monitoring_run_id,
@@ -319,6 +322,7 @@ def _run_check_monitoring_run_slice(
     result = _build_success_monitoring_run_result(
         subject_id=state.subject_id,
         monitoring_run_id=state.monitoring_run_id,
+        timeline_id=state.timeline_id,
         prepared_context=prepared_context,
         contract_check_result=contract_check_result,
         gateway=gateway,
@@ -334,6 +338,7 @@ def _build_success_monitoring_run_result(
     *,
     subject_id: str,
     monitoring_run_id: str,
+    timeline_id: str,
     prepared_context,
     contract_check_result: ContractCheckResult,
     gateway: MonitoringGateway,
@@ -343,6 +348,7 @@ def _build_success_monitoring_run_result(
     Args:
         subject_id: The ID of the monitored subject this run is associated with.
         monitoring_run_id: The ID of the monitoring run.
+        timeline_id: The Timeline identity returned by monitoring-run allocation.
         prepared_context: The prepared context produced by the prepare stage for this run.
         contract_check_result: The result of the contract check stage for this run.
         gateway: The monitoring gateway to use for retrieving any additional information needed.
@@ -350,11 +356,10 @@ def _build_success_monitoring_run_result(
     Returns:
         The canonical success result for this run, including comparability status and any findings.
     """
-    timeline_state = gateway.get_timeline_state(subject_id)
     return MonitorRunResult(
         monitoring_run_id=monitoring_run_id,
         subject_id=subject_id,
-        timeline_id=None if timeline_state is None else timeline_state.timeline_id,
+        timeline_id=timeline_id,
         lifecycle_status=LifecycleStatus.CHECKED,
         comparability_status=contract_check_result.status,
         summary=None,
@@ -369,25 +374,24 @@ def _build_existing_checked_monitoring_run_result(
     *,
     subject_id: str,
     monitoring_run_id: str,
+    timeline_id: str,
     existing_monitoring_run: MonitoringRunRecord,
-    gateway: MonitoringGateway,
 ) -> MonitorRunResult:
     """Build a success result for an already checked idempotent run.
 
     Args:
         subject_id: The ID of the monitored subject this run is associated with.
         monitoring_run_id: The ID of the monitoring run.
+        timeline_id: The Timeline identity returned by monitoring-run allocation.
         existing_monitoring_run: The previously persisted monitoring run record for this run.
-        gateway: The monitoring gateway to use for retrieving timeline information.
 
     Returns:
         The canonical success result for an already checked run.
     """
-    timeline_state = gateway.get_timeline_state(subject_id)
     return MonitorRunResult(
         monitoring_run_id=monitoring_run_id,
         subject_id=subject_id,
-        timeline_id=None if timeline_state is None else timeline_state.timeline_id,
+        timeline_id=timeline_id,
         lifecycle_status=LifecycleStatus.CHECKED,
         comparability_status=existing_monitoring_run.contract_check_result.status
         if existing_monitoring_run.contract_check_result is not None
@@ -404,27 +408,26 @@ def _build_failure_monitoring_run_result(
     *,
     subject_id: str,
     monitoring_run_id: str,
+    timeline_id: str,
     stage: str,
     error: Exception,
-    gateway: MonitoringGateway,
 ) -> MonitorRunResult:
     """Build the canonical failed result for a prepare/check execution error.
 
     Args:
         subject_id: The ID of the monitored subject this run is associated with.
         monitoring_run_id: The ID of the monitoring run.
+        timeline_id: The Timeline identity returned by monitoring-run allocation.
         stage: The stage during which the error occurred (e.g., "prepare" or "check").
         error: The exception raised during execution.
-        gateway: The monitoring gateway to use for retrieving any additional information needed.
 
     Returns:
         The canonical failure result for this run, including error details.
     """
-    timeline_state = gateway.get_timeline_state(subject_id)
     return MonitorRunResult(
         monitoring_run_id=monitoring_run_id,
         subject_id=subject_id,
-        timeline_id=None if timeline_state is None else timeline_state.timeline_id,
+        timeline_id=timeline_id,
         lifecycle_status=LifecycleStatus.FAILED,
         comparability_status=None,
         summary=None,
@@ -608,7 +611,7 @@ def _validate_checked_monitoring_run_rerun_inputs(
         return None
 
     return PrepareStageError(
-        code="prepare_baseline_trying_to_override_existing_timeline",
+        code="prepare_baseline_override_existing_timeline",
         message=(
             f"Provided baseline_source_run_id={baseline_source_run_id!r} "
             f"with resolved_baseline_source_run_id={resolved_baseline_source_run_id!r} "

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -608,11 +608,11 @@ def _validate_checked_monitoring_run_rerun_inputs(
         return None
 
     return PrepareStageError(
-        code="prepare_baseline_override_existing_timeline",
+        code="prepare_baseline_trying_to_override_existing_timeline",
         message=(
             f"Provided baseline_source_run_id={baseline_source_run_id!r} "
             f"with resolved_baseline_source_run_id={resolved_baseline_source_run_id!r} "
-            "does not match existing timeline "
+            "does not match existing timeline pinned "
             f"baseline_source_run_id={timeline_state.baseline_source_run_id!r} "
             f"for subject_id={subject_id}. Overriding an existing timeline's baseline "
             "is not allowed."

--- a/src/mlflow_monitor/result_contract.py
+++ b/src/mlflow_monitor/result_contract.py
@@ -51,7 +51,7 @@ class MonitorRunResult:
     Attributes:
         monitoring_run_id: Unique monitoring run identifier.
         subject_id: Monitored subject identifier.
-        timeline_id: Timeline identifier if known for this run.
+        timeline_id: Required Timeline identifier for this allocated Monitoring Run.
         lifecycle_status: Current workflow lifecycle status.
         comparability_status: Optional comparability verdict if computed.
         summary: Optional structured summary payload.
@@ -63,7 +63,7 @@ class MonitorRunResult:
 
     monitoring_run_id: str
     subject_id: str
-    timeline_id: str | None
+    timeline_id: str
     lifecycle_status: LifecycleStatus
     comparability_status: ComparabilityStatus | None
     summary: Mapping[str, str] | None
@@ -74,6 +74,8 @@ class MonitorRunResult:
 
     def __post_init__(self) -> None:
         """Freeze mapping and sequence fields after defensive copies."""
+        if not isinstance(self.timeline_id, str) or not self.timeline_id.strip():
+            raise ValueError("MonitorRunResult.timeline_id must be a non-empty string.")
         if self.lifecycle_status is LifecycleStatus.FAILED and self.error is None:
             raise ValueError(
                 "MonitorRunResult with lifecycle_status=failed requires a non-null error."

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -402,6 +402,92 @@ def _resolve_baseline_for_prepare(
     Returns:
         Baseline resolution result containing timeline and resolved baseline information.
     """
+    # The timeline does not exist yet, so we cannot resolve a baseline without it.
+    if timeline_state is None:
+        raise PrepareStageError(
+            code="prepare_missing_timeline",
+            message=(
+                f"No timeline exists for the {subject_id} and baseline resolution cannot proceed."
+            ),
+            details=(("subject_id", subject_id),),
+        )
+
+    # The timeline exists, so we can check for a pinned baseline.
+    pinned_baseline = timeline_state.baseline_source_run_id
+
+    # If there is no pinned baseline, we will need to bootstrap the baseline
+    if pinned_baseline is None:
+        if baseline_source_run_id is None or baseline_source_run_id == "":
+            raise PrepareStageError(
+                code="prepare_missing_baseline_for_uninitialized_timeline",
+                message=(
+                    f"The timeline for subject_id={subject_id!r} has no pinned baseline "
+                    "and no baseline_source_run_id was provided. "
+                    "A valid baseline_source_run_id is required to bootstrap the timeline."
+                ),
+                details=(
+                    ("subject_id", subject_id),
+                    ("baseline_source_run_id", baseline_source_run_id),
+                ),
+            )
+
+        resolved_baseline = gateway.resolve_source_run_id(
+            subject_id=subject_id,
+            source_experiment=compiled_recipe.source_requirements.source_experiment,
+            source_run_id=baseline_source_run_id,
+        )
+
+        if resolved_baseline is None:
+            raise PrepareStageError(
+                code="prepare_invalid_bootstrap_baseline",
+                message=(
+                    f"Baseline source run could not be resolved for subject_id={subject_id!r}, "
+                    f"source_experiment={compiled_recipe.source_requirements.source_experiment!r}, "
+                    f"and baseline_source_run_id={baseline_source_run_id!r}."
+                ),
+                details=(
+                    ("subject_id", subject_id),
+                    (
+                        "compiled_recipe.source_requirements.source_experiment",
+                        compiled_recipe.source_requirements.source_experiment,
+                    ),
+                    ("baseline_source_run_id", baseline_source_run_id),
+                ),
+            )
+
+        return BaselineResolutionResult(
+            baseline_source_run_id=resolved_baseline,
+            requires_bootstrap=True,
+        )
+
+    # If the timeline exists, we do not need to bootstrap the baseline.
+    if baseline_source_run_id is not None:
+        resolved_baseline = gateway.resolve_source_run_id(
+            subject_id=subject_id,
+            source_experiment=compiled_recipe.source_requirements.source_experiment,
+            source_run_id=baseline_source_run_id,
+        )
+
+        if resolved_baseline != pinned_baseline:
+            raise PrepareStageError(
+                code="prepare_baseline_trying_to_override_existing_timeline",
+                message=(
+                    f"Resolved baseline {resolved_baseline} does not match "
+                    f"pinned baseline {pinned_baseline} "
+                    f"for subject_id={subject_id}."
+                ),
+                details=(
+                    ("subject_id", subject_id),
+                    ("resolved_baseline", resolved_baseline),
+                    ("pinned_baseline", pinned_baseline),
+                ),
+            )
+
+    return BaselineResolutionResult(
+        baseline_source_run_id=pinned_baseline,
+        requires_bootstrap=False,
+    )
+
     if timeline_state is not None:
         if baseline_source_run_id is None:
             pass

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -232,7 +232,7 @@ def prepare_run_context(
 
     if baseline_resolution_result.requires_bootstrap:
         # race handling
-        timeline_init_result = gateway.initialize_timeline(
+        timeline_pin_baseline_result = gateway.pin_timeline_baseline(
             subject_id,
             baseline_resolution_result.baseline_source_run_id,
         )
@@ -247,17 +247,15 @@ def prepare_run_context(
                 ),
                 details=(("subject_id", subject_id),),
             )
-        if timeline_init_result.created:
+        if timeline_pin_baseline_result.baseline_pinned:
             if (
                 timeline_state.baseline_source_run_id
                 != baseline_resolution_result.baseline_source_run_id
             ):
                 _id = subject_id
                 raise PrepareStageError(
-                    code="prepare_timeline_initialization_failed",
-                    message=(
-                        f"Timeline initialization did not materialize state for subject_id={_id}."
-                    ),
+                    code="prepare_timeline_pin_failed",
+                    message=(f"Timeline pinning did not materialize state for subject_id={_id}."),
                     details=(("subject_id", subject_id),),
                 )
         elif (

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -296,6 +296,9 @@ def prepare_run_context(
     timeline_runs = gateway.list_timeline_monitoring_runs(subject_id, exclude_failed=True)
     previous_monitoring_run_id = timeline_runs[-1].monitoring_run_id if timeline_runs else None
 
+    assert timeline_state.baseline_source_run_id is not None
+    assert timeline_state.baseline_source_run_id != ""
+
     return PreparedContext(
         monitoring_run_id=monitoring_run_id,
         subject_id=subject_id,
@@ -472,14 +475,15 @@ def _resolve_baseline_for_prepare(
             raise PrepareStageError(
                 code="prepare_baseline_trying_to_override_existing_timeline",
                 message=(
-                    f"Resolved baseline {resolved_baseline} does not match "
-                    f"pinned baseline {pinned_baseline} "
-                    f"for subject_id={subject_id}."
+                    f"Provided baseline_source_run_id={baseline_source_run_id!r} "
+                    f"with resolved baseline_source_run_id={resolved_baseline!r} does not match "
+                    f"existing timeline pinned baseline_source_run_id={pinned_baseline!r} "
+                    f"for subject_id={subject_id!r}. "
+                    "Overriding an existing timeline's baseline is not allowed."
                 ),
                 details=(
                     ("subject_id", subject_id),
-                    ("resolved_baseline", resolved_baseline),
-                    ("pinned_baseline", pinned_baseline),
+                    ("baseline_source_run_id", resolved_baseline),
                 ),
             )
 
@@ -487,80 +491,3 @@ def _resolve_baseline_for_prepare(
         baseline_source_run_id=pinned_baseline,
         requires_bootstrap=False,
     )
-
-    if timeline_state is not None:
-        if baseline_source_run_id is None:
-            pass
-        else:
-            resolved_baseline_source_run_id = gateway.resolve_source_run_id(
-                subject_id=subject_id,
-                source_experiment=compiled_recipe.source_requirements.source_experiment,
-                source_run_id=baseline_source_run_id,
-            )
-            if resolved_baseline_source_run_id == timeline_state.baseline_source_run_id:
-                pass
-            else:
-                _id = subject_id
-                _provided_baseline = baseline_source_run_id
-                _existing_baseline = timeline_state.baseline_source_run_id
-                raise PrepareStageError(
-                    code="prepare_baseline_override_existing_timeline",
-                    message=(
-                        f"Provided baseline_source_run_id={_provided_baseline!r} "
-                        f"with resolved_baseline_source_run_id={resolved_baseline_source_run_id!r} "
-                        "does not match existing timeline "
-                        f"baseline_source_run_id={_existing_baseline!r} for subject_id={_id}. "
-                        "Overriding an existing timeline's baseline is not allowed."
-                    ),
-                    details=(
-                        ("subject_id", subject_id),
-                        ("baseline_source_run_id", _provided_baseline),
-                    ),
-                )
-
-        return BaselineResolutionResult(
-            baseline_source_run_id=timeline_state.baseline_source_run_id,
-            requires_bootstrap=False,
-        )
-    elif baseline_source_run_id:
-        resolved_baseline_source_run_id = gateway.resolve_source_run_id(
-            subject_id=subject_id,
-            source_experiment=compiled_recipe.source_requirements.source_experiment,
-            source_run_id=baseline_source_run_id,
-        )
-        if resolved_baseline_source_run_id is None:
-            raise PrepareStageError(
-                code="prepare_invalid_bootstrap_baseline",
-                message=(
-                    f"Baseline source run could not be resolved for subject_id={subject_id}, "
-                    "compiled_recipe.source_requirements.source_experiment="
-                    f"{compiled_recipe.source_requirements.source_experiment!r}, "
-                    f"and baseline_source_run_id={baseline_source_run_id!r}."
-                ),
-                details=(
-                    ("subject_id", subject_id),
-                    (
-                        "compiled_recipe.source_requirements.source_experiment",
-                        compiled_recipe.source_requirements.source_experiment,
-                    ),
-                    ("baseline_source_run_id", baseline_source_run_id),
-                ),
-            )
-
-        return BaselineResolutionResult(
-            baseline_source_run_id=resolved_baseline_source_run_id,
-            requires_bootstrap=True,
-        )
-    else:
-        raise PrepareStageError(
-            code="prepare_missing_baseline_no_timeline",
-            message=(
-                f"No timeline exists for subject_id={subject_id} "
-                "and no baseline_source_run_id was provided. "
-                "A valid baseline_source_run_id is required to bootstrap a new timeline."
-            ),
-            details=(
-                ("subject_id", subject_id),
-                ("baseline_source_run_id", baseline_source_run_id),
-            ),
-        )

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -148,9 +148,8 @@ def prepare_run_context(
         compiled_recipe: Execution-ready compiled Recipe.
         gateway: Gateway used for timeline and source-run reads.
         source_run_id: Invocation-owned Source Training Run identifier.
-        baseline_source_run_id: Optional baseline source run id used to bootstrap
-            a missing timeline baseline, or to explicitly confirm/pin the baseline
-            for an existing timeline.
+        baseline_source_run_id: Optional baseline source run id used to bootstrap ,i.e.,
+            pin timeline baseline, or to explicitly confirm the baseline for an existing timeline.
         custom_reference_monitoring_run_id: Optional invocation-owned Monitoring
             Run selected as a custom reference.
 
@@ -291,11 +290,31 @@ def prepare_run_context(
             details=(("subject_id", subject_id),),
         )
 
+    # This should be impossible to happen, adding this to mute the ruff complain.
+    if not timeline_state.baseline_source_run_id:
+        raise PrepareStageError(
+            code="prepare_baseline_missing",
+            message=(f"Timeline for subject_id={subject_id} does not have a pinned baseline."),
+            details=(("subject_id", subject_id),),
+        )
+
     timeline_runs = gateway.list_timeline_monitoring_runs(subject_id, exclude_failed=True)
     previous_monitoring_run_id = timeline_runs[-1].monitoring_run_id if timeline_runs else None
 
-    assert timeline_state.baseline_source_run_id is not None
-    assert timeline_state.baseline_source_run_id != ""
+    # No bootstrapping required, then we proceed to check if pinned baseline equals
+    # to the provided baseline if the provided baseline is not null or empty string.
+    if baseline_source_run_id and timeline_state.baseline_source_run_id != baseline_source_run_id:
+        raise PrepareStageError(
+            code="prepare_baseline_mismatch",
+            message=(
+                f"Pinned baseline {timeline_state.baseline_source_run_id!r} "
+                f"does not match provided baseline {baseline_source_run_id!r}."
+            ),
+            details=(
+                ("subject_id", subject_id),
+                ("baseline_source_run_id", baseline_source_run_id),
+            ),
+        )
 
     return PreparedContext(
         monitoring_run_id=monitoring_run_id,
@@ -408,7 +427,9 @@ def _resolve_baseline_for_prepare(
         raise PrepareStageError(
             code="prepare_missing_timeline",
             message=(
-                f"No timeline exists for the {subject_id} and baseline resolution cannot proceed."
+                f"No timeline exists for the subject_id={subject_id!r} "
+                "and baseline resolution cannot proceed. "
+                "Consider allocating a monitoring run first."
             ),
             details=(("subject_id", subject_id),),
         )
@@ -462,12 +483,30 @@ def _resolve_baseline_for_prepare(
         )
 
     # If the timeline exists, we do not need to bootstrap the baseline.
-    if baseline_source_run_id is not None:
+    if baseline_source_run_id:
         resolved_baseline = gateway.resolve_source_run_id(
             subject_id=subject_id,
             source_experiment=compiled_recipe.source_requirements.source_experiment,
             source_run_id=baseline_source_run_id,
         )
+
+        if resolved_baseline is None:
+            raise PrepareStageError(
+                code="prepare_invalid_baseline",
+                message=(
+                    f"Baseline source run could not be resolved for subject_id={subject_id!r}, "
+                    f"source_experiment={compiled_recipe.source_requirements.source_experiment!r}, "
+                    f"and source_run_id={baseline_source_run_id!r}."
+                ),
+                details=(
+                    ("subject_id", subject_id),
+                    (
+                        "compiled_recipe.source_requirements.source_experiment",
+                        compiled_recipe.source_requirements.source_experiment,
+                    ),
+                    ("baseline_source_run_id", baseline_source_run_id),
+                ),
+            )
 
         if resolved_baseline != pinned_baseline:
             raise PrepareStageError(

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -301,21 +301,6 @@ def prepare_run_context(
     timeline_runs = gateway.list_timeline_monitoring_runs(subject_id, exclude_failed=True)
     previous_monitoring_run_id = timeline_runs[-1].monitoring_run_id if timeline_runs else None
 
-    # No bootstrapping required, then we proceed to check if pinned baseline equals
-    # to the provided baseline if the provided baseline is not null or empty string.
-    if baseline_source_run_id and timeline_state.baseline_source_run_id != baseline_source_run_id:
-        raise PrepareStageError(
-            code="prepare_baseline_mismatch",
-            message=(
-                f"Pinned baseline {timeline_state.baseline_source_run_id!r} "
-                f"does not match provided baseline {baseline_source_run_id!r}."
-            ),
-            details=(
-                ("subject_id", subject_id),
-                ("baseline_source_run_id", baseline_source_run_id),
-            ),
-        )
-
     return PreparedContext(
         monitoring_run_id=monitoring_run_id,
         subject_id=subject_id,
@@ -510,7 +495,7 @@ def _resolve_baseline_for_prepare(
 
         if resolved_baseline != pinned_baseline:
             raise PrepareStageError(
-                code="prepare_baseline_trying_to_override_existing_timeline",
+                code="prepare_baseline_override_existing_timeline",
                 message=(
                     f"Provided baseline_source_run_id={baseline_source_run_id!r} "
                     f"with resolved baseline_source_run_id={resolved_baseline!r} does not match "

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -148,8 +148,8 @@ def prepare_run_context(
         compiled_recipe: Execution-ready compiled Recipe.
         gateway: Gateway used for timeline and source-run reads.
         source_run_id: Invocation-owned Source Training Run identifier.
-        baseline_source_run_id: Optional baseline source run id used to bootstrap ,i.e.,
-            pin timeline baseline, or to explicitly confirm the baseline for an existing timeline.
+        baseline_source_run_id: Optional baseline source run id used to bootstrap (pin)
+            timeline baseline, or to explicitly confirm the baseline for an existing timeline.
         custom_reference_monitoring_run_id: Optional invocation-owned Monitoring
             Run selected as a custom reference.
 
@@ -290,7 +290,7 @@ def prepare_run_context(
             details=(("subject_id", subject_id),),
         )
 
-    # This should be impossible to happen, adding this to mute the ruff complain.
+    # This should be impossible to happen, adding this check as a safeguard.
     if not timeline_state.baseline_source_run_id:
         raise PrepareStageError(
             code="prepare_baseline_missing",
@@ -480,8 +480,9 @@ def _resolve_baseline_for_prepare(
                 code="prepare_invalid_baseline",
                 message=(
                     f"Baseline source run could not be resolved for subject_id={subject_id!r}, "
-                    f"source_experiment={compiled_recipe.source_requirements.source_experiment!r}, "
-                    f"and source_run_id={baseline_source_run_id!r}."
+                    f"compiled_recipe.source_requirements.source_experiment="
+                    f"{compiled_recipe.source_requirements.source_experiment!r}, "
+                    f"and baseline_source_run_id={baseline_source_run_id!r}."
                 ),
                 details=(
                     ("subject_id", subject_id),
@@ -505,7 +506,7 @@ def _resolve_baseline_for_prepare(
                 ),
                 details=(
                     ("subject_id", subject_id),
-                    ("baseline_source_run_id", resolved_baseline),
+                    ("baseline_source_run_id", baseline_source_run_id),
                 ),
             )
 

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -468,7 +468,7 @@ def _resolve_baseline_for_prepare(
         )
 
     # If the timeline exists, we do not need to bootstrap the baseline.
-    if baseline_source_run_id:
+    if baseline_source_run_id is not None:
         resolved_baseline = gateway.resolve_source_run_id(
             subject_id=subject_id,
             source_experiment=compiled_recipe.source_requirements.source_experiment,

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -888,7 +888,7 @@ def test_mlflow_gateway_baseline_immutability_rejection(
     assert second.lifecycle_status is LifecycleStatus.FAILED
     assert second.comparability_status is None
     assert second.error is not None
-    assert second.error.code == "prepare_baseline_override_existing_timeline"
+    assert second.error.code == "prepare_baseline_trying_to_override_existing_timeline"
     assert dict(experiment_after.tags) == experiment_tags_before
     assert experiment_after.tags["training.baseline_run_id"] == baseline_run_id
     assert monitoring_run_before.info.status == "FINISHED"

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -888,7 +888,7 @@ def test_mlflow_gateway_baseline_immutability_rejection(
     assert second.lifecycle_status is LifecycleStatus.FAILED
     assert second.comparability_status is None
     assert second.error is not None
-    assert second.error.code == "prepare_baseline_trying_to_override_existing_timeline"
+    assert second.error.code == "prepare_baseline_override_existing_timeline"
     assert dict(experiment_after.tags) == experiment_tags_before
     assert experiment_after.tags["training.baseline_run_id"] == baseline_run_id
     assert monitoring_run_before.info.status == "FINISHED"

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -115,6 +115,12 @@ def test_mlflow_gateway_repairs_zero_tag_orphan_before_next_allocation(
         tracking_uri=tracking_uri,
         artifact_location=artifact_root_uri,
     )
+    uninitialized_timeline_state = repairing_gateway.get_timeline_state("churn_model")
+
+    assert uninitialized_timeline_state is not None
+    assert uninitialized_timeline_state.timeline_id == experiment.experiment_id
+    assert uninitialized_timeline_state.baseline_source_run_id is None
+
     recovered = repairing_gateway.create_or_reuse_monitoring_run(first_key)
     second = repairing_gateway.create_or_reuse_monitoring_run(
         IdempotencyKey(
@@ -129,9 +135,11 @@ def test_mlflow_gateway_repairs_zero_tag_orphan_before_next_allocation(
     monitoring_runs = raw.search_runs(experiment_ids=[experiment.experiment_id])
     assert recovered.monitoring_run_id == orphaned_run_id
     assert recovered.source_run_id == first_source_run_id
+    assert recovered.timeline_id == experiment.experiment_id
     assert recovered.sequence_index == 0
     assert recovered.allocated is False
     assert second.source_run_id == second_source_run_id
+    assert second.timeline_id == experiment.experiment_id
     assert second.sequence_index == 1
     assert second.allocated is True
     assert len(monitoring_runs) == 2
@@ -191,6 +199,7 @@ def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(
     assert experiment is not None
     assert result.lifecycle_status is LifecycleStatus.CHECKED
     assert result.comparability_status is ComparabilityStatus.PASS
+    assert result.timeline_id == experiment.experiment_id
     assert result.references == (
         MonitoringRunReference(
             kind="baseline",
@@ -214,6 +223,7 @@ def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(
     artifact_dir = Path(raw.download_artifacts(result.monitoring_run_id, "outputs"))
     payload = json.loads((artifact_dir / "result.json").read_text())
     assert payload["monitoring_run_id"] == result.monitoring_run_id
+    assert payload["timeline_id"] == experiment.experiment_id
     assert payload["lifecycle_status"] == "checked"
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -15,7 +15,11 @@ from mlflow_monitor.errors import (
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
 )
-from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey, InMemoryMonitoringGateway
+from mlflow_monitor.gateway import (
+    GatewayConfig,
+    IdempotencyKey,
+    InMemoryMonitoringGateway,
+)
 
 
 def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:
@@ -151,7 +155,7 @@ def test_create_or_reuse_monitoring_run_is_monotonic_per_subject() -> None:
     assert fraud_first.sequence_index == 0
 
 
-def test_initialize_timeline_is_deterministic_and_stores_baseline_reference() -> None:
+def test_pin_timeline_baseline_is_deterministic_and_stores_baseline_reference() -> None:
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     first_allocation = gateway.create_or_reuse_monitoring_run(
         IdempotencyKey(
@@ -162,8 +166,8 @@ def test_initialize_timeline_is_deterministic_and_stores_baseline_reference() ->
         )
     )
 
-    first_timeline_result = gateway.initialize_timeline("churn_model", "train-run-1")
-    second_timeline_result = gateway.initialize_timeline("churn_model", "train-run-2")
+    first_timeline_result = gateway.pin_timeline_baseline("churn_model", "train-run-1")
+    second_timeline_result = gateway.pin_timeline_baseline("churn_model", "train-run-2")
     second_allocation = gateway.create_or_reuse_monitoring_run(
         IdempotencyKey(
             subject_id="churn_model",
@@ -178,34 +182,34 @@ def test_initialize_timeline_is_deterministic_and_stores_baseline_reference() ->
     assert first_allocation.sequence_index == 0
     assert first_timeline_result.timeline_id == first_allocation.timeline_id
     assert second_timeline_result.timeline_id == first_timeline_result.timeline_id
-    assert first_timeline_result.created is True
-    assert second_timeline_result.created is False
+    assert first_timeline_result.baseline_pinned is True
+    assert second_timeline_result.baseline_pinned is False
     assert second_allocation.timeline_id == first_allocation.timeline_id
     assert second_allocation.sequence_index == 1
     assert timeline_state is not None
     assert timeline_state.baseline_source_run_id == "train-run-1"
 
 
-def test_initialize_timeline_requires_an_existing_allocation() -> None:
+def test_pin_timeline_baseline_requires_an_existing_allocation() -> None:
     gateway = InMemoryMonitoringGateway(GatewayConfig())
 
     with pytest.raises(
         GatewayConsistencyViolation,
         match="Timeline state for subject_id 'churn_model' not found.",
     ):
-        gateway.initialize_timeline("churn_model", "train-run-1")
+        gateway.pin_timeline_baseline("churn_model", "train-run-1")
 
     assert gateway.get_timeline_state("churn_model") is None
 
 
-def test_initialize_timeline_rejects_empty_baseline_source_run_id() -> None:
+def test_pin_timeline_baseline_rejects_empty_baseline_source_run_id() -> None:
     gateway = InMemoryMonitoringGateway(GatewayConfig())
 
     with pytest.raises(
         GatewayNamespaceViolation,
         match="baseline_source_run_id must be non-empty.",
     ):
-        gateway.initialize_timeline("churn_model", "")
+        gateway.pin_timeline_baseline("churn_model", "")
 
 
 def test_set_and_resolve_active_lkg_monitoring_run_id() -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -26,16 +26,27 @@ def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:
         recipe_id="default",
         recipe_version="v0",
     )
+
+    assert gateway.get_timeline_state("churn_model") is None
+
     first = gateway.create_or_reuse_monitoring_run(key)
+    timeline_state = gateway.get_timeline_state("churn_model")
     second = gateway.create_or_reuse_monitoring_run(key)
 
     assert first.monitoring_run_id.startswith("monitoring-run-")
     assert first.source_run_id == "train-run-1"
+    assert first.timeline_id == "timeline-churn_model"
     assert first.sequence_index == 0
     assert first.existing_monitoring_run is None
     assert first.allocated is True
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == first.timeline_id
+    assert (
+        timeline_state.baseline_source_run_id is None
+    )  # no bootstrap for create_or_reuse_monitoring_run
     assert second.monitoring_run_id == first.monitoring_run_id
     assert second.source_run_id == first.source_run_id
+    assert second.timeline_id == first.timeline_id
     assert second.sequence_index == first.sequence_index
     assert second.existing_monitoring_run is None
     assert second.allocated is False
@@ -142,15 +153,35 @@ def test_create_or_reuse_monitoring_run_is_monotonic_per_subject() -> None:
 
 def test_initialize_timeline_is_deterministic_and_stores_baseline_reference() -> None:
     gateway = InMemoryMonitoringGateway(GatewayConfig())
+    first_allocation = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-1",
+            recipe_id="default",
+            recipe_version="v0",
+        )
+    )
 
     first_timeline_result = gateway.initialize_timeline("churn_model", "train-run-1")
     second_timeline_result = gateway.initialize_timeline("churn_model", "train-run-2")
+    second_allocation = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-2",
+            recipe_id="default",
+            recipe_version="v0",
+        )
+    )
     timeline_state = gateway.get_timeline_state("churn_model")
 
-    assert first_timeline_result.timeline_id == "timeline-churn_model"
+    assert first_allocation.timeline_id == "timeline-churn_model"
+    assert first_allocation.sequence_index == 0
+    assert first_timeline_result.timeline_id == first_allocation.timeline_id
     assert second_timeline_result.timeline_id == first_timeline_result.timeline_id
     assert first_timeline_result.created is True
     assert second_timeline_result.created is False
+    assert second_allocation.timeline_id == first_allocation.timeline_id
+    assert second_allocation.sequence_index == 1
     assert timeline_state is not None
     assert timeline_state.baseline_source_run_id == "train-run-1"
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -186,6 +186,18 @@ def test_initialize_timeline_is_deterministic_and_stores_baseline_reference() ->
     assert timeline_state.baseline_source_run_id == "train-run-1"
 
 
+def test_initialize_timeline_requires_an_existing_allocation() -> None:
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+
+    with pytest.raises(
+        GatewayConsistencyViolation,
+        match="Timeline state for subject_id 'churn_model' not found.",
+    ):
+        gateway.initialize_timeline("churn_model", "train-run-1")
+
+    assert gateway.get_timeline_state("churn_model") is None
+
+
 def test_initialize_timeline_rejects_empty_baseline_source_run_id() -> None:
     gateway = InMemoryMonitoringGateway(GatewayConfig())
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -16,6 +16,7 @@ from mlflow_monitor.errors import (
     TrainingRunMutationViolation,
 )
 from mlflow_monitor.gateway import (
+    CreateOrReuseMonitoringRunResult,
     GatewayConfig,
     IdempotencyKey,
     InMemoryMonitoringGateway,
@@ -54,6 +55,25 @@ def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:
     assert second.sequence_index == first.sequence_index
     assert second.existing_monitoring_run is None
     assert second.allocated is False
+
+
+@pytest.mark.parametrize("timeline_id", [None, "", "   "])
+def test_create_or_reuse_result_requires_nonempty_timeline_id(
+    timeline_id: str | None,
+) -> None:
+    """Allocation results should reject missing Timeline identity immediately."""
+    with pytest.raises(
+        ValueError,
+        match="CreateOrReuseMonitoringRunResult.timeline_id must be a non-empty string",
+    ):
+        CreateOrReuseMonitoringRunResult(
+            monitoring_run_id="monitoring-run-1",
+            source_run_id="train-run-1",
+            timeline_id=timeline_id,
+            sequence_index=0,
+            existing_monitoring_run=None,
+            allocated=True,
+        )
 
 
 def test_create_or_reuse_monitoring_run_diff_recipe_version_creates_new() -> None:

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -192,7 +192,7 @@ def test_get_timeline_state_distinguishes_no_allocation_from_allocated_uninitial
         GatewayConsistencyViolation,
         match="Timeline state for subject_id 'churn_model' not found.",
     ):
-        gateway.initialize_timeline("churn_model", "train-run-1")
+        gateway.pin_timeline_baseline("churn_model", "train-run-1")
     stub_client.set_monitoring_experiment_tag.assert_not_called()
 
     stub_client.list_monitoring_runs_with_tag.return_value = (

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -188,6 +188,12 @@ def test_get_timeline_state_distinguishes_no_allocation_from_allocated_uninitial
         gateway = MLflowMonitoringGateway(GatewayConfig())
 
     assert gateway.get_timeline_state("churn_model") is None
+    with pytest.raises(
+        GatewayConsistencyViolation,
+        match="Timeline state for subject_id 'churn_model' not found.",
+    ):
+        gateway.initialize_timeline("churn_model", "train-run-1")
+    stub_client.set_monitoring_experiment_tag.assert_not_called()
 
     stub_client.list_monitoring_runs_with_tag.return_value = (
         _allocation_snapshot(

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -105,6 +105,7 @@ def test_create_or_reuse_monitoring_run_repairs_partial_allocation_index(
 
     assert result.monitoring_run_id == "monitoring-run-1"
     assert result.source_run_id == "train-run-1"
+    assert result.timeline_id == "experiment-1"
     assert result.sequence_index == 0
     assert result.allocated is False
     assert stub_client.set_monitoring_experiment_tag.call_args_list == [
@@ -143,6 +144,7 @@ def test_create_or_reuse_monitoring_run_repairs_orphan_before_new_allocation() -
 
     assert result.monitoring_run_id == "monitoring-run-2"
     assert result.source_run_id == "train-run-2"
+    assert result.timeline_id == "experiment-1"
     assert result.sequence_index == 1
     assert result.allocated is True
     stub_client.create_monitoring_run.assert_called_once_with(
@@ -174,6 +176,32 @@ def test_create_or_reuse_monitoring_run_repairs_orphan_before_new_allocation() -
             "monitoring-run-2",
         ),
     ]
+
+
+def test_get_timeline_state_distinguishes_no_allocation_from_allocated_uninitialized() -> None:
+    stub_client = MagicMock()
+    stub_client.get_monitoring_experiment_id_by_name.return_value = "experiment-1"
+    stub_client.get_monitoring_experiment_tags.return_value = {}
+    stub_client.list_monitoring_runs_with_tag.return_value = ()
+
+    with patch("mlflow_monitor.mlflow_gateway.MonitorMLflowClient", return_value=stub_client):
+        gateway = MLflowMonitoringGateway(GatewayConfig())
+
+    assert gateway.get_timeline_state("churn_model") is None
+
+    stub_client.list_monitoring_runs_with_tag.return_value = (
+        _allocation_snapshot(
+            run_id="monitoring-run-1",
+            source_run_id="train-run-1",
+            sequence_index=0,
+        ),
+    )
+
+    timeline_state = gateway.get_timeline_state("churn_model")
+
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "experiment-1"
+    assert timeline_state.baseline_source_run_id is None
 
 
 def test_create_or_reuse_monitoring_run_reuses_older_recipe_without_rewriting_cache() -> None:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,6 +19,7 @@ from mlflow_monitor.gateway import (
     GatewayConfig,
     IdempotencyKey,
     InMemoryMonitoringGateway,
+    TimelineState,
 )
 from mlflow_monitor.orchestration import run_orchestration
 from mlflow_monitor.result_contract import MonitorRunResult
@@ -158,6 +159,28 @@ class AllocationOnlyReplayGateway(InMemoryMonitoringGateway):
             existing_monitoring_run=None,
             allocated=False,
         )
+
+
+class UnreadableAllocatedTimelineGateway(InMemoryMonitoringGateway):
+    """Hide Timeline reads after returning a successful allocation."""
+
+    def __init__(self, config: GatewayConfig) -> None:
+        super().__init__(config)
+        self._timeline_reads_blocked = False
+        self.allocation_timeline_id: str | None = None
+
+    def create_or_reuse_monitoring_run(
+        self, key: IdempotencyKey
+    ) -> CreateOrReuseMonitoringRunResult:
+        result = super().create_or_reuse_monitoring_run(key)
+        self.allocation_timeline_id = result.timeline_id
+        self._timeline_reads_blocked = True
+        return result
+
+    def get_timeline_state(self, subject_id: str) -> TimelineState | None:
+        if self._timeline_reads_blocked:
+            return None
+        return super().get_timeline_state(subject_id)
 
 
 class FinalizingGateway(InMemoryMonitoringGateway):
@@ -574,6 +597,24 @@ def test_run_orchestration_prebootstrap_failure_preserves_allocation_sequence() 
     assert successful_monitoring_run.sequence_index == 1
 
 
+def test_run_orchestration_preserves_allocation_timeline_id_when_timeline_read_fails() -> None:
+    """A failed allocated result should use identity returned by allocation."""
+    gateway = UnreadableAllocatedTimelineGateway(GatewayConfig())
+
+    result = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    assert result.lifecycle_status is LifecycleStatus.FAILED
+    assert result.timeline_id == gateway.allocation_timeline_id == "timeline-churn_model"
+    assert result.error is not None
+    assert result.error.code == "prepare_missing_timeline"
+
+
 def test_run_orchestration_check_error_persists_failed_and_returns_runtime_error() -> None:
     gateway = make_gateway()
 
@@ -914,7 +955,7 @@ def test_run_orchestration_rejects_baseline_override_on_checked_idempotent_rerun
     assert second.comparability_status is None
     assert second.error is not None
     assert second.error.stage == "prepare"
-    assert second.error.code == "prepare_baseline_trying_to_override_existing_timeline"
+    assert second.error.code == "prepare_baseline_override_existing_timeline"
     assert stored is not None
     assert stored.lifecycle_status is LifecycleStatus.CHECKED
     assert stored.contract_check_result is not None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -914,7 +914,7 @@ def test_run_orchestration_rejects_baseline_override_on_checked_idempotent_rerun
     assert second.comparability_status is None
     assert second.error is not None
     assert second.error.stage == "prepare"
-    assert second.error.code == "prepare_baseline_override_existing_timeline"
+    assert second.error.code == "prepare_baseline_trying_to_override_existing_timeline"
     assert stored is not None
     assert stored.lifecycle_status is LifecycleStatus.CHECKED
     assert stored.contract_check_result is not None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -153,6 +153,7 @@ class AllocationOnlyReplayGateway(InMemoryMonitoringGateway):
         return CreateOrReuseMonitoringRunResult(
             monitoring_run_id=replayed.monitoring_run_id,
             source_run_id=replayed.source_run_id,
+            timeline_id=replayed.timeline_id,
             sequence_index=replayed.sequence_index,
             existing_monitoring_run=None,
             allocated=False,
@@ -520,13 +521,13 @@ def test_run_orchestration_failed_prepare_rerun_short_circuits_terminal_state() 
     assert stored.contract_check_result is None
 
 
-def test_run_orchestration_bootstrap_failure_returns_failed_result_without_timeline() -> None:
-    gateway = InMemoryMonitoringGateway(GatewayConfig())
+def test_run_orchestration_prebootstrap_failure_preserves_allocation_sequence() -> None:
+    gateway = make_gateway()
     gateway.add_source_run(
         subject_id="churn_model",
-        source_run_id="train-run-current",
+        source_run_id="train-run-second",
         source_experiment=None,
-        metrics={"f1": 0.91},
+        metrics={"f1": 0.92},
         artifacts=("metrics.json",),
         environment={"python": "3.12"},
         features=("age",),
@@ -534,22 +535,43 @@ def test_run_orchestration_bootstrap_failure_returns_failed_result_without_timel
         data_scope="validation:2026-03-01",
     )
 
-    result = run_orchestration(
+    failed_result = run_orchestration(
         subject_id="churn_model",
         source_run_id="train-run-current",
         baseline_source_run_id=None,
         gateway=gateway,
         contract_checker=DefaultContractChecker(),
     )
+    failed_monitoring_run = gateway.get_monitoring_run(
+        "churn_model", failed_result.monitoring_run_id
+    )
+    uninitialized_timeline_state = gateway.get_timeline_state("churn_model")
 
-    stored = gateway.get_monitoring_run("churn_model", result.monitoring_run_id)
+    successful_result = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-second",
+        baseline_source_run_id="train-run-baseline",
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+    successful_monitoring_run = gateway.get_monitoring_run(
+        "churn_model", successful_result.monitoring_run_id
+    )
 
-    assert result.lifecycle_status is LifecycleStatus.FAILED
-    assert result.timeline_id is None
-    assert result.error is not None
-    assert result.error.stage == "prepare"
-    assert stored is not None
-    assert stored.lifecycle_status is LifecycleStatus.FAILED
+    assert failed_result.lifecycle_status is LifecycleStatus.FAILED
+    assert failed_result.timeline_id == "timeline-churn_model"
+    assert failed_result.error is not None
+    assert failed_result.error.stage == "prepare"
+    assert failed_monitoring_run is not None
+    assert failed_monitoring_run.sequence_index == 0
+    assert failed_monitoring_run.lifecycle_status is LifecycleStatus.FAILED
+    assert uninitialized_timeline_state is not None
+    assert uninitialized_timeline_state.timeline_id == failed_result.timeline_id
+    assert uninitialized_timeline_state.baseline_source_run_id is None
+    assert successful_result.lifecycle_status is LifecycleStatus.CHECKED
+    assert successful_result.timeline_id == failed_result.timeline_id
+    assert successful_monitoring_run is not None
+    assert successful_monitoring_run.sequence_index == 1
 
 
 def test_run_orchestration_check_error_persists_failed_and_returns_runtime_error() -> None:

--- a/tests/test_result_contract.py
+++ b/tests/test_result_contract.py
@@ -70,6 +70,28 @@ def test_monitor_run_result_failure_envelope_construction() -> None:
     assert result.error is error
 
 
+@pytest.mark.parametrize("timeline_id", [None, ""])
+def test_monitor_run_result_requires_nonempty_timeline_id(timeline_id: str | None) -> None:
+    """Allocated monitoring run results should require Timeline identity."""
+    with pytest.raises(ValueError, match="timeline_id must be a non-empty string"):
+        MonitorRunResult(
+            monitoring_run_id="monitoring-run-2",
+            subject_id="churn_model",
+            timeline_id=timeline_id,
+            lifecycle_status=LifecycleStatus.FAILED,
+            comparability_status=None,
+            summary=None,
+            finding_ids=(),
+            diff_ids=(),
+            references=(),
+            error=MonitorRunError(
+                code="prepare_error",
+                message="Prepare failed after allocation.",
+                stage="prepare",
+            ),
+        )
+
+
 def test_monitor_run_result_to_dict_serializes_enums_and_error() -> None:
     """to_dict should serialize enum statuses and nested error payload."""
     error = MonitorRunError(

--- a/tests/test_result_contract.py
+++ b/tests/test_result_contract.py
@@ -55,7 +55,7 @@ def test_monitor_run_result_failure_envelope_construction() -> None:
     result = MonitorRunResult(
         monitoring_run_id="monitoring-run-2",
         subject_id="churn_model",
-        timeline_id=None,
+        timeline_id="timeline-1",
         lifecycle_status=LifecycleStatus.FAILED,
         comparability_status=None,
         summary=None,
@@ -132,7 +132,7 @@ def test_monitor_run_result_to_dict_stable_keys_for_success_and_failure() -> Non
     failure = MonitorRunResult(
         monitoring_run_id="monitoring-run-failure",
         subject_id="churn_model",
-        timeline_id=None,
+        timeline_id="timeline-1",
         lifecycle_status=LifecycleStatus.FAILED,
         comparability_status=None,
         summary=None,
@@ -161,7 +161,7 @@ def test_monitor_run_result_failed_requires_error() -> None:
         MonitorRunResult(
             monitoring_run_id="monitoring-run-failed",
             subject_id="churn_model",
-            timeline_id=None,
+            timeline_id="timeline-1",
             lifecycle_status=LifecycleStatus.FAILED,
             comparability_status=None,
             summary=None,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1617,6 +1617,55 @@ def test_prepare_run_context_succeeds_existing_timeline_with_correct_baseline_pa
     assert timeline_state.timeline_id == "timeline-churn_model"
 
 
+def test_prepare_run_context_accepts_baseline_alias_resolving_to_pinned_baseline() -> None:
+    """Prepare should compare a resolved baseline identity with the pinned identity."""
+    gateway = AliasResolvingBaselineGateway(GatewayConfig())
+    compiled_invocation = make_compiled_invocation(
+        source_run_id="train-run-current",
+        source_experiment="training/churn",
+        required_metrics=("f1", "auc"),
+        required_artifacts=("metrics.json",),
+    )
+    pin_test_timeline(
+        gateway,
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        compiled_recipe=compiled_invocation.compiled_recipe,
+    )
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        source_experiment="training/churn",
+        metrics={"f1": 0.91, "auc": 0.95},
+        artifacts=("metrics.json",),
+        environment={"python": "3.12"},
+        features=("age", "income"),
+        schema={"age": "int", "income": "float"},
+        data_scope="validation:2026-03-01",
+    )
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-baseline",
+        source_experiment="training/churn",
+        metrics={"f1": 0.87, "auc": 0.93},
+        artifacts=("metrics.json",),
+        environment={"python": "3.12"},
+        features=("age", "income"),
+        schema={"age": "int", "income": "float"},
+        data_scope="validation:2026-03-01",
+    )
+    gateway.add_source_run_alias("baseline-alias", "train-run-baseline")
+
+    prepared = prepare_test_context(
+        subject_id="churn_model",
+        compiled_invocation=compiled_invocation,
+        gateway=gateway,
+        baseline_source_run_id="baseline-alias",
+    )
+
+    assert prepared.baseline_source_run_id == "train-run-baseline"
+
+
 def test_prepare_run_context_succeeds_with_existed_timeline_and_no_baseline() -> None:
     """Baseline resolution should succeed by returning the existing pinned baseline."""
     gateway = make_gateway_with_timeline().gateway
@@ -1712,7 +1761,7 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
         )
 
     error = exc_info.value
-    assert error.code == "prepare_baseline_trying_to_override_existing_timeline"
+    assert error.code == "prepare_baseline_override_existing_timeline"
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-other"),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -17,10 +17,12 @@ from mlflow_monitor.domain import (
 )
 from mlflow_monitor.errors import CheckStageError, InvalidRunTransition, PrepareStageError
 from mlflow_monitor.gateway import (
+    CreateOrReuseMonitoringRunResult,
     GatewayConfig,
     IdempotencyKey,
     InMemoryMonitoringGateway,
     TimelineInitializationResult,
+    TimelineState,
 )
 from mlflow_monitor.recipe import SYSTEM_DEFAULT_RECIPE_ID
 from mlflow_monitor.recipe_compiler import CompiledRecipe, compile_recipe
@@ -56,13 +58,22 @@ class CompiledInvocation:
     custom_reference_monitoring_run_id: str | None
 
 
+@dataclass(frozen=True, slots=True)
+class InitializedTimelineFixture:
+    """Gateway plus opaque Monitoring Run identities created by its fixture."""
+
+    gateway: InMemoryMonitoringGateway
+    previous_monitoring_run_id: str
+    custom_monitoring_run_id: str
+
+
 def make_compiled_invocation(
     *,
     source_run_id: str = "train-run-123",
     source_experiment: str | None = "training/churn",
     required_metrics: tuple[str, ...] = ("f1", "auc"),
     required_artifacts: tuple[str, ...] = ("metrics.json",),
-    custom_reference_monitoring_run_id: str | None = "monitoring-run-custom-1",
+    custom_reference_monitoring_run_id: str | None = None,
     recipe_id: str = "default",
     contract_id: str = SYSTEM_DEFAULT_CONTRACT_ID,
 ) -> CompiledInvocation:
@@ -90,7 +101,6 @@ def make_compiled_invocation(
 
 def prepare_test_context(
     *,
-    monitoring_run_id: str,
     subject_id: str,
     compiled_invocation: CompiledInvocation | CompiledRecipe,
     gateway: InMemoryMonitoringGateway,
@@ -108,8 +118,14 @@ def prepare_test_context(
             raise AssertionError("A Source Training Run is required for a bare CompiledRecipe.")
         effective_source_run_id = source_run_id
         custom_reference_monitoring_run_id = None
+    allocation = allocate_test_monitoring_run(
+        gateway,
+        subject_id=subject_id,
+        source_run_id=effective_source_run_id,
+        compiled_recipe=compiled_recipe,
+    )
     return _prepare_run_context(
-        monitoring_run_id=monitoring_run_id,
+        monitoring_run_id=allocation.monitoring_run_id,
         subject_id=subject_id,
         compiled_recipe=compiled_recipe,
         gateway=gateway,
@@ -119,20 +135,72 @@ def prepare_test_context(
     )
 
 
-def make_gateway_with_timeline() -> InMemoryMonitoringGateway:
-    """Build a gateway fixture with timeline and source-run state."""
+def allocate_test_monitoring_run(
+    gateway: InMemoryMonitoringGateway,
+    *,
+    subject_id: str,
+    source_run_id: str,
+    compiled_recipe: CompiledRecipe,
+) -> CreateOrReuseMonitoringRunResult:
+    """Allocate a Monitoring Run through the same public API as production."""
+    return gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id=subject_id,
+            source_run_id=source_run_id,
+            recipe_id=compiled_recipe.identity.recipe_id,
+            recipe_version=compiled_recipe.identity.recipe_version,
+        )
+    )
+
+
+def initialize_test_timeline(
+    gateway: InMemoryMonitoringGateway,
+    *,
+    subject_id: str = "churn_model",
+    source_run_id: str = "train-run-123",
+    baseline_source_run_id: str = "train-run-baseline",
+    compiled_recipe: CompiledRecipe | None = None,
+) -> TimelineInitializationResult:
+    """Allocate a Monitoring Run before bootstrapping its Timeline baseline."""
+    effective_compiled_recipe = (
+        compiled_recipe or make_compiled_invocation(source_run_id=source_run_id).compiled_recipe
+    )
+    allocate_test_monitoring_run(
+        gateway,
+        subject_id=subject_id,
+        source_run_id=source_run_id,
+        compiled_recipe=effective_compiled_recipe,
+    )
+    return gateway.initialize_timeline(subject_id, baseline_source_run_id)
+
+
+def make_gateway_with_timeline() -> InitializedTimelineFixture:
+    """Build an initialized Timeline using public allocation operations."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
+    compiled_recipe = make_compiled_invocation().compiled_recipe
+    previous_allocation = allocate_test_monitoring_run(
+        gateway,
+        subject_id="churn_model",
+        source_run_id="train-run-prev",
+        compiled_recipe=compiled_recipe,
+    )
     gateway.initialize_timeline("churn_model", "train-run-baseline")
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
-        monitoring_run_id="monitoring-run-prev",
+        monitoring_run_id=previous_allocation.monitoring_run_id,
         source_run_id="train-run-prev",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
     )
+    custom_allocation = allocate_test_monitoring_run(
+        gateway,
+        subject_id="churn_model",
+        source_run_id="train-run-custom-1",
+        compiled_recipe=compiled_recipe,
+    )
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
-        monitoring_run_id="monitoring-run-custom-1",
+        monitoring_run_id=custom_allocation.monitoring_run_id,
         source_run_id="train-run-custom-1",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=1,
@@ -148,7 +216,11 @@ def make_gateway_with_timeline() -> InMemoryMonitoringGateway:
         schema={"age": "int", "income": "float"},
         data_scope="validation:2026-03-01",
     )
-    return gateway
+    return InitializedTimelineFixture(
+        gateway=gateway,
+        previous_monitoring_run_id=previous_allocation.monitoring_run_id,
+        custom_monitoring_run_id=custom_allocation.monitoring_run_id,
+    )
 
 
 class BrokenInitializeTimelineGateway(InMemoryMonitoringGateway):
@@ -181,23 +253,16 @@ class RaceWinningInitializeTimelineGateway(InMemoryMonitoringGateway):
         self, subject_id: str, baseline_source_run_id: str
     ) -> TimelineInitializationResult:
         """Materialize timeline state as if another writer initialized first."""
-        if self.get_timeline_state(subject_id) is None:
-            self._timeline_by_subject[subject_id] = self._timeline_by_subject.get(
-                subject_id,
-                None,
-            ) or self._build_competing_timeline_state(subject_id)
+        timeline_state = self.get_timeline_state(subject_id)
+        assert timeline_state is not None
+        if timeline_state.baseline_source_run_id is None:
+            self._timeline_by_subject[subject_id] = TimelineState(
+                timeline_id=timeline_state.timeline_id,
+                baseline_source_run_id=self._competing_baseline_source_run_id,
+            )
         return TimelineInitializationResult(
-            timeline_id=f"timeline-{subject_id}",
+            timeline_id=timeline_state.timeline_id,
             created=False,
-        )
-
-    def _build_competing_timeline_state(self, subject_id: str):
-        """Return timeline state pinned to the competing baseline."""
-        from mlflow_monitor.gateway import TimelineState
-
-        return TimelineState(
-            timeline_id=f"timeline-{subject_id}",
-            baseline_source_run_id=self._competing_baseline_source_run_id,
         )
 
 
@@ -401,25 +466,30 @@ def test_transition_run_preserves_comparability_fields() -> None:
 
 def test_prepare_run_context_succeeds_with_initialized_timeline() -> None:
     """Prepare should resolve references and required source-run inputs."""
-    gateway = make_gateway_with_timeline()
-    gateway.set_active_lkg_monitoring_run_id("churn_model", "monitoring-run-lkg")
-    compiled = make_compiled_invocation()
+    fixture = make_gateway_with_timeline()
+    gateway = fixture.gateway
+    gateway.set_active_lkg_monitoring_run_id("churn_model", fixture.previous_monitoring_run_id)
+    compiled = make_compiled_invocation(
+        custom_reference_monitoring_run_id=fixture.custom_monitoring_run_id
+    )
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=compiled,
         gateway=gateway,
     )
 
-    assert prepared.monitoring_run_id == "monitoring-run-1"
+    assert (
+        prepared.monitoring_run_id
+        == gateway.idempotency_bindings("churn_model")["train-run-123|default|v0"]
+    )
     assert prepared.subject_id == "churn_model"
     assert prepared.timeline_id == "timeline-churn_model"
     assert prepared.source_run_id == "train-run-123"
     assert prepared.baseline_source_run_id == "train-run-baseline"
-    assert prepared.previous_monitoring_run_id == "monitoring-run-custom-1"
-    assert prepared.active_lkg_monitoring_run_id == "monitoring-run-lkg"
-    assert prepared.custom_reference_monitoring_run_id == "monitoring-run-custom-1"
+    assert prepared.previous_monitoring_run_id == fixture.custom_monitoring_run_id
+    assert prepared.active_lkg_monitoring_run_id == fixture.previous_monitoring_run_id
+    assert prepared.custom_reference_monitoring_run_id == fixture.custom_monitoring_run_id
     assert prepared.contract == CONTRACT
     assert prepared.required_metrics == ("auc", "f1")
     assert prepared.required_artifacts == ("metrics.json",)
@@ -464,7 +534,6 @@ def test_prepare_run_context_bootstraps_allocated_uninitialized_timeline() -> No
     assert timeline_state.baseline_source_run_id is None
 
     prepared = prepare_test_context(
-        monitoring_run_id=allocation.monitoring_run_id,
         subject_id="churn_model",
         compiled_invocation=compiled_invocation,
         gateway=gateway,
@@ -472,6 +541,7 @@ def test_prepare_run_context_bootstraps_allocated_uninitialized_timeline() -> No
     )
     bootstrapped_timeline_state = gateway.get_timeline_state("churn_model")
 
+    assert prepared.monitoring_run_id == allocation.monitoring_run_id
     assert prepared.timeline_id == allocation.timeline_id
     assert bootstrapped_timeline_state is not None
     assert bootstrapped_timeline_state.timeline_id == allocation.timeline_id
@@ -680,7 +750,7 @@ def test_execute_contract_check_rejects_duplicate_reason_codes() -> None:
 def test_prepare_run_context_succeeds_without_previous_run() -> None:
     """Prepare should tolerate a missing previous run."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -694,7 +764,6 @@ def test_prepare_run_context_succeeds_without_previous_run() -> None:
     )
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(custom_reference_monitoring_run_id=None),
         gateway=gateway,
@@ -705,10 +774,9 @@ def test_prepare_run_context_succeeds_without_previous_run() -> None:
 
 def test_prepare_run_context_succeeds_without_active_lkg() -> None:
     """Prepare should tolerate a missing active LKG."""
-    gateway = make_gateway_with_timeline()
+    gateway = make_gateway_with_timeline().gateway
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(),
         gateway=gateway,
@@ -720,7 +788,7 @@ def test_prepare_run_context_succeeds_without_active_lkg() -> None:
 def test_prepare_run_context_allows_omitted_source_experiment_filter() -> None:
     """Prepare should resolve a raw source run when source_experiment is omitted."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -734,7 +802,6 @@ def test_prepare_run_context_allows_omitted_source_experiment_filter() -> None:
     )
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(
             source_experiment=None,
@@ -748,10 +815,9 @@ def test_prepare_run_context_allows_omitted_source_experiment_filter() -> None:
 
 def test_prepare_run_context_preserves_omitted_custom_reference() -> None:
     """Prepare should keep an omitted custom reference as None."""
-    gateway = make_gateway_with_timeline()
+    gateway = make_gateway_with_timeline().gateway
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(custom_reference_monitoring_run_id=None),
         gateway=gateway,
@@ -763,11 +829,10 @@ def test_prepare_run_context_preserves_omitted_custom_reference() -> None:
 def test_prepare_run_context_fails_when_source_run_cannot_be_resolved() -> None:
     """Prepare should fail explicitly when the source run is missing."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(gateway)
 
     with pytest.raises(PrepareStageError, match="Source training run could not be resolved"):
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(custom_reference_monitoring_run_id=None),
             gateway=gateway,
@@ -777,7 +842,7 @@ def test_prepare_run_context_fails_when_source_run_cannot_be_resolved() -> None:
 def test_prepare_run_context_fails_when_required_metric_is_missing() -> None:
     """Prepare should fail explicitly when a required metric is absent."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -792,7 +857,6 @@ def test_prepare_run_context_fails_when_required_metric_is_missing() -> None:
 
     with pytest.raises(PrepareStageError, match="missing required metric"):
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 required_metrics=("f1", "auc"),
@@ -805,7 +869,7 @@ def test_prepare_run_context_fails_when_required_metric_is_missing() -> None:
 def test_prepare_run_context_fails_when_required_artifact_is_missing() -> None:
     """Prepare should fail explicitly when a required artifact is absent."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -820,7 +884,6 @@ def test_prepare_run_context_fails_when_required_artifact_is_missing() -> None:
 
     with pytest.raises(PrepareStageError, match="missing required artifact"):
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 required_artifacts=("metrics.json",),
@@ -833,7 +896,14 @@ def test_prepare_run_context_fails_when_required_artifact_is_missing() -> None:
 def test_prepare_run_context_uses_invocation_owned_source_run_id() -> None:
     """Prepare should use the invocation identity rather than Recipe selection."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(
+        gateway,
+        source_run_id="train-run-runtime",
+        compiled_recipe=make_compiled_invocation(
+            source_run_id="train-run-runtime",
+            recipe_id=SYSTEM_DEFAULT_RECIPE_ID,
+        ).compiled_recipe,
+    )
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-runtime",
@@ -847,7 +917,6 @@ def test_prepare_run_context_uses_invocation_owned_source_run_id() -> None:
     )
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(
             source_run_id="train-run-runtime",
@@ -865,7 +934,12 @@ def test_prepare_run_context_uses_invocation_owned_source_run_id() -> None:
 def test_prepare_run_context_succeeds_for_resolved_system_default_recipe() -> None:
     """Prepare should treat the built-in default recipe as a first-class runtime input."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    compiled = compile_recipe()
+    initialize_test_timeline(
+        gateway,
+        source_run_id="train-run-runtime",
+        compiled_recipe=compiled,
+    )
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-runtime",
@@ -878,10 +952,7 @@ def test_prepare_run_context_succeeds_for_resolved_system_default_recipe() -> No
         data_scope="validation:2026-03-01",
     )
 
-    compiled = compile_recipe()
-
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=compiled,
         gateway=gateway,
@@ -903,7 +974,12 @@ def test_prepare_run_context_succeeds_for_resolved_system_default_recipe() -> No
 def test_prepare_run_context_allows_system_default_recipe_without_optional_evidence() -> None:
     """Prepare should not require extra metrics or artifacts for the system default recipe."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    compiled = compile_recipe()
+    initialize_test_timeline(
+        gateway,
+        source_run_id="train-run-runtime",
+        compiled_recipe=compiled,
+    )
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-runtime",
@@ -916,10 +992,7 @@ def test_prepare_run_context_allows_system_default_recipe_without_optional_evide
         data_scope="validation:2026-03-01",
     )
 
-    compiled = compile_recipe()
-
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=compiled,
         gateway=gateway,
@@ -935,7 +1008,7 @@ def test_prepare_run_context_allows_system_default_recipe_without_optional_evide
 def test_prepare_run_context_fails_when_custom_reference_is_missing() -> None:
     """Prepare should fail when configured custom reference is absent."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    initialize_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -952,7 +1025,6 @@ def test_prepare_run_context_fails_when_custom_reference_is_missing() -> None:
         PrepareStageError, match="Custom reference monitoring run could not be resolved"
     ):
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 custom_reference_monitoring_run_id="monitoring-run-missing"
@@ -963,10 +1035,17 @@ def test_prepare_run_context_fails_when_custom_reference_is_missing() -> None:
 
 def test_prepare_run_context_fails_when_custom_reference_is_on_another_subject() -> None:
     """Prepare should reject a custom reference from another subject timeline."""
-    gateway = make_gateway_with_timeline()
+    gateway = make_gateway_with_timeline().gateway
+    compiled_invocation = make_compiled_invocation()
+    foreign_allocation = allocate_test_monitoring_run(
+        gateway,
+        subject_id="fraud_model",
+        source_run_id="train-run-foreign",
+        compiled_recipe=compiled_invocation.compiled_recipe,
+    )
     gateway.upsert_monitoring_run(
         subject_id="fraud_model",
-        monitoring_run_id="monitoring-run-foreign",
+        monitoring_run_id=foreign_allocation.monitoring_run_id,
         source_run_id="train-run-foreign",
         lifecycle_status=LifecycleStatus.CLOSED,
         sequence_index=0,
@@ -976,58 +1055,31 @@ def test_prepare_run_context_fails_when_custom_reference_is_on_another_subject()
         PrepareStageError, match="Custom reference monitoring run could not be resolved"
     ):
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
-                custom_reference_monitoring_run_id="monitoring-run-foreign"
+                custom_reference_monitoring_run_id=foreign_allocation.monitoring_run_id
             ),
             gateway=gateway,
         )
 
 
-def test_prepare_run_context_succeeds_for_first_run_with_baseline_passed_in() -> None:
-    """Prepare should resolve references and required source-run inputs."""
+def test_prepare_run_context_fails_for_uninitialized_timeline_with_no_baseline() -> None:
+    """Prepare should require a baseline when allocation has not pinned one."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
         subject_id="churn_model",
-        source_run_id=BASELINE.source_run_id,
+        source_run_id="train-run-123",
         source_experiment="training/churn",
-        metrics=BASELINE.metric_snapshot,
+        metrics={"f1": 0.91, "auc": 0.95},
         artifacts=("metrics.json",),
-        environment=BASELINE.environment_context,
-        features=("age", "income"),
-        schema={"age": "int", "income": "float"},
+        environment={},
+        features=(),
+        schema={},
         data_scope="validation:2026-03-01",
     )
 
-    prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
-        subject_id="churn_model",
-        compiled_invocation=make_compiled_invocation(
-            source_run_id=BASELINE.source_run_id,
-            source_experiment="training/churn",
-            required_metrics=tuple(BASELINE.metric_snapshot.keys()),
-            required_artifacts=("metrics.json",),
-            custom_reference_monitoring_run_id=None,
-        ),
-        gateway=gateway,
-        baseline_source_run_id=BASELINE.source_run_id,
-    )
-
-    timeline_state = gateway.get_timeline_state("churn_model")
-
-    assert timeline_state is not None
-    assert timeline_state.baseline_source_run_id == "train-run-1"
-    assert timeline_state.timeline_id == "timeline-churn_model"
-
-
-def test_prepare_run_context_fails_for_first_run_with_no_baseline() -> None:
-    """Prepare should fail without existing timeline and provided baseline."""
-    gateway = InMemoryMonitoringGateway(GatewayConfig())
-
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id="train-run-123",
@@ -1040,25 +1092,39 @@ def test_prepare_run_context_fails_for_first_run_with_no_baseline() -> None:
         )
 
     error = exc_info.value
-    assert error.code == "prepare_missing_baseline_no_timeline"
+    assert error.code == "prepare_missing_baseline_for_uninitialized_timeline"
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", None),
     )
     assert error.message == (
-        "No timeline exists for subject_id=churn_model "
+        "The timeline for subject_id='churn_model' has no pinned baseline "
         "and no baseline_source_run_id was provided. "
-        "A valid baseline_source_run_id is required to bootstrap a new timeline."
+        "A valid baseline_source_run_id is required to bootstrap the timeline."
     )
+    timeline_state = gateway.get_timeline_state("churn_model")
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "timeline-churn_model"
+    assert timeline_state.baseline_source_run_id is None
 
 
-def test_prepare_run_context_fails_for_first_run_with_empty_baseline() -> None:
-    """Prepare should fail without existing timeline and provided baseline."""
+def test_prepare_run_context_fails_for_uninitialized_timeline_with_empty_baseline() -> None:
+    """Prepare should reject an empty baseline for an allocated Timeline."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-123",
+        source_experiment="training/churn",
+        metrics={"f1": 0.91, "auc": 0.95},
+        artifacts=("metrics.json",),
+        environment={},
+        features=(),
+        schema={},
+        data_scope="validation:2026-03-01",
+    )
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id="train-run-123",
@@ -1072,19 +1138,23 @@ def test_prepare_run_context_fails_for_first_run_with_empty_baseline() -> None:
         )
 
     error = exc_info.value
-    assert error.code == "prepare_missing_baseline_no_timeline"
+    assert error.code == "prepare_missing_baseline_for_uninitialized_timeline"
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", ""),
     )
     assert error.message == (
-        "No timeline exists for subject_id=churn_model "
+        "The timeline for subject_id='churn_model' has no pinned baseline "
         "and no baseline_source_run_id was provided. "
-        "A valid baseline_source_run_id is required to bootstrap a new timeline."
+        "A valid baseline_source_run_id is required to bootstrap the timeline."
     )
+    timeline_state = gateway.get_timeline_state("churn_model")
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "timeline-churn_model"
+    assert timeline_state.baseline_source_run_id is None
 
 
-def test_prepare_run_context_fails_for_first_run_with_missing_baseline_run() -> None:
+def test_prepare_run_context_fails_for_uninitialized_timeline_with_missing_baseline_run() -> None:
     """Prepare should reject bootstrap baselines that do not resolve."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
@@ -1101,7 +1171,6 @@ def test_prepare_run_context_fails_for_first_run_with_missing_baseline_run() -> 
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1122,14 +1191,14 @@ def test_prepare_run_context_fails_for_first_run_with_missing_baseline_run() -> 
         ("baseline_source_run_id", "missing-baseline"),
     )
     assert error.message == (
-        "Baseline source run could not be resolved for subject_id=churn_model, "
-        "compiled_recipe.source_requirements.source_experiment='training/churn', "
+        "Baseline source run could not be resolved for subject_id='churn_model', "
+        "source_experiment='training/churn', "
         "and baseline_source_run_id='missing-baseline'."
     )
 
 
-def test_prepare_run_context_does_not_persist_timeline_when_source_run_resolution_fails() -> None:
-    """Failed first prepare should not leave timeline state behind."""
+def test_prepare_run_context_does_not_bootstrap_when_source_run_resolution_fails() -> None:
+    """Failed Prepare should retain allocation without pinning a baseline."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
         subject_id="churn_model",
@@ -1145,7 +1214,6 @@ def test_prepare_run_context_does_not_persist_timeline_when_source_run_resolutio
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id="missing-source",
@@ -1159,11 +1227,14 @@ def test_prepare_run_context_does_not_persist_timeline_when_source_run_resolutio
         )
 
     assert exc_info.value.code == "prepare_source_run_not_found"
-    assert gateway.get_timeline_state("churn_model") is None
+    timeline_state = gateway.get_timeline_state("churn_model")
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "timeline-churn_model"
+    assert timeline_state.baseline_source_run_id is None
 
 
-def test_prepare_run_context_does_not_persist_timeline_when_metric_validation_fails() -> None:
-    """Failed first prepare should not persist bootstrap state on metric errors."""
+def test_prepare_run_context_does_not_bootstrap_when_metric_validation_fails() -> None:
+    """Metric validation failure should leave the baseline uninitialized."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
         subject_id="churn_model",
@@ -1179,7 +1250,6 @@ def test_prepare_run_context_does_not_persist_timeline_when_metric_validation_fa
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1193,11 +1263,14 @@ def test_prepare_run_context_does_not_persist_timeline_when_metric_validation_fa
         )
 
     assert exc_info.value.code == "prepare_missing_required_metric"
-    assert gateway.get_timeline_state("churn_model") is None
+    timeline_state = gateway.get_timeline_state("churn_model")
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "timeline-churn_model"
+    assert timeline_state.baseline_source_run_id is None
 
 
-def test_prepare_run_context_does_not_persist_timeline_when_artifact_validation_fails() -> None:
-    """Failed first prepare should not persist bootstrap state on artifact errors."""
+def test_prepare_run_context_does_not_bootstrap_when_artifact_validation_fails() -> None:
+    """Artifact validation failure should leave the baseline uninitialized."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
         subject_id="churn_model",
@@ -1213,7 +1286,6 @@ def test_prepare_run_context_does_not_persist_timeline_when_artifact_validation_
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1227,11 +1299,14 @@ def test_prepare_run_context_does_not_persist_timeline_when_artifact_validation_
         )
 
     assert exc_info.value.code == "prepare_missing_required_artifact"
-    assert gateway.get_timeline_state("churn_model") is None
+    timeline_state = gateway.get_timeline_state("churn_model")
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "timeline-churn_model"
+    assert timeline_state.baseline_source_run_id is None
 
 
-def test_prepare_run_context_does_not_persist_timeline_when_custom_reference_is_invalid() -> None:
-    """Failed first prepare should not persist bootstrap state on reference errors."""
+def test_prepare_run_context_does_not_bootstrap_when_custom_reference_is_invalid() -> None:
+    """Reference validation failure should leave the baseline uninitialized."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
         subject_id="churn_model",
@@ -1247,7 +1322,6 @@ def test_prepare_run_context_does_not_persist_timeline_when_custom_reference_is_
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1261,10 +1335,13 @@ def test_prepare_run_context_does_not_persist_timeline_when_custom_reference_is_
         )
 
     assert exc_info.value.code == "prepare_custom_reference_not_found"
-    assert gateway.get_timeline_state("churn_model") is None
+    timeline_state = gateway.get_timeline_state("churn_model")
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == "timeline-churn_model"
+    assert timeline_state.baseline_source_run_id is None
 
 
-def test_prepare_run_context_fails_for_first_run_with_foreign_subject_baseline() -> None:
+def test_prepare_rejects_foreign_subject_baseline_before_timeline_bootstrap() -> None:
     """Prepare should reject bootstrap baselines from another subject."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
@@ -1292,7 +1369,6 @@ def test_prepare_run_context_fails_for_first_run_with_foreign_subject_baseline()
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1313,13 +1389,13 @@ def test_prepare_run_context_fails_for_first_run_with_foreign_subject_baseline()
         ("baseline_source_run_id", "fraud-baseline"),
     )
     assert error.message == (
-        "Baseline source run could not be resolved for subject_id=churn_model, "
-        "compiled_recipe.source_requirements.source_experiment='training/churn', "
+        "Baseline source run could not be resolved for subject_id='churn_model', "
+        "source_experiment='training/churn', "
         "and baseline_source_run_id='fraud-baseline'."
     )
 
 
-def test_prepare_run_context_fails_for_first_run_with_foreign_experiment_baseline() -> None:
+def test_prepare_rejects_foreign_experiment_baseline_before_timeline_bootstrap() -> None:
     """Prepare should reject bootstrap baselines from another experiment."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     gateway.add_source_run(
@@ -1347,7 +1423,6 @@ def test_prepare_run_context_fails_for_first_run_with_foreign_experiment_baselin
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1368,8 +1443,8 @@ def test_prepare_run_context_fails_for_first_run_with_foreign_experiment_baselin
         ("baseline_source_run_id", "fraud-baseline"),
     )
     assert error.message == (
-        "Baseline source run could not be resolved for subject_id=churn_model, "
-        "compiled_recipe.source_requirements.source_experiment='training/churn', "
+        "Baseline source run could not be resolved for subject_id='churn_model', "
+        "source_experiment='training/churn', "
         "and baseline_source_run_id='fraud-baseline'."
     )
 
@@ -1391,7 +1466,6 @@ def test_prepare_run_context_fails_when_timeline_init_does_not_materialize_state
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1431,7 +1505,6 @@ def test_prepare_run_context_succeeds_when_competing_bootstrap_pins_same_baselin
     )
 
     prepared = prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(
             source_run_id=BASELINE.source_run_id,
@@ -1479,7 +1552,6 @@ def test_prepare_run_context_fails_when_competing_bootstrap_pins_different_basel
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id=BASELINE.source_run_id,
@@ -1503,8 +1575,18 @@ def test_prepare_run_context_fails_when_competing_bootstrap_pins_different_basel
 def test_prepare_run_context_succeeds_existing_timeline_with_correct_baseline_passed_in() -> None:
     """Prepare should resolve references and required source-run inputs."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    timeline_initialization_result = gateway.initialize_timeline(
-        "churn_model", BASELINE.source_run_id
+    compiled_invocation = make_compiled_invocation(
+        source_run_id=BASELINE.source_run_id,
+        source_experiment="training/churn",
+        required_metrics=tuple(BASELINE.metric_snapshot.keys()),
+        required_artifacts=("metrics.json",),
+        custom_reference_monitoring_run_id=None,
+    )
+    timeline_initialization_result = initialize_test_timeline(
+        gateway,
+        source_run_id=BASELINE.source_run_id,
+        baseline_source_run_id=BASELINE.source_run_id,
+        compiled_recipe=compiled_invocation.compiled_recipe,
     )
 
     gateway.add_source_run(
@@ -1520,15 +1602,8 @@ def test_prepare_run_context_succeeds_existing_timeline_with_correct_baseline_pa
     )
 
     prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
-        compiled_invocation=make_compiled_invocation(
-            source_run_id=BASELINE.source_run_id,
-            source_experiment="training/churn",
-            required_metrics=tuple(BASELINE.metric_snapshot.keys()),
-            required_artifacts=("metrics.json",),
-            custom_reference_monitoring_run_id=None,
-        ),
+        compiled_invocation=compiled_invocation,
         gateway=gateway,
         baseline_source_run_id=BASELINE.source_run_id,
     )
@@ -1544,11 +1619,10 @@ def test_prepare_run_context_succeeds_existing_timeline_with_correct_baseline_pa
 
 def test_prepare_run_context_succeeds_with_existed_timeline_and_no_baseline() -> None:
     """Baseline resolution should succeed by returning the existing pinned baseline."""
-    gateway = make_gateway_with_timeline()
+    gateway = make_gateway_with_timeline().gateway
     timeline_state = gateway.get_timeline_state("churn_model")
 
     prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(
             source_run_id="train-run-123",
@@ -1567,7 +1641,7 @@ def test_prepare_run_context_succeeds_with_existed_timeline_and_no_baseline() ->
 
 def test_prepare_run_context_succeeds_with_created_timeline_matching_baseline() -> None:
     """Prepare should succeed when provided baseline matches the existing timeline baseline."""
-    gateway = make_gateway_with_timeline()
+    gateway = make_gateway_with_timeline().gateway
 
     gateway.add_source_run(
         subject_id="churn_model",
@@ -1584,7 +1658,6 @@ def test_prepare_run_context_succeeds_with_created_timeline_matching_baseline() 
     timeline_state = gateway.get_timeline_state("churn_model")
 
     prepare_test_context(
-        monitoring_run_id="monitoring-run-1",
         subject_id="churn_model",
         compiled_invocation=make_compiled_invocation(
             source_run_id="train-run-123",
@@ -1604,7 +1677,7 @@ def test_prepare_run_context_succeeds_with_created_timeline_matching_baseline() 
 
 def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> None:
     """Prepare should fail when provided baseline does not match existing timeline baseline."""
-    gateway = make_gateway_with_timeline()
+    gateway = make_gateway_with_timeline().gateway
 
     # add source run that does not match the existing timeline baseline
     gateway.add_source_run(
@@ -1626,7 +1699,6 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
                 source_run_id="train-run-other",
@@ -1654,16 +1726,26 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
     )
 
 
-def test_prepare_run_context_fail_with_no_timeline_and_invalid_baseline() -> None:
-    """Prepare should fail with no timeline and invalid baseline that cannot be resolved."""
+def test_prepare_run_context_fails_for_uninitialized_timeline_and_invalid_baseline() -> None:
+    """Prepare should reject an unresolved baseline before bootstrapping."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        source_experiment="training/churn",
+        metrics={"f1": 0.91, "auc": 0.95},
+        artifacts=("metrics.json",),
+        environment={},
+        features=(),
+        schema={},
+        data_scope="validation:2026-03-01",
+    )
 
     with pytest.raises(PrepareStageError) as exc_info:
         prepare_test_context(
-            monitoring_run_id="monitoring-run-1",
             subject_id="churn_model",
             compiled_invocation=make_compiled_invocation(
-                source_run_id="train-run-baseline",
+                source_run_id="train-run-current",
                 source_experiment="training/churn",
                 required_metrics=("f1", "auc"),
                 required_artifacts=("metrics.json",),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1688,6 +1688,32 @@ def test_prepare_run_context_succeeds_with_existed_timeline_and_no_baseline() ->
     assert timeline_state.timeline_id == "timeline-churn_model"
 
 
+def test_prepare_run_context_rejects_empty_baseline_for_initialized_timeline() -> None:
+    """An explicit empty baseline should not be treated as an omitted baseline."""
+    gateway = make_gateway_with_timeline().gateway
+
+    with pytest.raises(PrepareStageError) as exc_info:
+        prepare_test_context(
+            subject_id="churn_model",
+            compiled_invocation=make_compiled_invocation(
+                source_run_id="train-run-123",
+                source_experiment="training/churn",
+                required_metrics=("f1", "auc"),
+                required_artifacts=("metrics.json",),
+            ),
+            gateway=gateway,
+            baseline_source_run_id="",
+        )
+
+    error = exc_info.value
+    assert error.code == "prepare_invalid_baseline"
+    assert error.details == (
+        ("subject_id", "churn_model"),
+        ("compiled_recipe.source_requirements.source_experiment", "training/churn"),
+        ("baseline_source_run_id", ""),
+    )
+
+
 def test_prepare_run_context_succeeds_with_created_timeline_matching_baseline() -> None:
     """Prepare should succeed when provided baseline matches the existing timeline baseline."""
     gateway = make_gateway_with_timeline().gateway

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1712,16 +1712,16 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
         )
 
     error = exc_info.value
-    assert error.code == "prepare_baseline_override_existing_timeline"
+    assert error.code == "prepare_baseline_trying_to_override_existing_timeline"
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-other"),
     )
     assert error.message == (
         "Provided baseline_source_run_id='train-run-other' "
-        "with resolved_baseline_source_run_id='train-run-other' "
-        "does not match existing timeline "
-        "baseline_source_run_id='train-run-baseline' for subject_id=churn_model. "
+        "with resolved baseline_source_run_id='train-run-other' "
+        "does not match existing timeline pinned "
+        "baseline_source_run_id='train-run-baseline' for subject_id='churn_model'. "
         "Overriding an existing timeline's baseline is not allowed."
     )
 
@@ -1763,7 +1763,7 @@ def test_prepare_run_context_fails_for_uninitialized_timeline_and_invalid_baseli
         ("baseline_source_run_id", "train-run-baseline"),
     )
     assert error.message == (
-        "Baseline source run could not be resolved for subject_id=churn_model, "
-        "compiled_recipe.source_requirements.source_experiment='training/churn', "
+        "Baseline source run could not be resolved for subject_id='churn_model', "
+        "source_experiment='training/churn', "
         "and baseline_source_run_id='train-run-baseline'."
     )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -21,7 +21,7 @@ from mlflow_monitor.gateway import (
     GatewayConfig,
     IdempotencyKey,
     InMemoryMonitoringGateway,
-    TimelineInitializationResult,
+    TimelinePinBaselineResult,
     TimelineState,
 )
 from mlflow_monitor.recipe import SYSTEM_DEFAULT_RECIPE_ID
@@ -153,14 +153,14 @@ def allocate_test_monitoring_run(
     )
 
 
-def initialize_test_timeline(
+def pin_test_timeline(
     gateway: InMemoryMonitoringGateway,
     *,
     subject_id: str = "churn_model",
     source_run_id: str = "train-run-123",
     baseline_source_run_id: str = "train-run-baseline",
     compiled_recipe: CompiledRecipe | None = None,
-) -> TimelineInitializationResult:
+) -> TimelinePinBaselineResult:
     """Allocate a Monitoring Run before bootstrapping its Timeline baseline."""
     effective_compiled_recipe = (
         compiled_recipe or make_compiled_invocation(source_run_id=source_run_id).compiled_recipe
@@ -171,7 +171,7 @@ def initialize_test_timeline(
         source_run_id=source_run_id,
         compiled_recipe=effective_compiled_recipe,
     )
-    return gateway.initialize_timeline(subject_id, baseline_source_run_id)
+    return gateway.pin_timeline_baseline(subject_id, baseline_source_run_id)
 
 
 def make_gateway_with_timeline() -> InitializedTimelineFixture:
@@ -184,7 +184,7 @@ def make_gateway_with_timeline() -> InitializedTimelineFixture:
         source_run_id="train-run-prev",
         compiled_recipe=compiled_recipe,
     )
-    gateway.initialize_timeline("churn_model", "train-run-baseline")
+    gateway.pin_timeline_baseline("churn_model", "train-run-baseline")
     gateway.upsert_monitoring_run(
         subject_id="churn_model",
         monitoring_run_id=previous_allocation.monitoring_run_id,
@@ -226,13 +226,13 @@ def make_gateway_with_timeline() -> InitializedTimelineFixture:
 class BrokenInitializeTimelineGateway(InMemoryMonitoringGateway):
     """Test double whose timeline initialization does not persist state."""
 
-    def initialize_timeline(
+    def pin_timeline_baseline(
         self, subject_id: str, baseline_source_run_id: str
-    ) -> TimelineInitializationResult:
-        """Pretend to initialize the timeline without storing timeline state."""
-        return TimelineInitializationResult(
+    ) -> TimelinePinBaselineResult:
+        """Pretend to pin the timeline baseline without storing timeline state."""
+        return TimelinePinBaselineResult(
             timeline_id=f"timeline-{subject_id}",
-            created=True,
+            baseline_pinned=True,
         )
 
 
@@ -249,9 +249,9 @@ class RaceWinningInitializeTimelineGateway(InMemoryMonitoringGateway):
         super().__init__(config)
         self._competing_baseline_source_run_id = competing_baseline_source_run_id
 
-    def initialize_timeline(
+    def pin_timeline_baseline(
         self, subject_id: str, baseline_source_run_id: str
-    ) -> TimelineInitializationResult:
+    ) -> TimelinePinBaselineResult:
         """Materialize timeline state as if another writer initialized first."""
         timeline_state = self.get_timeline_state(subject_id)
         assert timeline_state is not None
@@ -260,9 +260,9 @@ class RaceWinningInitializeTimelineGateway(InMemoryMonitoringGateway):
                 timeline_id=timeline_state.timeline_id,
                 baseline_source_run_id=self._competing_baseline_source_run_id,
             )
-        return TimelineInitializationResult(
+        return TimelinePinBaselineResult(
             timeline_id=timeline_state.timeline_id,
-            created=False,
+            baseline_pinned=False,
         )
 
 
@@ -750,7 +750,7 @@ def test_execute_contract_check_rejects_duplicate_reason_codes() -> None:
 def test_prepare_run_context_succeeds_without_previous_run() -> None:
     """Prepare should tolerate a missing previous run."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(gateway)
+    pin_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -788,7 +788,7 @@ def test_prepare_run_context_succeeds_without_active_lkg() -> None:
 def test_prepare_run_context_allows_omitted_source_experiment_filter() -> None:
     """Prepare should resolve a raw source run when source_experiment is omitted."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(gateway)
+    pin_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -829,7 +829,7 @@ def test_prepare_run_context_preserves_omitted_custom_reference() -> None:
 def test_prepare_run_context_fails_when_source_run_cannot_be_resolved() -> None:
     """Prepare should fail explicitly when the source run is missing."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(gateway)
+    pin_test_timeline(gateway)
 
     with pytest.raises(PrepareStageError, match="Source training run could not be resolved"):
         prepare_test_context(
@@ -842,7 +842,7 @@ def test_prepare_run_context_fails_when_source_run_cannot_be_resolved() -> None:
 def test_prepare_run_context_fails_when_required_metric_is_missing() -> None:
     """Prepare should fail explicitly when a required metric is absent."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(gateway)
+    pin_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -869,7 +869,7 @@ def test_prepare_run_context_fails_when_required_metric_is_missing() -> None:
 def test_prepare_run_context_fails_when_required_artifact_is_missing() -> None:
     """Prepare should fail explicitly when a required artifact is absent."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(gateway)
+    pin_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -896,7 +896,7 @@ def test_prepare_run_context_fails_when_required_artifact_is_missing() -> None:
 def test_prepare_run_context_uses_invocation_owned_source_run_id() -> None:
     """Prepare should use the invocation identity rather than Recipe selection."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(
+    pin_test_timeline(
         gateway,
         source_run_id="train-run-runtime",
         compiled_recipe=make_compiled_invocation(
@@ -935,7 +935,7 @@ def test_prepare_run_context_succeeds_for_resolved_system_default_recipe() -> No
     """Prepare should treat the built-in default recipe as a first-class runtime input."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     compiled = compile_recipe()
-    initialize_test_timeline(
+    pin_test_timeline(
         gateway,
         source_run_id="train-run-runtime",
         compiled_recipe=compiled,
@@ -975,7 +975,7 @@ def test_prepare_run_context_allows_system_default_recipe_without_optional_evide
     """Prepare should not require extra metrics or artifacts for the system default recipe."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
     compiled = compile_recipe()
-    initialize_test_timeline(
+    pin_test_timeline(
         gateway,
         source_run_id="train-run-runtime",
         compiled_recipe=compiled,
@@ -1008,7 +1008,7 @@ def test_prepare_run_context_allows_system_default_recipe_without_optional_evide
 def test_prepare_run_context_fails_when_custom_reference_is_missing() -> None:
     """Prepare should fail when configured custom reference is absent."""
     gateway = InMemoryMonitoringGateway(GatewayConfig())
-    initialize_test_timeline(gateway)
+    pin_test_timeline(gateway)
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-123",
@@ -1479,10 +1479,10 @@ def test_prepare_run_context_fails_when_timeline_init_does_not_materialize_state
         )
 
     error = exc_info.value
-    assert error.code == "prepare_timeline_initialization_failed"
+    assert error.code == "prepare_timeline_pin_failed"
     assert error.details == (("subject_id", "churn_model"),)
     assert error.message == (
-        "Timeline initialization did not materialize state for subject_id=churn_model."
+        "Timeline pinning did not materialize state for subject_id=churn_model."
     )
 
 
@@ -1582,7 +1582,7 @@ def test_prepare_run_context_succeeds_existing_timeline_with_correct_baseline_pa
         required_artifacts=("metrics.json",),
         custom_reference_monitoring_run_id=None,
     )
-    timeline_initialization_result = initialize_test_timeline(
+    timeline_pin_baseline_result = pin_test_timeline(
         gateway,
         source_run_id=BASELINE.source_run_id,
         baseline_source_run_id=BASELINE.source_run_id,
@@ -1610,8 +1610,8 @@ def test_prepare_run_context_succeeds_existing_timeline_with_correct_baseline_pa
 
     timeline_state = gateway.get_timeline_state("churn_model")
 
-    assert timeline_initialization_result.created is True
-    assert timeline_initialization_result.timeline_id == "timeline-churn_model"
+    assert timeline_pin_baseline_result.baseline_pinned is True
+    assert timeline_pin_baseline_result.timeline_id == "timeline-churn_model"
     assert timeline_state is not None
     assert timeline_state.baseline_source_run_id == BASELINE.source_run_id
     assert timeline_state.timeline_id == "timeline-churn_model"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -18,6 +18,7 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import CheckStageError, InvalidRunTransition, PrepareStageError
 from mlflow_monitor.gateway import (
     GatewayConfig,
+    IdempotencyKey,
     InMemoryMonitoringGateway,
     TimelineInitializationResult,
 )
@@ -425,6 +426,56 @@ def test_prepare_run_context_succeeds_with_initialized_timeline() -> None:
     assert prepared.recipe_id == "default"
     assert prepared.recipe_version == "v0"
     assert prepared.contract_id == SYSTEM_DEFAULT_CONTRACT_ID
+
+
+def test_prepare_run_context_bootstraps_allocated_uninitialized_timeline() -> None:
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+    for source_run_id in (BASELINE.source_run_id, "train-run-current"):
+        gateway.add_source_run(
+            subject_id="churn_model",
+            source_run_id=source_run_id,
+            source_experiment="training/churn",
+            metrics=BASELINE.metric_snapshot,
+            artifacts=("metrics.json",),
+            environment=BASELINE.environment_context,
+            features=("age", "income"),
+            schema={"age": "int", "income": "float"},
+            data_scope="validation:2026-03-01",
+        )
+    compiled_invocation = make_compiled_invocation(
+        source_run_id="train-run-current",
+        required_metrics=tuple(BASELINE.metric_snapshot),
+        custom_reference_monitoring_run_id=None,
+    )
+    compiled_recipe = compiled_invocation.compiled_recipe
+    allocation = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            recipe_id=compiled_recipe.identity.recipe_id,
+            recipe_version=compiled_recipe.identity.recipe_version,
+        )
+    )
+
+    timeline_state = gateway.get_timeline_state("churn_model")
+
+    assert timeline_state is not None
+    assert timeline_state.timeline_id == allocation.timeline_id
+    assert timeline_state.baseline_source_run_id is None
+
+    prepared = prepare_test_context(
+        monitoring_run_id=allocation.monitoring_run_id,
+        subject_id="churn_model",
+        compiled_invocation=compiled_invocation,
+        gateway=gateway,
+        baseline_source_run_id=BASELINE.source_run_id,
+    )
+    bootstrapped_timeline_state = gateway.get_timeline_state("churn_model")
+
+    assert prepared.timeline_id == allocation.timeline_id
+    assert bootstrapped_timeline_state is not None
+    assert bootstrapped_timeline_state.timeline_id == allocation.timeline_id
+    assert bootstrapped_timeline_state.baseline_source_run_id == BASELINE.source_run_id
 
 
 def test_execute_contract_check_returns_warn_result_for_environment_mismatch() -> None:


### PR DESCRIPTION
## What changed

The timeline identity is created by the time the first monitoring run is allocated. For instance, before `prepare` is called, a monitoring run would be allocated through `create_or_reuse_monitoring_run` method, and if the timeline does not exist, that is the experiment or `subject_id` has not been monitored yet. Thus, the timeline would be created at that time with `baseline_source_run_id = None` for the timeline state. 

Later, when the allocation is finished, and the `prepare` is finished, the timeline would be bootstrapped with `baseline_source_run_id`. This prevents that when the timeline is bootstrapped, but failed in flight of `prepare`. 

This is a rather big change, where `gateway` and `mlflow_gateway` behaviors are changed as well as `prepare` stage, in particular, on how to resolve the baseline source run.

## Ticket
[V0-010]()


## Impact

<!-- Describe user-facing or developer-facing behavior, compatibility, and migration impact. -->

This now makes the allocation prerequisite before the monitoring workflow can be started from `prepare` stage.

## Validation

<!-- Check only commands that were run successfully (do not change the commands). Explain any omissions below. -->

- [x] `uv sync --extra dev`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Matching `docs/site/` content is updated, or no developer-doc change is required
- [x] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
- [x] `uv build`

<!-- Validation omissions, if any: -->
- no doc changes
- all validation runs pass locally and through CI.