### PR TITLE
Accept compiled Recipes at the run boundary

### DIFF
--- a/docs/site/source/recipe.rst
+++ b/docs/site/source/recipe.rst
@@ -67,6 +67,37 @@ Finding policies, each registered by its exact ID and version; duplicate
 identities, including the packaged policy identity, are rejected. Custom
 Contracts remain outside the v0 boundary.
 
+Running a Compiled Recipe
+-------------------------
+
+Recipe parsing and compilation finish before monitoring execution. Pass only the
+resulting ``CompiledRecipe`` to ``monitor.run()``:
+
+.. code-block:: python
+
+   from mlflow_monitor import monitor
+   from mlflow_monitor.recipe import load_recipe_json
+   from mlflow_monitor.recipe_compiler import compile_recipe
+
+   recipe = load_recipe_json("recipes/churn.json")
+   compiled_recipe = compile_recipe(recipe)
+
+   result = monitor.run(
+       subject_id="customer-churn",
+       source_run_id="source-run-103",
+       recipe=compiled_recipe,
+   )
+
+Passing ``recipe=None`` selects the precompiled system default. ``monitor.run()``
+rejects raw mappings, file paths, and ``ComponentRegistry`` values; callers must
+parse and compile those inputs before execution. The optional
+``custom_reference_monitoring_run_id`` is supplied by each invocation and remains
+outside the reusable Recipe.
+
+The compiled Recipe ID and version participate in Monitoring Run idempotency.
+MLflow-Monitor does not globally compare effective plans that reuse the same ID
+and version across unrelated Monitoring Runs.
+
 
 Recipe Compiler
 ---------------

--- a/src/mlflow_monitor/monitor.py
+++ b/src/mlflow_monitor/monitor.py
@@ -6,6 +6,7 @@ from mlflow_monitor.contract_checker import DefaultContractChecker
 from mlflow_monitor.gateway import GatewayConfig, MonitoringGateway
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.orchestration import run_orchestration
+from mlflow_monitor.recipe_compiler import CompiledRecipe
 from mlflow_monitor.result_contract import MonitorRunResult
 
 
@@ -14,18 +15,27 @@ def run(
     subject_id: str,
     source_run_id: str,
     baseline_source_run_id: str | None = None,
+    custom_reference_monitoring_run_id: str | None = None,
+    recipe: CompiledRecipe | None = None,
     gateway: MonitoringGateway | None = None,
 ) -> MonitorRunResult:
-    """Execute a monitoring run for one monitored subject, source run, and baseline source run.
+    """Execute monitoring for one Source Training Run.
 
     Args:
-        subject_id: The ID of the monitored subject this run is associated with.
-        source_run_id: The original run ID from the training system that produced this run.
-        baseline_source_run_id: baseline source run id for first run.
-        gateway: The monitoring gateway to use for persistence during orchestration.
+        subject_id: Monitored subject identifier.
+        source_run_id: Source Training Run identifier to monitor.
+        baseline_source_run_id: Optional Baseline Source Run identifier used to
+            bootstrap or confirm the subject's immutable baseline.
+        custom_reference_monitoring_run_id: Optional invocation-owned Reference
+            Monitoring Run identifier.
+        recipe: Precompiled Recipe, or ``None`` for the system default.
+        gateway: Optional persistence gateway override.
 
     Returns:
-        The result of the monitoring run execution, including comparability status and any findings.
+        The current synchronous monitoring result.
+
+    Raises:
+        TypeError: If ``recipe`` is neither a ``CompiledRecipe`` nor ``None``.
     """
     if gateway is None:
         gateway = MLflowMonitoringGateway(GatewayConfig())
@@ -34,6 +44,8 @@ def run(
         subject_id=subject_id,
         source_run_id=source_run_id,
         baseline_source_run_id=baseline_source_run_id,
+        custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
+        recipe=recipe,
         gateway=gateway,
         contract_checker=DefaultContractChecker(),
     )

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -128,7 +128,9 @@ def _resolve_startup(recipe: CompiledRecipe | None) -> CompiledRecipe:
     if recipe is None:
         return SYSTEM_DEFAULT_COMPILED_RECIPE
     if not isinstance(recipe, CompiledRecipe):
-        raise TypeError("recipe must be a CompiledRecipe or None.")
+        raise TypeError(
+            f"recipe must be a CompiledRecipe or None, got {type(recipe).__name__}."
+        )
     return recipe
 
 

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -128,9 +128,7 @@ def _resolve_startup(recipe: CompiledRecipe | None) -> CompiledRecipe:
     if recipe is None:
         return SYSTEM_DEFAULT_COMPILED_RECIPE
     if not isinstance(recipe, CompiledRecipe):
-        raise TypeError(
-            f"recipe must be a CompiledRecipe or None, got {type(recipe).__name__}."
-        )
+        raise TypeError(f"recipe must be a CompiledRecipe or None, got {type(recipe).__name__}.")
     return recipe
 
 

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -48,6 +48,8 @@ class OrchestrationState:
         source_run_id: The original run ID from the training system that produced this run.
         baseline_source_run_id: The source run ID of the baseline this run is compared against
         compiled_recipe: The execution-ready compiled Recipe for this run.
+        custom_reference_monitoring_run_id: Optional invocation-owned Reference
+            Monitoring Run identifier.
         timeline_id: The Timeline identity returned by monitoring-run allocation.
         monitoring_run_id: The unique ID of the monitoring run to be executed.
         existing_monitoring_run: The existing monitoring run record, if any.
@@ -60,6 +62,7 @@ class OrchestrationState:
     source_run_id: str
     baseline_source_run_id: str | None
     compiled_recipe: CompiledRecipe
+    custom_reference_monitoring_run_id: str | None
     timeline_id: str
     monitoring_run_id: str
     existing_monitoring_run: MonitoringRunRecord | None
@@ -74,6 +77,8 @@ def run_orchestration(
     baseline_source_run_id: str | None,
     gateway: MonitoringGateway,
     contract_checker: ContractChecker,
+    custom_reference_monitoring_run_id: str | None = None,
+    recipe: CompiledRecipe | None = None,
 ) -> MonitorRunResult:
     """Execute the orchestration for one monitoring run, including prepare and check stages.
 
@@ -83,17 +88,24 @@ def run_orchestration(
         baseline_source_run_id: The source run ID of the baseline this run is compared against
         gateway: The monitoring gateway to use for persistence during orchestration.
         contract_checker: The contract checker to use for executing the contract check stage.
+        custom_reference_monitoring_run_id: Optional invocation-owned Reference
+            Monitoring Run identifier.
+        recipe: Precompiled Recipe, or ``None`` for the system default.
 
     Returns:
         The result of the monitoring run execution, including comparability status and any findings.
 
+    Raises:
+        TypeError: If ``recipe`` is neither a ``CompiledRecipe`` nor ``None``.
+
     """  # noqa: E501
-    compiled_recipe = _resolve_startup()
+    compiled_recipe = _resolve_startup(recipe)
     state_or_result = _resolve_orchestration_state(
         subject_id=subject_id,
         source_run_id=source_run_id,
         baseline_source_run_id=baseline_source_run_id,
         compiled_recipe=compiled_recipe,
+        custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
         gateway=gateway,
     )
     if isinstance(state_or_result, MonitorRunResult):
@@ -111,9 +123,13 @@ def run_orchestration(
     )
 
 
-def _resolve_startup() -> CompiledRecipe:
-    """Return the precompiled system-default Recipe before allocation."""
-    return SYSTEM_DEFAULT_COMPILED_RECIPE
+def _resolve_startup(recipe: CompiledRecipe | None) -> CompiledRecipe:
+    """Validate and resolve the execution-ready Recipe before allocation."""
+    if recipe is None:
+        return SYSTEM_DEFAULT_COMPILED_RECIPE
+    if not isinstance(recipe, CompiledRecipe):
+        raise TypeError("recipe must be a CompiledRecipe or None.")
+    return recipe
 
 
 def _resolve_orchestration_state(
@@ -122,6 +138,7 @@ def _resolve_orchestration_state(
     source_run_id: str,
     baseline_source_run_id: str | None,
     compiled_recipe: CompiledRecipe,
+    custom_reference_monitoring_run_id: str | None,
     gateway: MonitoringGateway,
 ) -> OrchestrationState | MonitorRunResult:
     """Resolve idempotency state and apply rerun short-circuit policy."""
@@ -137,6 +154,7 @@ def _resolve_orchestration_state(
         source_run_id=create_or_reuse_result.source_run_id,
         baseline_source_run_id=baseline_source_run_id,
         compiled_recipe=compiled_recipe,
+        custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
         timeline_id=create_or_reuse_result.timeline_id,
         monitoring_run_id=create_or_reuse_result.monitoring_run_id,
         existing_monitoring_run=create_or_reuse_result.existing_monitoring_run,
@@ -224,6 +242,7 @@ def _run_prepare_monitoring_run_slice(
             gateway=gateway,
             source_run_id=state.source_run_id,
             baseline_source_run_id=state.baseline_source_run_id,
+            custom_reference_monitoring_run_id=state.custom_reference_monitoring_run_id,
         )
     except _OWNED_FAILURES as exc:
         gateway.upsert_monitoring_run(

--- a/tests/integration/test_monitor_api.py
+++ b/tests/integration/test_monitor_api.py
@@ -11,6 +11,8 @@ from mlflow import MlflowClient
 
 from mlflow_monitor import monitor
 from mlflow_monitor.domain import ComparabilityStatus, LifecycleStatus, MonitoringRunReference
+from mlflow_monitor.recipe import build_system_default_recipe
+from mlflow_monitor.recipe_compiler import compile_recipe
 
 
 def test_monitor_run_defaults_to_real_mlflow_gateway(
@@ -143,3 +145,65 @@ def test_monitor_run_warn_outcome_via_environment_mismatch(
     assert payload["monitoring_run_id"] == result.monitoring_run_id
     assert payload["lifecycle_status"] == "checked"
     assert payload["comparability_status"] == "warn"
+
+
+def test_monitor_run_persists_supplied_compiled_recipe_identity(
+    tracking_uri: str,
+    artifact_root_uri: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    create_training_run,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    raw = MlflowClient(tracking_uri=tracking_uri)
+    baseline_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="baseline",
+        metrics={"f1": 0.87},
+        params={"feature_columns": "age"},
+        tags={
+            "python_version": "3.12",
+            "schema.age": "int",
+            "data_scope": "validation:2026-03-01",
+        },
+    )
+    current_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="current-custom-recipe",
+        metrics={"f1": 0.91},
+        params={"feature_columns": "age"},
+        tags={
+            "python_version": "3.12",
+            "schema.age": "int",
+            "data_scope": "validation:2026-03-01",
+        },
+    )
+    recipe = build_system_default_recipe()
+    recipe["identity"] = {
+        "recipe_id": "custom-churn",
+        "recipe_version": "7",
+    }
+    compiled_recipe = compile_recipe(recipe)
+
+    previous_tracking_uri = mlflow.get_tracking_uri()
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", tracking_uri)
+    mlflow.set_tracking_uri(tracking_uri)
+    try:
+        result = monitor.run(
+            subject_id="churn_model",
+            source_run_id=current_run_id,
+            baseline_source_run_id=baseline_run_id,
+            recipe=compiled_recipe,
+        )
+    finally:
+        mlflow.set_tracking_uri(previous_tracking_uri)
+
+    monitoring_run = raw.get_run(result.monitoring_run_id)
+
+    assert result.lifecycle_status is LifecycleStatus.CHECKED
+    assert monitoring_run.data.tags["monitoring.recipe_id"] == "custom-churn"
+    assert monitoring_run.data.tags["monitoring.recipe_version"] == "7"

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -69,7 +69,7 @@ def make_compiled_recipe(
     recipe_version: str = "3",
     metric_names: list[str] | None = None,
 ) -> CompiledRecipe:
-    """Build one system-only compiled Recipe with configurable effective analysis."""
+    """Build a compiled Recipe with configurable identity and analysis."""
     raw = build_system_default_recipe()
     raw["identity"] = {
         "recipe_id": recipe_id,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from mlflow_monitor import monitor
+from mlflow_monitor.builtins import SYSTEM_DEFAULT_RECIPE_ID
 from mlflow_monitor.contract_checker import DefaultContractChecker
 from mlflow_monitor.domain import (
     ComparabilityStatus,
@@ -22,12 +25,13 @@ from mlflow_monitor.gateway import (
     TimelineState,
 )
 from mlflow_monitor.orchestration import run_orchestration
+from mlflow_monitor.recipe import SYSTEM_DEFAULT_RECIPE_VERSION, build_system_default_recipe
+from mlflow_monitor.recipe_compiler import CompiledRecipe, ComponentRegistry, compile_recipe
 from mlflow_monitor.result_contract import MonitorRunResult
 
 
-def make_gateway() -> InMemoryMonitoringGateway:
-    """Build a gateway with baseline and current source runs."""
-    gateway = InMemoryMonitoringGateway(GatewayConfig())
+def add_default_source_runs(gateway: InMemoryMonitoringGateway) -> None:
+    """Seed a gateway with the default baseline and current Source Training Runs."""
     gateway.add_source_run(
         subject_id="churn_model",
         source_run_id="train-run-baseline",
@@ -50,7 +54,30 @@ def make_gateway() -> InMemoryMonitoringGateway:
         schema={"age": "int"},
         data_scope="validation:2026-03-01",
     )
+
+
+def make_gateway() -> InMemoryMonitoringGateway:
+    """Build a gateway with baseline and current source runs."""
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+    add_default_source_runs(gateway)
     return gateway
+
+
+def make_compiled_recipe(
+    *,
+    recipe_id: str = "churn-monitoring",
+    recipe_version: str = "3",
+    metric_names: list[str] | None = None,
+) -> CompiledRecipe:
+    """Build one system-only compiled Recipe with configurable effective analysis."""
+    raw = build_system_default_recipe()
+    raw["identity"] = {
+        "recipe_id": recipe_id,
+        "recipe_version": recipe_version,
+    }
+    if metric_names is not None:
+        raw["analysis"] = {"metric_names": metric_names}
+    return compile_recipe(raw)
 
 
 class InvalidResultContractChecker:
@@ -198,6 +225,20 @@ class FinalizingGateway(InMemoryMonitoringGateway):
     ) -> None:
         assert monitoring_run_id == result.monitoring_run_id
         self.finalized_results.append(result)
+
+
+class RecordingAllocationGateway(InMemoryMonitoringGateway):
+    """Record every idempotency key presented to Monitoring Run allocation."""
+
+    def __init__(self, config: GatewayConfig) -> None:
+        super().__init__(config)
+        self.allocation_keys: list[IdempotencyKey] = []
+
+    def create_or_reuse_monitoring_run(
+        self, key: IdempotencyKey
+    ) -> CreateOrReuseMonitoringRunResult:
+        self.allocation_keys.append(key)
+        return super().create_or_reuse_monitoring_run(key)
 
 
 def test_run_orchestration_first_run_persists_checked_state() -> None:
@@ -986,6 +1027,189 @@ def test_public_run_is_a_thin_facade(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["baseline_source_run_id"] == "train-run-baseline"
     assert captured["gateway"] is gateway
     assert "monitoring_run_id_factory" not in captured
+
+
+def test_public_run_forwards_compiled_recipe_and_custom_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = object()
+    captured: dict[str, object] = {}
+    gateway = InMemoryMonitoringGateway(GatewayConfig())
+    compiled_recipe = make_compiled_recipe()
+
+    def fake_run_orchestration(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(monitor, "run_orchestration", fake_run_orchestration)
+
+    result = monitor.run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        custom_reference_monitoring_run_id="monitoring-run-reference",
+        recipe=compiled_recipe,
+        gateway=gateway,
+    )
+
+    assert result is expected
+    assert captured["recipe"] is compiled_recipe
+    assert captured["custom_reference_monitoring_run_id"] == "monitoring-run-reference"
+
+
+def test_public_run_explicit_none_uses_system_default_recipe_identity() -> None:
+    gateway = RecordingAllocationGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+
+    result = monitor.run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        recipe=None,
+        gateway=gateway,
+    )
+
+    assert result.lifecycle_status is LifecycleStatus.CHECKED
+    assert gateway.allocation_keys == [
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            recipe_id=SYSTEM_DEFAULT_RECIPE_ID,
+            recipe_version=SYSTEM_DEFAULT_RECIPE_VERSION,
+        )
+    ]
+
+
+def test_public_run_uses_supplied_compiled_recipe_identity_for_idempotency() -> None:
+    gateway = RecordingAllocationGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    compiled_recipe = make_compiled_recipe(recipe_id="custom-churn", recipe_version="7")
+
+    result = monitor.run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        recipe=compiled_recipe,
+        gateway=gateway,
+    )
+
+    assert result.lifecycle_status is LifecycleStatus.CHECKED
+    assert gateway.allocation_keys == [
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            recipe_id="custom-churn",
+            recipe_version="7",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "recipe_input",
+    [
+        pytest.param(build_system_default_recipe(), id="raw-mapping"),
+        pytest.param(Path("recipe.json"), id="path"),
+        pytest.param("recipe.json", id="string-path"),
+        pytest.param(ComponentRegistry(), id="component-registry"),
+    ],
+)
+def test_public_run_rejects_uncompiled_recipe_without_allocating(recipe_input: object) -> None:
+    gateway = RecordingAllocationGateway(GatewayConfig())
+
+    with pytest.raises(TypeError) as exc_info:
+        monitor.run(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id="train-run-baseline",
+            recipe=recipe_input,
+            gateway=gateway,
+        )
+
+    assert "unexpected keyword argument" not in str(exc_info.value)
+    assert gateway.allocation_keys == []
+
+
+def test_public_run_adds_invocation_owned_custom_reference() -> None:
+    gateway = make_gateway()
+    compiled_recipe = make_compiled_recipe()
+    reference_allocation = gateway.create_or_reuse_monitoring_run(
+        IdempotencyKey(
+            subject_id="churn_model",
+            source_run_id="train-run-reference",
+            recipe_id=compiled_recipe.identity.recipe_id,
+            recipe_version=compiled_recipe.identity.recipe_version,
+        )
+    )
+    gateway.upsert_monitoring_run(
+        subject_id="churn_model",
+        monitoring_run_id=reference_allocation.monitoring_run_id,
+        source_run_id="train-run-reference",
+        lifecycle_status=LifecycleStatus.CLOSED,
+        sequence_index=reference_allocation.sequence_index,
+    )
+
+    result = monitor.run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        custom_reference_monitoring_run_id=reference_allocation.monitoring_run_id,
+        recipe=compiled_recipe,
+        gateway=gateway,
+    )
+
+    assert result.lifecycle_status is LifecycleStatus.CHECKED
+    assert result.references == (
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind="previous",
+            monitoring_run_id=reference_allocation.monitoring_run_id,
+            source_run_id="train-run-reference",
+        ),
+        MonitoringRunReference(
+            kind="custom",
+            monitoring_run_id=reference_allocation.monitoring_run_id,
+            source_run_id="train-run-reference",
+        ),
+    )
+
+
+def test_public_run_does_not_globally_compare_effective_plans_for_same_recipe_identity() -> None:
+    gateway = make_gateway()
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-next",
+        source_experiment=None,
+        metrics={"f1": 0.92},
+        artifacts=("metrics.json",),
+        environment={"python": "3.12"},
+        features=("age",),
+        schema={"age": "int"},
+        data_scope="validation:2026-03-02",
+    )
+    select_no_metrics = make_compiled_recipe(metric_names=[])
+    select_f1 = make_compiled_recipe(metric_names=["f1"])
+
+    first = monitor.run(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        recipe=select_no_metrics,
+        gateway=gateway,
+    )
+    second = monitor.run(
+        subject_id="churn_model",
+        source_run_id="train-run-next",
+        recipe=select_f1,
+        gateway=gateway,
+    )
+
+    assert first.lifecycle_status is LifecycleStatus.CHECKED
+    assert second.lifecycle_status is LifecycleStatus.CHECKED
+    assert second.monitoring_run_id != first.monitoring_run_id
 
 
 def test_public_run_defaults_to_mlflow_gateway(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed

- Added `recipe: CompiledRecipe | None` and invocation-owned `custom_reference_monitoring_run_id` inputs to `monitor.run()`.
- Validated Recipe input before Monitoring Run allocation and used the compiled Recipe identity for idempotency.
- Propagated the custom Reference Monitoring Run into Prepare.
- Added unit and real-MLflow integration coverage for the run-boundary contract.
- Documented the compile-then-run workflow and rejected raw input forms.

## Ticket or Issue

V0-011

## Why

Recipe compilation is a side-effect-free preflight operation. Monitoring execution should consume only an execution-ready `CompiledRecipe`, while preserving the zero-configuration system default and keeping execution identities outside reusable Recipes.

## Review context

- Relevant public docs: [Recipe and Compiler](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/ticket/v0-011-compiled-recipe-run-boundary/docs/site/source/recipe.rst)
- Required behavior: `monitor.run()` accepts a compiled Recipe or `None`, rejects raw Recipe inputs before allocation, uses Recipe ID/version for idempotency, and accepts an invocation-owned custom Reference Monitoring Run.
- Out of scope: prepared-context persistence and replay comparison, Recipe fingerprints or global effective-plan scans, closed-only reference selection changes, and CLI Recipe loading.

## Impact

Python callers can now compile a custom Recipe before execution and pass it directly to `monitor.run()`. Existing callers that omit `recipe` retain the precompiled system-default behavior. Raw mappings, file paths, strings, and component registries are rejected at the run boundary before any Monitoring Run is allocated.

## Validation

- [x] `uv sync --extra dev`
- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Matching `docs/site/` content is updated, or no developer-doc change is required
- [x] `uv run --group doc sphinx-build -W -b html docs/site/source docs/site/build/html`
- [x] `uv build`

Validation omissions: none.
