### PR TITLE
Persist and hydrate prepared context

### DIFF
--- a/src/mlflow_monitor/builtins/builtin_contract.py
+++ b/src/mlflow_monitor/builtins/builtin_contract.py
@@ -11,7 +11,7 @@ SYSTEM_DEFAULT_EXECUTION_CONTRACT_REF = "system_default_execution"
 SYSTEM_DEFAULT_PERMISSIVE_CONTRACT_RAW = MappingProxyType(
     {
         "contract_id": SYSTEM_DEFAULT_CONTRACT_ID,
-        "version": "v0",
+        "contract_version": "v0",
         "schema_contract_ref": SYSTEM_DEFAULT_SCHEMA_CONTRACT_REF,
         "feature_contract_ref": SYSTEM_DEFAULT_FEATURE_CONTRACT_REF,
         "metric_contract_ref": None,

--- a/src/mlflow_monitor/contract.py
+++ b/src/mlflow_monitor/contract.py
@@ -85,7 +85,7 @@ def parse_contract_v0(raw: Mapping[str, object]) -> Contract:
 
     return Contract(
         contract_id=_require_string(raw, "contract_id"),
-        version=_require_string(raw, "version"),
+        contract_version=_require_string(raw, "contract_version"),
         schema_contract_ref=_optional_string(raw, "schema_contract_ref"),
         feature_contract_ref=_optional_string(raw, "feature_contract_ref"),
         metric_contract_ref=_optional_string(raw, "metric_contract_ref"),

--- a/src/mlflow_monitor/domain.py
+++ b/src/mlflow_monitor/domain.py
@@ -199,7 +199,7 @@ class Contract:
 
     Attributes:
         contract_id: Unique identifier for the contract.
-        version: Version string for the contract schema.
+        contract_version: Version string for the contract schema.
         schema_contract_ref: Optional reference to a schema contract defining expected data shapes.
         feature_contract_ref: Optional reference to a feature contract defining expected features.
         metric_contract_ref: Optional reference to a metric contract defining expected metrics.
@@ -208,7 +208,7 @@ class Contract:
     """  # noqa: E501
 
     contract_id: str
-    version: str
+    contract_version: str
     schema_contract_ref: str | None
     feature_contract_ref: str | None
     metric_contract_ref: str | None

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_timeline"
+
 
 @dataclass(frozen=True, slots=True)
 class InvariantViolation(ValueError):

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -36,6 +36,7 @@ Lifecycle sketch:
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -309,6 +310,14 @@ class MonitoringGateway(Protocol):
         result: MonitorRunResult,
     ) -> None:
         """Ensure final result payloads and terminal monitoring-run state are persisted."""
+        ...
+
+    def read_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        path: str,
+    ) -> dict[str, Any] | None:
+        """Read one dictionary payload from a JSON artifact on a monitoring run."""
         ...
 
     def write_monitoring_run_json_artifact(
@@ -839,6 +848,22 @@ class InMemoryMonitoringGateway:
     ) -> None:
         """No-op finalization hook for the in-memory test gateway."""
         _ = (monitoring_run_id, result)
+
+    def read_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        path: str,
+    ) -> dict[str, Any] | None:
+        """Read one dictionary payload from a JSON artifact on a monitoring run."""
+        self._validate_monitoring_run_artifact_target(monitoring_run_id)
+
+        existing_artifact_encoded = self._monitoring_runs_artifact_store.get(
+            (monitoring_run_id, path)
+        )
+        if existing_artifact_encoded is None:
+            return None
+
+        return json.loads(existing_artifact_encoded)
 
     def write_monitoring_run_json_artifact(
         self,

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -863,7 +863,18 @@ class InMemoryMonitoringGateway:
         if existing_artifact_encoded is None:
             return None
 
-        return json.loads(existing_artifact_encoded)
+        try:
+            existing_artifact_decoded = json.loads(existing_artifact_encoded)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(existing_artifact_decoded, dict):
+            raise ValueError("Monitoring run JSON artifact {path!r} must contain a JSON object.")
+
+        # validate nested values, including ensuring no infinite or NaN values.
+        canonical_json(existing_artifact_decoded)
+
+        return existing_artifact_decoded
 
     def write_monitoring_run_json_artifact(
         self,

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -865,11 +865,13 @@ class InMemoryMonitoringGateway:
 
         try:
             existing_artifact_decoded = json.loads(existing_artifact_encoded)
-        except json.JSONDecodeError:
-            return None
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Monitoring run JSON artifact {path!r} contains invalid JSON."
+            ) from exc
 
         if not isinstance(existing_artifact_decoded, dict):
-            raise ValueError("Monitoring run JSON artifact {path!r} must contain a JSON object.")
+            raise ValueError(f"Monitoring run JSON artifact {path!r} must contain a JSON object.")
 
         # validate nested values, including ensuring no infinite or NaN values.
         canonical_json(existing_artifact_decoded)

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -726,6 +726,27 @@ class MLflowMonitoringGateway:
         self._validate_subject_id(subject_id)
         return f"{self._config.namespace_prefix}/{subject_id}"
 
+    def read_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        path: str,
+    ) -> dict[str, Any] | None:
+        """Read one exact-path JSON artifact from a Monitoring Run.
+
+        Args:
+            monitoring_run_id: Monitoring Run that owns the artifact.
+            path: Exact artifact path to read.
+
+        Returns:
+            Decoded JSON object, or ``None`` when the artifact is missing.
+
+        Raises:
+            GatewayNamespaceViolation: If the target is not an allocated
+                Monitoring Run in this Gateway namespace.
+        """
+        self._validate_monitoring_run_artifact_target(monitoring_run_id)
+        return self._mlflow.read_monitoring_run_json_artifact(monitoring_run_id, path)
+
     def write_monitoring_run_json_artifact(
         self,
         monitoring_run_id: str,

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -10,7 +10,10 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
 )
 from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
+    GatewayConsistencyViolation,
+    GatewayNamespaceViolation,
     PrepareStageError,
     TerminalRunRetryError,
 )
@@ -238,11 +241,24 @@ def _run_prepare_monitoring_run_slice(
         state.existing_monitoring_run is not None
         and state.existing_monitoring_run.lifecycle_status is LifecycleStatus.PREPARED
     ):
-        raw_prepared_context = gateway.read_monitoring_run_json_artifact(
-            state.monitoring_run_id,
-            PREPARED_CONTEXT_ARTIFACT_PATH,
-        )
-        return hydrate_prepared_context(
+        try:
+            raw_prepared_context = gateway.read_monitoring_run_json_artifact(
+                state.monitoring_run_id,
+                PREPARED_CONTEXT_ARTIFACT_PATH,
+            )
+        except (GatewayConsistencyViolation, GatewayNamespaceViolation):
+            raise
+        except ValueError as exc:
+            raise GatewayConsistencyViolation(
+                code="prepared_context_inconsistent",
+                message="Persisted prepared context is missing, broken, or inconsistent.",
+                details=(
+                    ("reason", "broken_artifact"),
+                    ("field", "prepared_context"),
+                ),
+            ) from exc
+
+        prepared_context = hydrate_prepared_context(
             raw_prepared_context,
             compiled_recipe=state.compiled_recipe,
             monitoring_run_id=state.monitoring_run_id,
@@ -251,6 +267,25 @@ def _run_prepare_monitoring_run_slice(
             timeline_id=state.timeline_id,
             sequence_index=state.sequence_index,
         )
+
+        rerun_error = _validate_rerun_baseline_input(
+            subject_id=state.subject_id,
+            supplied_baseline_source_run_id=state.baseline_source_run_id,
+            expected_baseline_source_run_id=prepared_context.baseline_source_run_id,
+            source_experiment=state.compiled_recipe.source_requirements.source_experiment,
+            gateway=gateway,
+        )
+
+        if rerun_error is not None:
+            return _build_failure_monitoring_run_result(
+                subject_id=state.subject_id,
+                monitoring_run_id=state.monitoring_run_id,
+                timeline_id=state.timeline_id,
+                stage="prepare",
+                error=rerun_error,
+            )
+
+        return prepared_context
 
     try:
         prepared_context = prepare_run_context(
@@ -544,6 +579,42 @@ def _build_terminal_failed_monitoring_run_rerun_error(
     )
 
 
+def _validate_rerun_baseline_input(
+    *,
+    subject_id: str,
+    supplied_baseline_source_run_id: str | None,
+    expected_baseline_source_run_id: str | None,
+    source_experiment: str | None,
+    gateway: MonitoringGateway,
+) -> PrepareStageError | None:
+    """Validate the input for rerunning a monitoring run against a baseline."""
+    if supplied_baseline_source_run_id is None:
+        return None
+
+    resolved = gateway.resolve_source_run_id(
+        subject_id=subject_id,
+        source_experiment=source_experiment,
+        source_run_id=supplied_baseline_source_run_id,
+    )
+    if resolved == expected_baseline_source_run_id:
+        return None
+
+    return PrepareStageError(
+        code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+        message=(
+            f"Provided baseline_source_run_id={supplied_baseline_source_run_id!r} "
+            f"with resolved baseline_source_run_id={resolved!r} does not match "
+            f"existing timeline pinned baseline_source_run_id={expected_baseline_source_run_id!r} "
+            f"for subject_id={subject_id!r}. "
+            "Overriding an existing timeline's baseline is not allowed."
+        ),
+        details=(
+            ("subject_id", subject_id),
+            ("baseline_source_run_id", supplied_baseline_source_run_id),
+        ),
+    )
+
+
 def _validate_checked_monitoring_run_rerun_inputs(
     *,
     subject_id: str,
@@ -574,7 +645,7 @@ def _validate_checked_monitoring_run_rerun_inputs(
         return None
 
     return PrepareStageError(
-        code="prepare_baseline_override_existing_timeline",
+        code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
         message=(
             f"Provided baseline_source_run_id={baseline_source_run_id!r} "
             f"with resolved_baseline_source_run_id={resolved_baseline_source_run_id!r} "

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -7,13 +7,10 @@ from dataclasses import dataclass
 from mlflow_monitor.contract_checker import ContractChecker
 from mlflow_monitor.domain import (
     ContractCheckResult,
-    DiffReferenceKind,
     LifecycleStatus,
-    MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
     CheckStageError,
-    GatewayConsistencyViolation,
     PrepareStageError,
     TerminalRunRetryError,
 )
@@ -28,9 +25,12 @@ from mlflow_monitor.recipe_compiler import (
 )
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
 from mlflow_monitor.workflow import (
+    PREPARED_CONTEXT_ARTIFACT_PATH,
     PreparedContext,
     execute_contract_check,
+    hydrate_prepared_context,
     prepare_run_context,
+    prepared_context_to_dict,
 )
 
 _OWNED_FAILURES = (
@@ -234,6 +234,24 @@ def _run_prepare_monitoring_run_slice(
             sequence_index=state.sequence_index,
         )
 
+    if (
+        state.existing_monitoring_run is not None
+        and state.existing_monitoring_run.lifecycle_status is LifecycleStatus.PREPARED
+    ):
+        raw_prepared_context = gateway.read_monitoring_run_json_artifact(
+            state.monitoring_run_id,
+            PREPARED_CONTEXT_ARTIFACT_PATH,
+        )
+        return hydrate_prepared_context(
+            raw_prepared_context,
+            compiled_recipe=state.compiled_recipe,
+            monitoring_run_id=state.monitoring_run_id,
+            source_run_id=state.source_run_id,
+            subject_id=state.subject_id,
+            timeline_id=state.timeline_id,
+            sequence_index=state.sequence_index,
+        )
+
     try:
         prepared_context = prepare_run_context(
             monitoring_run_id=state.monitoring_run_id,
@@ -241,6 +259,7 @@ def _run_prepare_monitoring_run_slice(
             compiled_recipe=state.compiled_recipe,
             gateway=gateway,
             source_run_id=state.source_run_id,
+            sequence_index=state.sequence_index,
             baseline_source_run_id=state.baseline_source_run_id,
             custom_reference_monitoring_run_id=state.custom_reference_monitoring_run_id,
         )
@@ -264,6 +283,12 @@ def _run_prepare_monitoring_run_slice(
             result=result,
         )
         return result
+
+    gateway.write_monitoring_run_json_artifact(
+        monitoring_run_id=state.monitoring_run_id,
+        data=prepared_context_to_dict(prepared_context),
+        path=PREPARED_CONTEXT_ARTIFACT_PATH,
+    )
 
     if (
         state.existing_monitoring_run is None
@@ -336,7 +361,7 @@ def _run_check_monitoring_run_slice(
         lifecycle_status=LifecycleStatus.CHECKED,
         sequence_index=state.sequence_index,
         contract_check_result=contract_check_result,
-        references=_build_monitoring_run_references(prepared_context, gateway),
+        references=prepared_context.references,
     )
     result = _build_success_monitoring_run_result(
         subject_id=state.subject_id,
@@ -344,7 +369,6 @@ def _run_check_monitoring_run_slice(
         timeline_id=state.timeline_id,
         prepared_context=prepared_context,
         contract_check_result=contract_check_result,
-        gateway=gateway,
     )
     gateway.finalize_monitoring_run_result(
         monitoring_run_id=state.monitoring_run_id,
@@ -360,7 +384,6 @@ def _build_success_monitoring_run_result(
     timeline_id: str,
     prepared_context,
     contract_check_result: ContractCheckResult,
-    gateway: MonitoringGateway,
 ) -> MonitorRunResult:
     """Build the canonical success result for one checked monitoring run.
 
@@ -370,7 +393,6 @@ def _build_success_monitoring_run_result(
         timeline_id: The Timeline identity returned by monitoring-run allocation.
         prepared_context: The prepared context produced by the prepare stage for this run.
         contract_check_result: The result of the contract check stage for this run.
-        gateway: The monitoring gateway to use for retrieving any additional information needed.
 
     Returns:
         The canonical success result for this run, including comparability status and any findings.
@@ -384,7 +406,7 @@ def _build_success_monitoring_run_result(
         summary=None,
         finding_ids=(),
         diff_ids=(),
-        references=_build_monitoring_run_references(prepared_context, gateway),
+        references=prepared_context.references,
         error=None,
     )
 
@@ -459,84 +481,6 @@ def _build_failure_monitoring_run_result(
             stage=stage,
             details=_error_details(error),
         ),
-    )
-
-
-def _build_monitoring_run_references(
-    prepared_context,
-    gateway: MonitoringGateway,
-) -> tuple[MonitoringRunReference, ...]:
-    """Build ordered typed references for persistence.
-
-    Args:
-        prepared_context: The prepared context produced by the prepare stage for this run.
-        gateway: Gateway used to hydrate source identity for monitoring-run references.
-
-    Returns:
-        Ordered typed references used during contract check.
-    """
-    references = [
-        MonitoringRunReference(
-            kind=DiffReferenceKind.BASELINE,
-            monitoring_run_id=None,
-            source_run_id=prepared_context.baseline_source_run_id,
-        )
-    ]
-    if prepared_context.previous_monitoring_run_id is not None:
-        references.append(
-            _hydrate_monitoring_run_reference(
-                kind=DiffReferenceKind.PREVIOUS,
-                subject_id=prepared_context.subject_id,
-                monitoring_run_id=prepared_context.previous_monitoring_run_id,
-                gateway=gateway,
-            )
-        )
-    if prepared_context.active_lkg_monitoring_run_id is not None:
-        references.append(
-            _hydrate_monitoring_run_reference(
-                kind=DiffReferenceKind.LKG,
-                subject_id=prepared_context.subject_id,
-                monitoring_run_id=prepared_context.active_lkg_monitoring_run_id,
-                gateway=gateway,
-            )
-        )
-    if prepared_context.custom_reference_monitoring_run_id is not None:
-        references.append(
-            _hydrate_monitoring_run_reference(
-                kind=DiffReferenceKind.CUSTOM,
-                subject_id=prepared_context.subject_id,
-                monitoring_run_id=prepared_context.custom_reference_monitoring_run_id,
-                gateway=gateway,
-            )
-        )
-    return tuple(references)
-
-
-def _hydrate_monitoring_run_reference(
-    *,
-    kind: DiffReferenceKind,
-    subject_id: str,
-    monitoring_run_id: str,
-    gateway: MonitoringGateway,
-) -> MonitoringRunReference:
-    """Hydrate a complete reference pair from a monitoring-run pointer."""
-    record = gateway.get_monitoring_run(subject_id, monitoring_run_id)
-    if record is None:
-        raise GatewayConsistencyViolation(
-            code="monitoring_reference_inconsistent",
-            message=(
-                "Monitoring reference could not be hydrated for "
-                f"monitoring_run_id={monitoring_run_id!r}."
-            ),
-            details=(
-                ("kind", kind.value),
-                ("monitoring_run_id", monitoring_run_id),
-            ),
-        )
-    return MonitoringRunReference(
-        kind=kind,
-        monitoring_run_id=record.monitoring_run_id,
-        source_run_id=record.source_run_id,
     )
 
 

--- a/src/mlflow_monitor/recipe_compiler.py
+++ b/src/mlflow_monitor/recipe_compiler.py
@@ -168,7 +168,7 @@ class CompiledRecipe:
             self.effective_plan.contract.contract_id,
             self.effective_plan.contract.contract_version,
         )
-        actual = (self.contract.contract_id, self.contract.version)
+        actual = (self.contract.contract_id, self.contract.contract_version)
         if expcted != actual:
             raise ValueError(
                 f"Mismatch between effective plan contract {expcted} and resolved contract {actual}"
@@ -232,7 +232,7 @@ class ComponentRegistry:
         object.__setattr__(
             self,
             "contracts",
-            MappingProxyType({(contract.contract_id, contract.version): contract}),
+            MappingProxyType({(contract.contract_id, contract.contract_version): contract}),
         )
         object.__setattr__(
             self,

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -300,13 +300,9 @@ def hydrate_prepared_context(
         )
 
     contract = _hydrate_prepared_contract(raw.get("contract"))
-    expected_contract_identity = (
-        compiled_recipe.effective_plan.contract.contract_id,
-        compiled_recipe.effective_plan.contract.contract_version,
-    )
-    if (contract.contract_id, contract.contract_version) != expected_contract_identity:
+    if contract != compiled_recipe.contract:
         raise _prepared_context_inconsistent(
-            reason="contract_identity_mismatch",
+            reason="contract_mismatch",
             field="contract",
         )
 

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -14,6 +14,7 @@ the gateway owns all persistence-specific mechanics.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 
 from mlflow_monitor.contract_checker import (
@@ -23,19 +24,21 @@ from mlflow_monitor.contract_checker import (
 from mlflow_monitor.domain import (
     Contract,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
     Run,
 )
 from mlflow_monitor.errors import (
     CheckStageError,
+    GatewayConsistencyViolation,
     InvalidRunTransition,
     InvariantViolation,
     PrepareStageError,
 )
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
 from mlflow_monitor.invariant import validate_contract_check_result
-from mlflow_monitor.recipe_compiler import CompiledRecipe
+from mlflow_monitor.recipe_compiler import CompiledRecipe, EffectiveRecipePlan
 
 _ALLOWED_TRANSITIONS = {
     LifecycleStatus.CREATED: {
@@ -58,6 +61,41 @@ _ALLOWED_TRANSITIONS = {
     LifecycleStatus.FAILED: set(),
 }
 
+PREPARED_CONTEXT_ARTIFACT_PATH = "state/prepared_context.json"
+_PREPARED_CONTEXT_ARTIFACT_SCHEMA_VERSION = "v0"
+_PREPARED_CONTEXT_FIELDS = frozenset(
+    {
+        "artifact_schema_version",
+        "monitoring_run_id",
+        "source_run_id",
+        "subject_id",
+        "timeline_id",
+        "sequence_index",
+        "baseline_source_run_id",
+        "effective_recipe",
+        "contract",
+        "references",
+    }
+)
+_PREPARED_CONTRACT_FIELDS = frozenset(
+    {
+        "contract_id",
+        "contract_version",
+        "schema_contract_ref",
+        "feature_contract_ref",
+        "metric_contract_ref",
+        "data_scope_contract_ref",
+        "execution_contract_ref",
+    }
+)
+_PREPARED_REFERENCE_FIELDS = frozenset({"kind", "monitoring_run_id", "source_run_id"})
+_REFERENCE_ORDER = {
+    DiffReferenceKind.BASELINE: 0,
+    DiffReferenceKind.PREVIOUS: 1,
+    DiffReferenceKind.LKG: 2,
+    DiffReferenceKind.CUSTOM: 3,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class BaselineResolutionResult:
@@ -77,7 +115,6 @@ class PreparedContext:
     """Resolved prepare-stage context required before contract checking.
 
     Attributes:
-        artifact_schema_version: Version of the prepared context artifact schema.
         monitoring_run_id: Stable monitoring run identifier.
         source_run_id: Resolved source training run id.
         subject_id: Stable monitored subject identifier.
@@ -89,16 +126,332 @@ class PreparedContext:
         references: Tuple of resolved monitoring run references.
     """
 
-    artifact_schema_version: str
     monitoring_run_id: str
     source_run_id: str
     subject_id: str
     timeline_id: str
     sequence_index: int
-    baseline_source_run_id: str | None
-    effective_recipe: CompiledRecipe
+    baseline_source_run_id: str
+    effective_recipe: EffectiveRecipePlan
     contract: Contract
     references: tuple[MonitoringRunReference, ...]
+
+    def __post_init__(self) -> None:
+        """Freeze the ordered resolved references after a defensive copy."""
+        object.__setattr__(self, "references", tuple(self.references))
+
+    @property
+    def recipe_id(self) -> str:
+        """Return the normalized Recipe identifier."""
+        return self.effective_recipe.identity.recipe_id
+
+    @property
+    def recipe_version(self) -> str:
+        """Return the normalized Recipe version."""
+        return self.effective_recipe.identity.recipe_version
+
+    @property
+    def contract_id(self) -> str:
+        """Return the resolved Contract identifier."""
+        return self.contract.contract_id
+
+    @property
+    def source_experiment(self) -> str | None:
+        """Return the normalized optional Source Training Run experiment filter."""
+        return self.effective_recipe.source_requirements.source_experiment
+
+    @property
+    def required_metrics(self) -> tuple[str, ...]:
+        """Return normalized required metric names."""
+        return self.effective_recipe.source_requirements.required_metric_names
+
+    @property
+    def required_artifacts(self) -> tuple[str, ...]:
+        """Return normalized required artifact paths."""
+        return self.effective_recipe.source_requirements.required_artifact_paths
+
+    @property
+    def previous_monitoring_run_id(self) -> str | None:
+        """Return the frozen previous Monitoring Run identifier, when resolved."""
+        return self._reference_monitoring_run_id(DiffReferenceKind.PREVIOUS)
+
+    @property
+    def active_lkg_monitoring_run_id(self) -> str | None:
+        """Return the frozen LKG Monitoring Run identifier, when resolved."""
+        return self._reference_monitoring_run_id(DiffReferenceKind.LKG)
+
+    @property
+    def custom_reference_monitoring_run_id(self) -> str | None:
+        """Return the frozen custom Monitoring Run identifier, when resolved."""
+        return self._reference_monitoring_run_id(DiffReferenceKind.CUSTOM)
+
+    def _reference_monitoring_run_id(self, kind: DiffReferenceKind) -> str | None:
+        """Return one resolved Monitoring Run identifier by reference kind."""
+        for reference in self.references:
+            if reference.kind is kind:
+                return reference.monitoring_run_id
+        return None
+
+
+def prepared_context_to_dict(context: PreparedContext) -> dict[str, object]:
+    """Serialize one prepared context into its canonical artifact payload.
+
+    Args:
+        context: Typed prepared context to persist.
+
+    Returns:
+        JSON-compatible prepared-context artifact content.
+    """
+    contract = context.contract
+    return {
+        "artifact_schema_version": _PREPARED_CONTEXT_ARTIFACT_SCHEMA_VERSION,
+        "monitoring_run_id": context.monitoring_run_id,
+        "source_run_id": context.source_run_id,
+        "subject_id": context.subject_id,
+        "timeline_id": context.timeline_id,
+        "sequence_index": context.sequence_index,
+        "baseline_source_run_id": context.baseline_source_run_id,
+        "effective_recipe": context.effective_recipe.to_dict(),
+        "contract": {
+            "contract_id": contract.contract_id,
+            "contract_version": contract.contract_version,
+            "schema_contract_ref": contract.schema_contract_ref,
+            "feature_contract_ref": contract.feature_contract_ref,
+            "metric_contract_ref": contract.metric_contract_ref,
+            "data_scope_contract_ref": contract.data_scope_contract_ref,
+            "execution_contract_ref": contract.execution_contract_ref,
+        },
+        "references": [reference.to_dict() for reference in context.references],
+    }
+
+
+def hydrate_prepared_context(
+    raw: Mapping[str, object] | None,
+    *,
+    compiled_recipe: CompiledRecipe,
+    monitoring_run_id: str,
+    source_run_id: str,
+    subject_id: str,
+    timeline_id: str,
+    sequence_index: int,
+) -> PreparedContext:
+    """Hydrate and validate one committed prepared-context artifact.
+
+    Args:
+        raw: Decoded prepared-context JSON object, or ``None`` when missing.
+        compiled_recipe: Caller-supplied executable Recipe whose effective plan
+            must exactly match the persisted plan.
+        monitoring_run_id: Allocated Monitoring Run identity expected in the artifact.
+        source_run_id: Immutable Source Training Run identity expected in the artifact.
+        subject_id: Subject identity expected in the artifact.
+        timeline_id: Allocated Timeline identity expected in the artifact.
+        sequence_index: Allocated Timeline sequence expected in the artifact.
+
+    Returns:
+        Typed context reconstructed without live Prepare resolution.
+
+    Raises:
+        GatewayConsistencyViolation: If the artifact is malformed or contradicts
+            the current allocation or compiled Recipe.
+    """
+    if raw is None:
+        raise _prepared_context_inconsistent(
+            reason="missing_artifact",
+            field="prepared_context",
+        )
+    _require_exact_prepared_fields(raw, _PREPARED_CONTEXT_FIELDS, section="prepared_context")
+    if raw.get("artifact_schema_version") != _PREPARED_CONTEXT_ARTIFACT_SCHEMA_VERSION:
+        raise _prepared_context_inconsistent(
+            reason="unsupported_artifact_schema_version",
+            field="artifact_schema_version",
+        )
+
+    expected_identity: tuple[tuple[str, str | int], ...] = (
+        ("monitoring_run_id", monitoring_run_id),
+        ("source_run_id", source_run_id),
+        ("subject_id", subject_id),
+        ("timeline_id", timeline_id),
+        ("sequence_index", sequence_index),
+    )
+    for field, expected in expected_identity:
+        actual = raw.get(field)
+        if isinstance(expected, int):
+            valid_type = isinstance(actual, int) and not isinstance(actual, bool)
+        else:
+            valid_type = isinstance(actual, str) and bool(actual.strip())
+        if not valid_type or actual != expected:
+            raise _prepared_context_inconsistent(
+                reason="allocation_identity_mismatch",
+                field=field,
+            )
+
+    baseline_source_run_id = _require_prepared_string(raw, "baseline_source_run_id")
+
+    effective_recipe = raw.get("effective_recipe")
+    if not isinstance(effective_recipe, Mapping):
+        raise _prepared_context_inconsistent(
+            reason="invalid_field_type",
+            field="effective_recipe",
+        )
+    if dict(effective_recipe) != compiled_recipe.effective_plan.to_dict():
+        raise _prepared_context_inconsistent(
+            reason="effective_recipe_mismatch",
+            field="effective_recipe",
+        )
+
+    contract = _hydrate_prepared_contract(raw.get("contract"))
+    expected_contract_identity = (
+        compiled_recipe.effective_plan.contract.contract_id,
+        compiled_recipe.effective_plan.contract.contract_version,
+    )
+    if (contract.contract_id, contract.contract_version) != expected_contract_identity:
+        raise _prepared_context_inconsistent(
+            reason="contract_identity_mismatch",
+            field="contract",
+        )
+
+    references = _hydrate_prepared_references(
+        raw.get("references"),
+        baseline_source_run_id=baseline_source_run_id,
+    )
+    return PreparedContext(
+        monitoring_run_id=monitoring_run_id,
+        source_run_id=source_run_id,
+        subject_id=subject_id,
+        timeline_id=timeline_id,
+        sequence_index=sequence_index,
+        baseline_source_run_id=baseline_source_run_id,
+        effective_recipe=compiled_recipe.effective_plan,
+        contract=contract,
+        references=references,
+    )
+
+
+def _hydrate_prepared_contract(raw: object) -> Contract:
+    """Hydrate the complete Contract frozen in prepared state."""
+    if not isinstance(raw, Mapping):
+        raise _prepared_context_inconsistent(reason="invalid_field_type", field="contract")
+    _require_exact_prepared_fields(raw, _PREPARED_CONTRACT_FIELDS, section="contract")
+    return Contract(
+        contract_id=_require_prepared_string(raw, "contract_id"),
+        contract_version=_require_prepared_string(raw, "contract_version"),
+        schema_contract_ref=_require_prepared_optional_string(raw, "schema_contract_ref"),
+        feature_contract_ref=_require_prepared_optional_string(raw, "feature_contract_ref"),
+        metric_contract_ref=_require_prepared_optional_string(raw, "metric_contract_ref"),
+        data_scope_contract_ref=_require_prepared_optional_string(
+            raw,
+            "data_scope_contract_ref",
+        ),
+        execution_contract_ref=_require_prepared_optional_string(raw, "execution_contract_ref"),
+    )
+
+
+def _hydrate_prepared_references(
+    raw: object,
+    *,
+    baseline_source_run_id: str,
+) -> tuple[MonitoringRunReference, ...]:
+    """Hydrate canonical resolved Monitoring Run references."""
+    if not isinstance(raw, list):
+        raise _prepared_context_inconsistent(reason="invalid_field_type", field="references")
+
+    references: list[MonitoringRunReference] = []
+    for index, item in enumerate(raw):
+        field = f"references[{index}]"
+        if not isinstance(item, Mapping):
+            raise _prepared_context_inconsistent(reason="invalid_field_type", field=field)
+        _require_exact_prepared_fields(item, _PREPARED_REFERENCE_FIELDS, section=field)
+        kind = item.get("kind")
+        monitoring_run_id = item.get("monitoring_run_id")
+        source_run_id = item.get("source_run_id")
+        if not isinstance(kind, str):
+            raise _prepared_context_inconsistent(reason="invalid_field_type", field=f"{field}.kind")
+        if monitoring_run_id is not None and not isinstance(monitoring_run_id, str):
+            raise _prepared_context_inconsistent(
+                reason="invalid_field_type",
+                field=f"{field}.monitoring_run_id",
+            )
+        if not isinstance(source_run_id, str):
+            raise _prepared_context_inconsistent(
+                reason="invalid_field_type",
+                field=f"{field}.source_run_id",
+            )
+        try:
+            reference = MonitoringRunReference(
+                kind=DiffReferenceKind(kind),
+                monitoring_run_id=monitoring_run_id,
+                source_run_id=source_run_id,
+            )
+        except ValueError as exc:
+            raise _prepared_context_inconsistent(
+                reason="invalid_reference",
+                field=field,
+            ) from exc
+        references.append(reference)
+
+    if not references or references[0] != MonitoringRunReference(
+        kind=DiffReferenceKind.BASELINE,
+        monitoring_run_id=None,
+        source_run_id=baseline_source_run_id,
+    ):
+        raise _prepared_context_inconsistent(
+            reason="baseline_reference_mismatch",
+            field="references",
+        )
+
+    reference_kinds = tuple(reference.kind for reference in references)
+    if (
+        len(reference_kinds) != len(set(reference_kinds))
+        or tuple(sorted(reference_kinds, key=_REFERENCE_ORDER.__getitem__)) != reference_kinds
+    ):
+        raise _prepared_context_inconsistent(
+            reason="noncanonical_references",
+            field="references",
+        )
+    return tuple(references)
+
+
+def _require_exact_prepared_fields(
+    raw: Mapping[str, object],
+    expected: frozenset[str],
+    *,
+    section: str,
+) -> None:
+    """Require one prepared-artifact mapping to have exactly its canonical fields."""
+    if set(raw) != expected:
+        raise _prepared_context_inconsistent(reason="invalid_fields", field=section)
+
+
+def _require_prepared_string(raw: Mapping[str, object], field: str) -> str:
+    """Return one required nonempty string from a prepared artifact mapping."""
+    value = raw.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise _prepared_context_inconsistent(reason="invalid_field_type", field=field)
+    return value
+
+
+def _require_prepared_optional_string(
+    raw: Mapping[str, object],
+    field: str,
+) -> str | None:
+    """Return one optional string from a prepared artifact mapping."""
+    value = raw.get(field)
+    if value is not None and not isinstance(value, str):
+        raise _prepared_context_inconsistent(reason="invalid_field_type", field=field)
+    return value
+
+
+def _prepared_context_inconsistent(
+    *,
+    reason: str,
+    field: str,
+) -> GatewayConsistencyViolation:
+    """Build the stable failure raised for invalid persisted prepared state."""
+    return GatewayConsistencyViolation(
+        code="prepared_context_inconsistent",
+        message="Persisted prepared context is missing, malformed, or inconsistent.",
+        details=(("reason", reason), ("field", field)),
+    )
 
 
 def transition_run(run: Run, to_status: LifecycleStatus) -> Run:
@@ -133,6 +486,7 @@ def prepare_run_context(
     compiled_recipe: CompiledRecipe,
     gateway: MonitoringGateway,
     source_run_id: str,
+    sequence_index: int,
     baseline_source_run_id: str | None = None,
     custom_reference_monitoring_run_id: str | None = None,
 ) -> PreparedContext:
@@ -144,6 +498,7 @@ def prepare_run_context(
         compiled_recipe: Execution-ready compiled Recipe.
         gateway: Gateway used for timeline and source-run reads.
         source_run_id: Invocation-owned Source Training Run identifier.
+        sequence_index: Stable allocation order within the Timeline.
         baseline_source_run_id: Optional baseline source run id used to bootstrap (pin)
             timeline baseline, or to explicitly confirm the baseline for an existing timeline.
         custom_reference_monitoring_run_id: Optional invocation-owned Monitoring
@@ -294,39 +649,85 @@ def prepare_run_context(
             details=(("subject_id", subject_id),),
         )
 
+    references = [
+        MonitoringRunReference(
+            kind=DiffReferenceKind.BASELINE,
+            monitoring_run_id=None,
+            source_run_id=timeline_state.baseline_source_run_id,
+        )
+    ]
+
     timeline_runs = gateway.list_timeline_monitoring_runs(subject_id, exclude_failed=True)
-    previous_monitoring_run_id = timeline_runs[-1].monitoring_run_id if timeline_runs else None
+    if timeline_runs:
+        previous = timeline_runs[-1]
+        references.append(
+            MonitoringRunReference(
+                kind=DiffReferenceKind.PREVIOUS,
+                monitoring_run_id=previous.monitoring_run_id,
+                source_run_id=previous.source_run_id,
+            )
+        )
+
+    active_lkg_monitoring_run_id = gateway.resolve_active_lkg_monitoring_run_id(subject_id)
+    if active_lkg_monitoring_run_id is not None:
+        references.append(
+            _hydrate_monitoring_run_reference(
+                kind=DiffReferenceKind.LKG,
+                subject_id=subject_id,
+                monitoring_run_id=active_lkg_monitoring_run_id,
+                gateway=gateway,
+            )
+        )
+
+    if custom_reference_monitoring_run_id is not None:
+        references.append(
+            _hydrate_monitoring_run_reference(
+                kind=DiffReferenceKind.CUSTOM,
+                subject_id=subject_id,
+                monitoring_run_id=custom_reference_monitoring_run_id,
+                gateway=gateway,
+            )
+        )
 
     return PreparedContext(
-        artifact_schema_version="v0",
         monitoring_run_id=monitoring_run_id,
         source_run_id=resolved_source_run_id,
         subject_id=subject_id,
         timeline_id=timeline_state.timeline_id,
-        sequence_index=0,
+        sequence_index=sequence_index,
         baseline_source_run_id=timeline_state.baseline_source_run_id,
-        effective_recipe=compiled_recipe,
+        effective_recipe=compiled_recipe.effective_plan,
         contract=compiled_recipe.contract,
-        references=,
+        references=tuple(references),
     )
 
-    # return PreparedContext(
-    #     monitoring_run_id=monitoring_run_id,
-    #     subject_id=subject_id,
-    #     recipe_id=compiled_recipe.identity.recipe_id,
-    #     recipe_version=compiled_recipe.identity.recipe_version,
-    #     contract_id=compiled_recipe.contract.contract_id,
-    #     source_experiment=compiled_recipe.source_requirements.source_experiment,
-    #     timeline_id=timeline_state.timeline_id,
-    #     baseline_source_run_id=timeline_state.baseline_source_run_id,
-    #     previous_monitoring_run_id=previous_monitoring_run_id,
-    #     active_lkg_monitoring_run_id=gateway.resolve_active_lkg_monitoring_run_id(subject_id),
-    #     custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
-    #     source_run_id=resolved_source_run_id,
-    #     contract=compiled_recipe.contract,
-    #     required_metrics=compiled_recipe.source_requirements.required_metric_names,
-    #     required_artifacts=compiled_recipe.source_requirements.required_artifact_paths,
-    # )
+
+def _hydrate_monitoring_run_reference(
+    *,
+    kind: DiffReferenceKind,
+    subject_id: str,
+    monitoring_run_id: str,
+    gateway: MonitoringGateway,
+) -> MonitoringRunReference:
+    """Freeze a complete reference pair from a resolved Monitoring Run pointer."""
+    record = gateway.get_monitoring_run(subject_id, monitoring_run_id)
+    if record is None:
+        raise GatewayConsistencyViolation(
+            code="monitoring_reference_inconsistent",
+            message=(
+                "Monitoring reference could not be hydrated for "
+                f"monitoring_run_id={monitoring_run_id!r}."
+            ),
+            details=(
+                ("kind", kind.value),
+                ("monitoring_run_id", monitoring_run_id),
+            ),
+        )
+    return MonitoringRunReference(
+        kind=kind,
+        monitoring_run_id=record.monitoring_run_id,
+        source_run_id=record.source_run_id,
+    )
 
 
 def execute_contract_check(

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -30,6 +30,7 @@ from mlflow_monitor.domain import (
     Run,
 )
 from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     GatewayConsistencyViolation,
     InvalidRunTransition,
@@ -613,7 +614,7 @@ def prepare_run_context(
             _resolved_baseline = baseline_resolution_result.baseline_source_run_id
             _existing_baseline = timeline_state.baseline_source_run_id
             raise PrepareStageError(
-                code="prepare_baseline_override_existing_timeline",
+                code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
                 message=(
                     f"Provided baseline_source_run_id={_provided_baseline!r} "
                     f"with resolved_baseline_source_run_id={_resolved_baseline!r} "
@@ -902,7 +903,7 @@ def _resolve_baseline_for_prepare(
 
         if resolved_baseline != pinned_baseline:
             raise PrepareStageError(
-                code="prepare_baseline_override_existing_timeline",
+                code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
                 message=(
                     f"Provided baseline_source_run_id={baseline_source_run_id!r} "
                     f"with resolved baseline_source_run_id={resolved_baseline!r} does not match "

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -20,7 +20,13 @@ from mlflow_monitor.contract_checker import (
     ContractChecker,
     make_contract_evaluation_context,
 )
-from mlflow_monitor.domain import Contract, ContractCheckResult, LifecycleStatus, Run
+from mlflow_monitor.domain import (
+    Contract,
+    ContractCheckResult,
+    LifecycleStatus,
+    MonitoringRunReference,
+    Run,
+)
 from mlflow_monitor.errors import (
     CheckStageError,
     InvalidRunTransition,
@@ -71,38 +77,28 @@ class PreparedContext:
     """Resolved prepare-stage context required before contract checking.
 
     Attributes:
+        artifact_schema_version: Version of the prepared context artifact schema.
         monitoring_run_id: Stable monitoring run identifier.
-        subject_id: Stable monitored subject identifier.
-        recipe_id: Stable recipe identifier.
-        recipe_version: Stable recipe version.
-        contract_id: Stable contract identifier.
-        source_experiment: Optional source experiment name.
-        timeline_id: Stable timeline identifier.
-        baseline_source_run_id: Resolved baseline source run id.
-        previous_monitoring_run_id: Resolved previous monitoring run id.
-        active_lkg_monitoring_run_id: Resolved active LKG monitoring run id.
-        custom_reference_monitoring_run_id: Resolved custom reference monitoring run id.
         source_run_id: Resolved source training run id.
+        subject_id: Stable monitored subject identifier.
+        timeline_id: Stable timeline identifier.
+        sequence_index: Sequence index within the timeline.
+        baseline_source_run_id: Resolved baseline source run id.
+        effective_recipe: Resolved effective compiled Recipe.
         contract: Resolved contract.
-        required_metrics: Sequence of required metric names.
-        required_artifacts: Sequence of required artifact names.
+        references: Tuple of resolved monitoring run references.
     """
 
+    artifact_schema_version: str
     monitoring_run_id: str
-    subject_id: str
-    recipe_id: str
-    recipe_version: str
-    contract_id: str
-    source_experiment: str | None
-    timeline_id: str
-    baseline_source_run_id: str
-    previous_monitoring_run_id: str | None
-    active_lkg_monitoring_run_id: str | None
-    custom_reference_monitoring_run_id: str | None
     source_run_id: str
+    subject_id: str
+    timeline_id: str
+    sequence_index: int
+    baseline_source_run_id: str | None
+    effective_recipe: CompiledRecipe
     contract: Contract
-    required_metrics: tuple[str, ...]
-    required_artifacts: tuple[str, ...]
+    references: tuple[MonitoringRunReference, ...]
 
 
 def transition_run(run: Run, to_status: LifecycleStatus) -> Run:
@@ -302,22 +298,35 @@ def prepare_run_context(
     previous_monitoring_run_id = timeline_runs[-1].monitoring_run_id if timeline_runs else None
 
     return PreparedContext(
+        artifact_schema_version="v0",
         monitoring_run_id=monitoring_run_id,
-        subject_id=subject_id,
-        recipe_id=compiled_recipe.identity.recipe_id,
-        recipe_version=compiled_recipe.identity.recipe_version,
-        contract_id=compiled_recipe.contract.contract_id,
-        source_experiment=compiled_recipe.source_requirements.source_experiment,
-        timeline_id=timeline_state.timeline_id,
-        baseline_source_run_id=timeline_state.baseline_source_run_id,
-        previous_monitoring_run_id=previous_monitoring_run_id,
-        active_lkg_monitoring_run_id=gateway.resolve_active_lkg_monitoring_run_id(subject_id),
-        custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
         source_run_id=resolved_source_run_id,
+        subject_id=subject_id,
+        timeline_id=timeline_state.timeline_id,
+        sequence_index=0,
+        baseline_source_run_id=timeline_state.baseline_source_run_id,
+        effective_recipe=compiled_recipe,
         contract=compiled_recipe.contract,
-        required_metrics=compiled_recipe.source_requirements.required_metric_names,
-        required_artifacts=compiled_recipe.source_requirements.required_artifact_paths,
+        references=,
     )
+
+    # return PreparedContext(
+    #     monitoring_run_id=monitoring_run_id,
+    #     subject_id=subject_id,
+    #     recipe_id=compiled_recipe.identity.recipe_id,
+    #     recipe_version=compiled_recipe.identity.recipe_version,
+    #     contract_id=compiled_recipe.contract.contract_id,
+    #     source_experiment=compiled_recipe.source_requirements.source_experiment,
+    #     timeline_id=timeline_state.timeline_id,
+    #     baseline_source_run_id=timeline_state.baseline_source_run_id,
+    #     previous_monitoring_run_id=previous_monitoring_run_id,
+    #     active_lkg_monitoring_run_id=gateway.resolve_active_lkg_monitoring_run_id(subject_id),
+    #     custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
+    #     source_run_id=resolved_source_run_id,
+    #     contract=compiled_recipe.contract,
+    #     required_metrics=compiled_recipe.source_requirements.required_metric_names,
+    #     required_artifacts=compiled_recipe.source_requirements.required_artifact_paths,
+    # )
 
 
 def execute_contract_check(

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -40,6 +40,7 @@ from mlflow_monitor.errors import (
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
 from mlflow_monitor.invariant import validate_contract_check_result
 from mlflow_monitor.recipe_compiler import CompiledRecipe, EffectiveRecipePlan
+from mlflow_monitor.utils import canonical_json
 
 _ALLOWED_TRANSITIONS = {
     LifecycleStatus.CREATED: {
@@ -294,7 +295,17 @@ def hydrate_prepared_context(
             reason="invalid_field_type",
             field="effective_recipe",
         )
-    if dict(effective_recipe) != compiled_recipe.effective_plan.to_dict():
+
+    try:
+        persisted = canonical_json(dict(effective_recipe))
+        expected = canonical_json(compiled_recipe.effective_plan.to_dict())
+    except (TypeError, ValueError) as exc:
+        raise _prepared_context_inconsistent(
+            reason="invalide_field_type",
+            field="effective_recipe",
+        ) from exc
+
+    if persisted != expected:
         raise _prepared_context_inconsistent(
             reason="effective_recipe_mismatch",
             field="effective_recipe",

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -137,7 +137,7 @@ class PreparedContext:
     references: tuple[MonitoringRunReference, ...]
 
     def __post_init__(self) -> None:
-        """Freeze the ordered resolved references after a defensive copy."""
+        """Freeze the ordered resolved references."""
         object.__setattr__(self, "references", tuple(self.references))
 
     @property

--- a/tests/integration/test_json_artifact_gateway_contract.py
+++ b/tests/integration/test_json_artifact_gateway_contract.py
@@ -26,6 +26,14 @@ class _JsonArtifactGateway(Protocol):
         """Write missing content or validate an identical existing artifact."""
         ...
 
+    def read_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        path: str,
+    ) -> dict[str, object] | None:
+        """Read exact-path content or return None when it is missing."""
+        ...
+
 
 @dataclass(frozen=True, slots=True)
 class _GatewayHarness:
@@ -100,6 +108,40 @@ def test_json_artifact_contract_writes_missing_accepts_identical_and_rejects_dif
         monitoring_run_id=monitoring_run_id,
         data=original,
         path=path,
+    )
+
+
+def test_json_artifact_contract_reads_exact_path_and_distinguishes_missing(
+    json_artifact_gateway: _GatewayHarness,
+) -> None:
+    monitoring_run_id = json_artifact_gateway.allocate("source-run-1")
+    path = "state/prepared_context.json"
+    payload = {"z": 1, "a": {"value": "prepared"}}
+
+    assert (
+        json_artifact_gateway.gateway.read_monitoring_run_json_artifact(
+            monitoring_run_id,
+            path,
+        )
+        is None
+    )
+
+    json_artifact_gateway.gateway.write_monitoring_run_json_artifact(
+        monitoring_run_id=monitoring_run_id,
+        data=payload,
+        path=path,
+    )
+
+    assert json_artifact_gateway.gateway.read_monitoring_run_json_artifact(
+        monitoring_run_id,
+        path,
+    ) == {"a": {"value": "prepared"}, "z": 1}
+    assert (
+        json_artifact_gateway.gateway.read_monitoring_run_json_artifact(
+            monitoring_run_id,
+            "outputs/prepared_context.json",
+        )
+        is None
     )
 
 

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -22,6 +22,7 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
     MonitoringRunReference,
 )
+from mlflow_monitor.errors import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.orchestration import run_orchestration
@@ -975,7 +976,7 @@ def test_mlflow_gateway_baseline_immutability_rejection(
     assert second.lifecycle_status is LifecycleStatus.FAILED
     assert second.comparability_status is None
     assert second.error is not None
-    assert second.error.code == "prepare_baseline_override_existing_timeline"
+    assert second.error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert dict(experiment_after.tags) == experiment_tags_before
     assert experiment_after.tags["training.baseline_run_id"] == baseline_run_id
     assert monitoring_run_before.info.status == "FINISHED"

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -61,6 +61,18 @@ class ExplodingContractChecker:
         raise AssertionError("idempotent replay must not re-run check")
 
 
+class InterruptingContractChecker:
+    """Simulate process interruption after Prepare commits and before Check."""
+
+    def check(
+        self,
+        contract: Contract,
+        context: ContractEvaluationContext,
+    ) -> ContractCheckResult:
+        _ = (contract, context)
+        raise RuntimeError("simulated interruption during check")
+
+
 def test_mlflow_gateway_repairs_zero_tag_orphan_before_next_allocation(
     tracking_uri: str,
     artifact_root_uri: str,
@@ -306,6 +318,80 @@ def test_mlflow_gateway_checked_replay_repairs_incomplete_terminal_finalization(
     assert payload["monitoring_run_id"] == monitoring_run_id
     assert payload["lifecycle_status"] == "checked"
     assert payload["comparability_status"] == "pass"
+
+
+def test_mlflow_gateway_replays_prepared_context_after_check_interruption(
+    tracking_uri: str,
+    artifact_root_uri: str,
+    create_training_run: Callable[..., str],
+) -> None:
+    raw = MlflowClient(tracking_uri=tracking_uri)
+    baseline_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="baseline",
+        metrics={"f1": 0.87},
+        params={"feature_columns": "age"},
+        tags={
+            "python_version": "3.12",
+            "schema.age": "int",
+            "data_scope": "validation:2026-03-01",
+        },
+    )
+    current_run_id = create_training_run(
+        raw=raw,
+        experiment_name="training/churn",
+        artifact_root_uri=artifact_root_uri,
+        run_name="current",
+        metrics={"f1": 0.91},
+        params={"feature_columns": "age"},
+        tags={
+            "python_version": "3.12",
+            "schema.age": "int",
+            "data_scope": "validation:2026-03-01",
+        },
+    )
+    gateway = MLflowMonitoringGateway(
+        GatewayConfig(),
+        tracking_uri=tracking_uri,
+        artifact_location=artifact_root_uri,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated interruption during check"):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id=current_run_id,
+            baseline_source_run_id=baseline_run_id,
+            gateway=gateway,
+            contract_checker=InterruptingContractChecker(),
+        )
+
+    experiment = raw.get_experiment_by_name("mlflow_monitor/churn_model")
+    assert experiment is not None
+    monitoring_run_id = experiment.tags[f"training.{current_run_id}.monitoring_run_id"]
+    prepared_run = raw.get_run(monitoring_run_id)
+    assert prepared_run.data.tags["monitoring.lifecycle_status"] == "prepared"
+    prepared_path = Path(raw.download_artifacts(monitoring_run_id, "state/prepared_context.json"))
+    prepared_payload = json.loads(prepared_path.read_text())
+    assert prepared_payload["monitoring_run_id"] == monitoring_run_id
+    assert prepared_payload["source_run_id"] == current_run_id
+
+    replay_gateway = MLflowMonitoringGateway(
+        GatewayConfig(),
+        tracking_uri=tracking_uri,
+        artifact_location=artifact_root_uri,
+    )
+    replay = run_orchestration(
+        subject_id="churn_model",
+        source_run_id=current_run_id,
+        baseline_source_run_id=None,
+        gateway=replay_gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    assert replay.monitoring_run_id == monitoring_run_id
+    assert replay.lifecycle_status is LifecycleStatus.CHECKED
 
 
 def test_mlflow_gateway_reuses_baseline_resolves_previous_and_idempotent_rerun(

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -18,6 +18,7 @@ from mlflow_monitor.domain import (
     ComparabilityStatus,
     Contract,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
 )
@@ -214,7 +215,7 @@ def test_mlflow_gateway_first_run_bootstraps_and_finalizes_result(
     assert result.timeline_id == experiment.experiment_id
     assert result.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id=baseline_run_id,
         ),
@@ -471,12 +472,12 @@ def test_mlflow_gateway_reuses_baseline_resolves_previous_and_idempotent_rerun(
     assert experiment is not None
     assert second.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id=baseline_run_id,
         ),
         MonitoringRunReference(
-            kind="previous",
+            kind=DiffReferenceKind.PREVIOUS,
             monitoring_run_id=first.monitoring_run_id,
             source_run_id=first_current_run_id,
         ),

--- a/tests/integration/test_monitor_api.py
+++ b/tests/integration/test_monitor_api.py
@@ -10,7 +10,12 @@ import pytest
 from mlflow import MlflowClient
 
 from mlflow_monitor import monitor
-from mlflow_monitor.domain import ComparabilityStatus, LifecycleStatus, MonitoringRunReference
+from mlflow_monitor.domain import (
+    ComparabilityStatus,
+    DiffReferenceKind,
+    LifecycleStatus,
+    MonitoringRunReference,
+)
 from mlflow_monitor.recipe import build_system_default_recipe
 from mlflow_monitor.recipe_compiler import compile_recipe
 
@@ -69,7 +74,7 @@ def test_monitor_run_defaults_to_real_mlflow_gateway(
     assert result.comparability_status is ComparabilityStatus.PASS
     assert result.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id=baseline_run_id,
         ),
@@ -114,7 +119,7 @@ def test_monitor_run_defaults_to_real_mlflow_gateway(
         },
         "references": [
             {
-                "kind": "baseline",
+                "kind": DiffReferenceKind.BASELINE,
                 "monitoring_run_id": None,
                 "source_run_id": baseline_run_id,
             }

--- a/tests/integration/test_monitor_api.py
+++ b/tests/integration/test_monitor_api.py
@@ -84,6 +84,43 @@ def test_monitor_run_defaults_to_real_mlflow_gateway(
     assert payload["monitoring_run_id"] == result.monitoring_run_id
     assert payload["lifecycle_status"] == "checked"
 
+    prepared_path = Path(
+        raw.download_artifacts(
+            result.monitoring_run_id,
+            "state/prepared_context.json",
+        )
+    )
+    prepared_payload = json.loads(prepared_path.read_text())
+    compiled_recipe = compile_recipe()
+    contract = compiled_recipe.contract
+
+    assert prepared_payload == {
+        "artifact_schema_version": "v0",
+        "monitoring_run_id": result.monitoring_run_id,
+        "source_run_id": current_run_id,
+        "subject_id": "churn_model",
+        "timeline_id": experiment.experiment_id,
+        "sequence_index": 0,
+        "baseline_source_run_id": baseline_run_id,
+        "effective_recipe": compiled_recipe.effective_plan.to_dict(),
+        "contract": {
+            "contract_id": contract.contract_id,
+            "contract_version": contract.version,
+            "schema_contract_ref": contract.schema_contract_ref,
+            "feature_contract_ref": contract.feature_contract_ref,
+            "metric_contract_ref": contract.metric_contract_ref,
+            "data_scope_contract_ref": contract.data_scope_contract_ref,
+            "execution_contract_ref": contract.execution_contract_ref,
+        },
+        "references": [
+            {
+                "kind": "baseline",
+                "monitoring_run_id": None,
+                "source_run_id": baseline_run_id,
+            }
+        ],
+    }
+
 
 def test_monitor_run_warn_outcome_via_environment_mismatch(
     tracking_uri: str,

--- a/tests/integration/test_monitor_api.py
+++ b/tests/integration/test_monitor_api.py
@@ -105,7 +105,7 @@ def test_monitor_run_defaults_to_real_mlflow_gateway(
         "effective_recipe": compiled_recipe.effective_plan.to_dict(),
         "contract": {
             "contract_id": contract.contract_id,
-            "contract_version": contract.version,
+            "contract_version": contract.contract_version,
             "schema_contract_ref": contract.schema_contract_ref,
             "feature_contract_ref": contract.feature_contract_ref,
             "metric_contract_ref": contract.metric_contract_ref,

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -18,7 +18,7 @@ from mlflow_monitor.errors import ContractResolutionError
 
 system_default_permissive_contract = Contract(
     contract_id=SYSTEM_DEFAULT_CONTRACT_ID,
-    version="v0",
+    contract_version="v0",
     schema_contract_ref=SYSTEM_DEFAULT_SCHEMA_CONTRACT_REF,
     feature_contract_ref=SYSTEM_DEFAULT_FEATURE_CONTRACT_REF,
     metric_contract_ref=None,
@@ -33,7 +33,7 @@ def test_resolve_contract_v0_returns_default_permissive_contract() -> None:
 
     assert resolved == system_default_permissive_contract
     assert resolved.contract_id == SYSTEM_DEFAULT_CONTRACT_ID
-    assert resolved.version == "v0"
+    assert resolved.contract_version == "v0"
     assert resolved.schema_contract_ref is not None
     assert resolved.feature_contract_ref is not None
     assert resolved.data_scope_contract_ref is not None
@@ -57,7 +57,7 @@ def test_parse_contract_v0_rejects_non_string_optional_ref() -> None:
         parse_contract_v0(
             {
                 "contract_id": SYSTEM_DEFAULT_CONTRACT_ID,
-                "version": "v0",
+                "contract_version": "v0",
                 "schema_contract_ref": "schema",
                 "feature_contract_ref": "feature",
                 "metric_contract_ref": None,

--- a/tests/test_contract_checker.py
+++ b/tests/test_contract_checker.py
@@ -18,7 +18,7 @@ from mlflow_monitor.domain import (
 
 CONTRACT = Contract(
     contract_id="default",
-    version="v0",
+    contract_version="v0",
     schema_contract_ref=None,
     feature_contract_ref=None,
     metric_contract_ref=None,
@@ -111,7 +111,7 @@ def test_default_contract_checker_returns_pass_when_no_checks_are_enabled() -> N
     """Concrete checker should pass when the contract enables no checks."""
     contract = Contract(
         contract_id="default_permissive",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,
@@ -150,7 +150,7 @@ def test_default_contract_checker_warns_for_execution_environment_mismatch() -> 
     """Concrete checker should warn when execution checking is enabled and env differs."""
     contract = Contract(
         contract_id="env_repro",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,
@@ -195,7 +195,7 @@ def test_default_contract_checker_fails_for_schema_mismatch() -> None:
     """Concrete checker should fail when schema checking is enabled and schema differs."""
     contract = Contract(
         contract_id="schema_exact",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref="builtin:schema_exact",
         feature_contract_ref=None,
         metric_contract_ref=None,
@@ -240,7 +240,7 @@ def test_default_contract_checker_fails_for_feature_mismatch() -> None:
     """Concrete checker should fail when feature checking is enabled and features differ."""
     contract = Contract(
         contract_id="feature_exact",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref="builtin:feature_exact",
         metric_contract_ref=None,
@@ -285,7 +285,7 @@ def test_default_contract_checker_fails_for_data_scope_mismatch() -> None:
     """Concrete checker should fail when data-scope checking is enabled and scope differs."""
     contract = Contract(
         contract_id="data_scope_exact",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,
@@ -330,7 +330,7 @@ def test_default_contract_checker_fails_when_blocking_and_warning_reasons_coexis
     """Concrete checker should fail when any blocking reason exists."""
     contract = Contract(
         contract_id="env_and_schema_exact",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref="builtin:schema_exact",
         feature_contract_ref=None,
         metric_contract_ref=None,
@@ -380,7 +380,7 @@ def test_default_contract_checker_ignores_metric_differences_for_deferred_metric
     """Concrete checker should not emit metric mismatch reasons in D-004D."""
     contract = Contract(
         contract_id="metric_exact_deferred",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref="builtin:metric_exact",
@@ -419,7 +419,7 @@ def test_default_contract_checker_emits_reasons_in_deterministic_dimension_order
     """Concrete checker should preserve a stable reason ordering across dimensions."""
     contract = Contract(
         contract_id="all_dimensions",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref="builtin:schema_exact",
         feature_contract_ref="builtin:feature_exact",
         metric_contract_ref="builtin:metric_exact",
@@ -479,7 +479,7 @@ def test_default_contract_checker_returns_pass_when_enabled_checks_match() -> No
     """Concrete checker should pass when enabled checks find no mismatches."""
     contract = Contract(
         contract_id="env_repro",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -26,7 +26,7 @@ def test_canonical_entities_can_be_constructed() -> None:
     """Test that domain entities can be constructed with expected fields and types."""
     contract = Contract(
         contract_id="default",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,
@@ -141,7 +141,7 @@ def test_relationship_shapes_match_cast() -> None:
     """Test that related entities can be associated with correct field types."""
     contract = Contract(
         contract_id="default",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,

--- a/tests/test_finding_policy.py
+++ b/tests/test_finding_policy.py
@@ -31,6 +31,8 @@ class _ExamplePolicy:
         parameters: Mapping[str, JSONValue],
     ) -> FrozenFindingPolicyParameters:
         threshold = parameters.get("threshold", 0.05)
+        if not isinstance(threshold, (int, float)):
+            raise TypeError("threshold must be a number")
         return MappingProxyType({"threshold": threshold})
 
     def evaluate(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -7,6 +7,7 @@ from mlflow_monitor.domain import (
     ComparabilityStatus,
     ContractCheckReason,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
 )
@@ -69,7 +70,8 @@ def test_create_or_reuse_result_requires_nonempty_timeline_id(
         CreateOrReuseMonitoringRunResult(
             monitoring_run_id="monitoring-run-1",
             source_run_id="train-run-1",
-            timeline_id=timeline_id,
+            # delibrately passing null
+            timeline_id=timeline_id,  # pyright: ignore[reportArgumentType]
             sequence_index=0,
             existing_monitoring_run=None,
             allocated=True,
@@ -639,12 +641,12 @@ def test_upsert_monitoring_run_stores_references() -> None:
         contract_check_result=result,
         references=(
             MonitoringRunReference(
-                kind="baseline",
+                kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id="train-run-baseline",
             ),
             MonitoringRunReference(
-                kind="lkg",
+                kind=DiffReferenceKind.LKG,
                 monitoring_run_id="monitoring-run-lkg",
                 source_run_id="train-run-lkg",
             ),
@@ -657,12 +659,12 @@ def test_upsert_monitoring_run_stores_references() -> None:
     assert stored.source_run_id == "train-run-1"
     assert stored.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
         MonitoringRunReference(
-            kind="lkg",
+            kind=DiffReferenceKind.LKG,
             monitoring_run_id="monitoring-run-lkg",
             source_run_id="train-run-lkg",
         ),
@@ -725,7 +727,7 @@ def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
             sequence_index=1,
             references=(
                 MonitoringRunReference(
-                    kind="previous",
+                    kind=DiffReferenceKind.PREVIOUS,
                     monitoring_run_id="monitoring-run-previous",
                     source_run_id="train-run-claimed-reference",
                 ),
@@ -762,12 +764,12 @@ def test_upsert_monitoring_run_preserves_check_outputs_when_only_lifecycle_statu
         contract_check_result=result,
         references=(
             MonitoringRunReference(
-                kind="baseline",
+                kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id="train-run-baseline",
             ),
             MonitoringRunReference(
-                kind="lkg",
+                kind=DiffReferenceKind.LKG,
                 monitoring_run_id="monitoring-run-lkg",
                 source_run_id="train-run-lkg",
             ),
@@ -790,12 +792,12 @@ def test_upsert_monitoring_run_preserves_check_outputs_when_only_lifecycle_statu
     assert stored.contract_check_result == result
     assert stored.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
         MonitoringRunReference(
-            kind="lkg",
+            kind=DiffReferenceKind.LKG,
             monitoring_run_id="monitoring-run-lkg",
             source_run_id="train-run-lkg",
         ),

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -21,7 +21,7 @@ from mlflow_monitor.invariant import (
 
 CONTRACT = Contract(
     contract_id="default",
-    version="v0",
+    contract_version="v0",
     schema_contract_ref=None,
     feature_contract_ref=None,
     metric_contract_ref=None,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -14,6 +14,7 @@ from mlflow_monitor.domain import (
     ComparabilityStatus,
     ContractCheckReason,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
 )
@@ -476,7 +477,7 @@ def test_run_orchestration_first_run_persists_checked_state() -> None:
     assert result.timeline_id == "timeline-churn_model"
     assert result.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
@@ -530,22 +531,22 @@ def test_run_orchestration_persists_complete_prepared_context() -> None:
 
     expected_references = (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
         MonitoringRunReference(
-            kind="previous",
+            kind=DiffReferenceKind.PREVIOUS,
             monitoring_run_id=first.monitoring_run_id,
             source_run_id="train-run-current",
         ),
         MonitoringRunReference(
-            kind="lkg",
+            kind=DiffReferenceKind.LKG,
             monitoring_run_id=first.monitoring_run_id,
             source_run_id="train-run-current",
         ),
         MonitoringRunReference(
-            kind="custom",
+            kind=DiffReferenceKind.CUSTOM,
             monitoring_run_id=first.monitoring_run_id,
             source_run_id="train-run-current",
         ),
@@ -833,12 +834,12 @@ def test_run_orchestration_later_run_can_omit_baseline_source_run_id() -> None:
     assert second.lifecycle_status is LifecycleStatus.CHECKED
     assert second.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
         MonitoringRunReference(
-            kind="previous",
+            kind=DiffReferenceKind.PREVIOUS,
             monitoring_run_id=first.monitoring_run_id,
             source_run_id="train-run-current",
         ),
@@ -1301,7 +1302,7 @@ def test_run_orchestration_checked_rerun_omitting_baseline_replays_result() -> N
     assert second.comparability_status is ComparabilityStatus.PASS
     assert second.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
@@ -1337,12 +1338,12 @@ def test_run_orchestration_checked_rerun_preserves_references() -> None:
 
     assert first.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
         MonitoringRunReference(
-            kind="lkg",
+            kind=DiffReferenceKind.LKG,
             monitoring_run_id="monitoring-run-lkg",
             source_run_id="train-run-lkg",
         ),
@@ -1610,7 +1611,8 @@ def test_public_run_rejects_uncompiled_recipe_without_allocating(recipe_input: o
             subject_id="churn_model",
             source_run_id="train-run-current",
             baseline_source_run_id="train-run-baseline",
-            recipe=recipe_input,
+            # delibrately passing wrong type for test
+            recipe=recipe_input,  # pyright: ignore[reportArgumentType]
             gateway=gateway,
         )
 
@@ -1649,17 +1651,17 @@ def test_public_run_adds_invocation_owned_custom_reference() -> None:
     assert result.lifecycle_status is LifecycleStatus.CHECKED
     assert result.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-baseline",
         ),
         MonitoringRunReference(
-            kind="previous",
+            kind=DiffReferenceKind.PREVIOUS,
             monitoring_run_id=reference_allocation.monitoring_run_id,
             source_run_id="train-run-reference",
         ),
         MonitoringRunReference(
-            kind="custom",
+            kind=DiffReferenceKind.CUSTOM,
             monitoring_run_id=reference_allocation.monitoring_run_id,
             source_run_id="train-run-reference",
         ),

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -18,7 +18,10 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
     MonitoringRunReference,
 )
-from mlflow_monitor.errors import GatewayConsistencyViolation
+from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    GatewayConsistencyViolation,
+)
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
     GatewayConfig,
@@ -1486,7 +1489,7 @@ def test_run_orchestration_rejects_baseline_override_on_checked_idempotent_rerun
     assert second.comparability_status is None
     assert second.error is not None
     assert second.error.stage == "prepare"
-    assert second.error.code == "prepare_baseline_override_existing_timeline"
+    assert second.error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert stored is not None
     assert stored.lifecycle_status is LifecycleStatus.CHECKED
     assert stored.contract_check_result is not None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Protocol, cast
 
 import pytest
 
@@ -28,6 +29,33 @@ from mlflow_monitor.orchestration import run_orchestration
 from mlflow_monitor.recipe import SYSTEM_DEFAULT_RECIPE_VERSION, build_system_default_recipe
 from mlflow_monitor.recipe_compiler import CompiledRecipe, ComponentRegistry, compile_recipe
 from mlflow_monitor.result_contract import MonitorRunResult
+from mlflow_monitor.utils import canonical_json
+
+_PREPARED_CONTEXT_PATH = "state/prepared_context.json"
+_USE_STORED_PREPARED_CONTEXT = object()
+
+
+class _ReadablePreparedContextGateway(Protocol):
+    """Test-facing Gateway contract for prepared-context hydration."""
+
+    def read_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        path: str,
+    ) -> dict[str, object] | None:
+        """Read one exact-path Monitoring Run JSON artifact."""
+        ...
+
+
+def read_prepared_context(
+    gateway: InMemoryMonitoringGateway,
+    monitoring_run_id: str,
+) -> dict[str, object] | None:
+    """Read the persisted prepared context through the planned Gateway API."""
+    return cast(_ReadablePreparedContextGateway, gateway).read_monitoring_run_json_artifact(
+        monitoring_run_id,
+        _PREPARED_CONTEXT_PATH,
+    )
 
 
 def add_default_source_runs(gateway: InMemoryMonitoringGateway) -> None:
@@ -78,6 +106,38 @@ def make_compiled_recipe(
     if metric_names is not None:
         raw["analysis"] = {"metric_names": metric_names}
     return compile_recipe(raw)
+
+
+def expected_prepared_context_payload(
+    *,
+    monitoring_run_id: str,
+    source_run_id: str,
+    sequence_index: int,
+    compiled_recipe: CompiledRecipe,
+    references: tuple[MonitoringRunReference, ...],
+) -> dict[str, object]:
+    """Build the complete V0-012 prepared-context artifact contract."""
+    contract = compiled_recipe.contract
+    return {
+        "artifact_schema_version": "v0",
+        "monitoring_run_id": monitoring_run_id,
+        "source_run_id": source_run_id,
+        "subject_id": "churn_model",
+        "timeline_id": "timeline-churn_model",
+        "sequence_index": sequence_index,
+        "baseline_source_run_id": "train-run-baseline",
+        "effective_recipe": compiled_recipe.effective_plan.to_dict(),
+        "contract": {
+            "contract_id": contract.contract_id,
+            "contract_version": contract.version,
+            "schema_contract_ref": contract.schema_contract_ref,
+            "feature_contract_ref": contract.feature_contract_ref,
+            "metric_contract_ref": contract.metric_contract_ref,
+            "data_scope_contract_ref": contract.data_scope_contract_ref,
+            "execution_contract_ref": contract.execution_contract_ref,
+        },
+        "references": [reference.to_dict() for reference in references],
+    }
 
 
 class InvalidResultContractChecker:
@@ -241,6 +301,163 @@ class RecordingAllocationGateway(InMemoryMonitoringGateway):
         return super().create_or_reuse_monitoring_run(key)
 
 
+class RecordingPreparedCommitGateway(InMemoryMonitoringGateway):
+    """Record prepared artifact and lifecycle writes in call order."""
+
+    def __init__(self, config: GatewayConfig) -> None:
+        super().__init__(config)
+        self.persistence_events: list[tuple[str, object]] = []
+
+    def write_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        data: dict[str, object],
+        path: str,
+    ) -> None:
+        super().write_monitoring_run_json_artifact(monitoring_run_id, data, path)
+        self.persistence_events.append(("artifact", path))
+
+    def upsert_monitoring_run(
+        self,
+        subject_id: str,
+        monitoring_run_id: str,
+        source_run_id: str,
+        lifecycle_status: LifecycleStatus,
+        sequence_index: int,
+        contract_check_result: ContractCheckResult | None = None,
+        references: tuple[MonitoringRunReference, ...] | None = None,
+    ) -> None:
+        super().upsert_monitoring_run(
+            subject_id=subject_id,
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            lifecycle_status=lifecycle_status,
+            sequence_index=sequence_index,
+            contract_check_result=contract_check_result,
+            references=references,
+        )
+        self.persistence_events.append(("lifecycle", lifecycle_status))
+
+
+class InterruptPreparedCommitGateway(InMemoryMonitoringGateway):
+    """Interrupt once after Prepare should have written its artifact."""
+
+    def __init__(self, config: GatewayConfig) -> None:
+        super().__init__(config)
+        self.last_allocation: CreateOrReuseMonitoringRunResult | None = None
+        self._interrupt_prepared_commit = True
+
+    def create_or_reuse_monitoring_run(
+        self, key: IdempotencyKey
+    ) -> CreateOrReuseMonitoringRunResult:
+        result = super().create_or_reuse_monitoring_run(key)
+        self.last_allocation = result
+        return result
+
+    def upsert_monitoring_run(
+        self,
+        subject_id: str,
+        monitoring_run_id: str,
+        source_run_id: str,
+        lifecycle_status: LifecycleStatus,
+        sequence_index: int,
+        contract_check_result: ContractCheckResult | None = None,
+        references: tuple[MonitoringRunReference, ...] | None = None,
+    ) -> None:
+        if lifecycle_status is LifecycleStatus.PREPARED and self._interrupt_prepared_commit:
+            self._interrupt_prepared_commit = False
+            raise RuntimeError("simulated interruption before prepared commit")
+        super().upsert_monitoring_run(
+            subject_id=subject_id,
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            lifecycle_status=lifecycle_status,
+            sequence_index=sequence_index,
+            contract_check_result=contract_check_result,
+            references=references,
+        )
+
+    def replace_prepared_context_for_test(self, data: dict[str, object]) -> None:
+        """Replace the partial artifact to simulate contradictory persisted content."""
+        assert self.last_allocation is not None
+        self._monitoring_runs_artifact_store[
+            (self.last_allocation.monitoring_run_id, _PREPARED_CONTEXT_PATH)
+        ] = canonical_json(data)
+
+
+class PreparedReplayGateway(InMemoryMonitoringGateway):
+    """Control prepared-context reads and reject live Prepare resolution on replay."""
+
+    def __init__(self, config: GatewayConfig) -> None:
+        super().__init__(config)
+        self.block_prepare_resolution = False
+        self.prepared_context_override: object = _USE_STORED_PREPARED_CONTEXT
+        self.corrupt_timeline_id = False
+        self.last_allocation: CreateOrReuseMonitoringRunResult | None = None
+        self._allocation_in_progress = False
+
+    def create_or_reuse_monitoring_run(
+        self, key: IdempotencyKey
+    ) -> CreateOrReuseMonitoringRunResult:
+        self._allocation_in_progress = True
+        try:
+            result = super().create_or_reuse_monitoring_run(key)
+        finally:
+            self._allocation_in_progress = False
+        self.last_allocation = result
+        return result
+
+    def get_timeline_state(self, subject_id: str) -> TimelineState | None:
+        if self.block_prepare_resolution and not self._allocation_in_progress:
+            raise AssertionError("prepared replay must not reload Timeline state")
+        return super().get_timeline_state(subject_id)
+
+    def read_monitoring_run_json_artifact(
+        self,
+        monitoring_run_id: str,
+        path: str,
+    ) -> dict[str, object] | None:
+        if (
+            path == _PREPARED_CONTEXT_PATH
+            and self.prepared_context_override is not _USE_STORED_PREPARED_CONTEXT
+        ):
+            if self.prepared_context_override is None:
+                return None
+            return cast(dict[str, object], self.prepared_context_override)
+
+        reader = cast(_ReadablePreparedContextGateway, super())
+        artifact = reader.read_monitoring_run_json_artifact(monitoring_run_id, path)
+        if artifact is None or path != _PREPARED_CONTEXT_PATH or not self.corrupt_timeline_id:
+            return artifact
+        corrupted = dict(artifact)
+        corrupted["timeline_id"] = "timeline-other"
+        return corrupted
+
+
+def leave_monitoring_run_prepared(
+    gateway: PreparedReplayGateway,
+    *,
+    recipe: CompiledRecipe | None = None,
+) -> str:
+    """Interrupt Check after Prepare has committed and return its Monitoring Run ID."""
+    with pytest.raises(RuntimeError, match="checker exploded"):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id="train-run-baseline",
+            recipe=recipe,
+            gateway=gateway,
+            contract_checker=RaisingContractChecker(),
+        )
+
+    assert gateway.last_allocation is not None
+    monitoring_run_id = gateway.last_allocation.monitoring_run_id
+    stored = gateway.get_monitoring_run("churn_model", monitoring_run_id)
+    assert stored is not None
+    assert stored.lifecycle_status is LifecycleStatus.PREPARED
+    return monitoring_run_id
+
+
 def test_run_orchestration_first_run_persists_checked_state() -> None:
     gateway = make_gateway()
 
@@ -275,6 +492,251 @@ def test_run_orchestration_first_run_persists_checked_state() -> None:
     assert stored.comparability_status is ComparabilityStatus.PASS
     assert stored.contract_check_result is not None
     assert stored.contract_check_result.status is ComparabilityStatus.PASS
+
+
+def test_run_orchestration_persists_complete_prepared_context() -> None:
+    gateway = make_gateway()
+    compiled_recipe = make_compiled_recipe(metric_names=["f1"])
+    first = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        recipe=compiled_recipe,
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+    gateway.set_active_lkg_monitoring_run_id("churn_model", first.monitoring_run_id)
+    gateway.add_source_run(
+        subject_id="churn_model",
+        source_run_id="train-run-next",
+        source_experiment=None,
+        metrics={"f1": 0.92},
+        artifacts=("metrics.json",),
+        environment={"python": "3.12"},
+        features=("age",),
+        schema={"age": "int"},
+        data_scope="validation:2026-03-02",
+    )
+
+    second = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-next",
+        baseline_source_run_id=None,
+        custom_reference_monitoring_run_id=first.monitoring_run_id,
+        recipe=compiled_recipe,
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    expected_references = (
+        MonitoringRunReference(
+            kind="baseline",
+            monitoring_run_id=None,
+            source_run_id="train-run-baseline",
+        ),
+        MonitoringRunReference(
+            kind="previous",
+            monitoring_run_id=first.monitoring_run_id,
+            source_run_id="train-run-current",
+        ),
+        MonitoringRunReference(
+            kind="lkg",
+            monitoring_run_id=first.monitoring_run_id,
+            source_run_id="train-run-current",
+        ),
+        MonitoringRunReference(
+            kind="custom",
+            monitoring_run_id=first.monitoring_run_id,
+            source_run_id="train-run-current",
+        ),
+    )
+    assert read_prepared_context(gateway, second.monitoring_run_id) == (
+        expected_prepared_context_payload(
+            monitoring_run_id=second.monitoring_run_id,
+            source_run_id="train-run-next",
+            sequence_index=1,
+            compiled_recipe=compiled_recipe,
+            references=expected_references,
+        )
+    )
+
+
+def test_prepare_writes_context_before_prepared_lifecycle_marker() -> None:
+    gateway = RecordingPreparedCommitGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+
+    run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id="train-run-baseline",
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    artifact_index = gateway.persistence_events.index(("artifact", _PREPARED_CONTEXT_PATH))
+    prepared_index = gateway.persistence_events.index(("lifecycle", LifecycleStatus.PREPARED))
+    assert artifact_index < prepared_index
+
+
+def test_created_replay_reuses_identical_partial_prepared_context() -> None:
+    gateway = InterruptPreparedCommitGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+
+    with pytest.raises(RuntimeError, match="simulated interruption before prepared commit"):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id="train-run-baseline",
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    assert gateway.last_allocation is not None
+    monitoring_run_id = gateway.last_allocation.monitoring_run_id
+    stored = gateway.get_monitoring_run("churn_model", monitoring_run_id)
+    assert stored is not None
+    assert stored.lifecycle_status is LifecycleStatus.CREATED
+    assert read_prepared_context(gateway, monitoring_run_id) is not None
+
+    replay = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id=None,
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    assert replay.monitoring_run_id == monitoring_run_id
+    assert replay.lifecycle_status is LifecycleStatus.CHECKED
+
+
+def test_created_replay_rejects_conflicting_partial_prepared_context() -> None:
+    gateway = InterruptPreparedCommitGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+
+    with pytest.raises(RuntimeError, match="simulated interruption before prepared commit"):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id="train-run-baseline",
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    gateway.replace_prepared_context_for_test(
+        {
+            "artifact_schema_version": "v0",
+            "monitoring_run_id": "contradictory-monitoring-run",
+            "source_run_id": "train-run-current",
+        }
+    )
+
+    with pytest.raises(GatewayConsistencyViolation):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id=None,
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    assert gateway.last_allocation is not None
+    stored = gateway.get_monitoring_run(
+        "churn_model",
+        gateway.last_allocation.monitoring_run_id,
+    )
+    assert stored is not None
+    assert stored.lifecycle_status is LifecycleStatus.CREATED
+
+
+def test_prepared_replay_hydrates_context_without_prepare_resolution() -> None:
+    gateway = PreparedReplayGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    monitoring_run_id = leave_monitoring_run_prepared(gateway)
+    gateway.block_prepare_resolution = True
+
+    replay = run_orchestration(
+        subject_id="churn_model",
+        source_run_id="train-run-current",
+        baseline_source_run_id=None,
+        gateway=gateway,
+        contract_checker=DefaultContractChecker(),
+    )
+
+    assert replay.monitoring_run_id == monitoring_run_id
+    assert replay.lifecycle_status is LifecycleStatus.CHECKED
+
+
+def test_prepared_replay_rejects_missing_prepared_context() -> None:
+    gateway = PreparedReplayGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    leave_monitoring_run_prepared(gateway)
+    gateway.prepared_context_override = None
+
+    with pytest.raises(GatewayConsistencyViolation):
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id=None,
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+
+def test_prepared_replay_rejects_malformed_prepared_context() -> None:
+    gateway = PreparedReplayGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    leave_monitoring_run_prepared(gateway)
+    gateway.prepared_context_override = {"artifact_schema_version": "v0"}
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id=None,
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    assert exc_info.value.code == "prepared_context_inconsistent"
+
+
+def test_prepared_replay_rejects_conflicting_persisted_identity() -> None:
+    gateway = PreparedReplayGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    leave_monitoring_run_prepared(gateway)
+    gateway.corrupt_timeline_id = True
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id=None,
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    assert exc_info.value.code == "prepared_context_inconsistent"
+
+
+def test_prepared_replay_rejects_different_effective_plan_for_same_recipe_identity() -> None:
+    gateway = PreparedReplayGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    first_recipe = make_compiled_recipe(metric_names=[])
+    second_recipe = make_compiled_recipe(metric_names=["f1"])
+    leave_monitoring_run_prepared(gateway, recipe=first_recipe)
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id=None,
+            recipe=second_recipe,
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    assert exc_info.value.code == "prepared_context_inconsistent"
 
 
 def test_run_orchestration_upserts_created_when_allocation_exists_without_run_record() -> None:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -129,7 +129,7 @@ def expected_prepared_context_payload(
         "effective_recipe": compiled_recipe.effective_plan.to_dict(),
         "contract": {
             "contract_id": contract.contract_id,
-            "contract_version": contract.version,
+            "contract_version": contract.contract_version,
             "schema_contract_ref": contract.schema_contract_ref,
             "feature_contract_ref": contract.feature_contract_ref,
             "metric_contract_ref": contract.metric_contract_ref,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -719,6 +719,33 @@ def test_prepared_replay_rejects_conflicting_persisted_identity() -> None:
     assert exc_info.value.code == "prepared_context_inconsistent"
 
 
+def test_prepared_replay_rejects_changed_contract_definition_for_same_identity() -> None:
+    gateway = PreparedReplayGateway(GatewayConfig())
+    add_default_source_runs(gateway)
+    monitoring_run_id = leave_monitoring_run_prepared(gateway)
+
+    prepared_context = read_prepared_context(gateway, monitoring_run_id)
+    assert prepared_context is not None
+    corrupted_context = dict(prepared_context)
+    persisted_contract = corrupted_context["contract"]
+    assert isinstance(persisted_contract, dict)
+    corrupted_contract = dict(persisted_contract)
+    corrupted_contract["execution_contract_ref"] = None
+    corrupted_context["contract"] = corrupted_contract
+    gateway.prepared_context_override = corrupted_context
+
+    with pytest.raises(GatewayConsistencyViolation) as exc_info:
+        run_orchestration(
+            subject_id="churn_model",
+            source_run_id="train-run-current",
+            baseline_source_run_id=None,
+            gateway=gateway,
+            contract_checker=DefaultContractChecker(),
+        )
+
+    assert exc_info.value.code == "prepared_context_inconsistent"
+
+
 def test_prepared_replay_rejects_different_effective_plan_for_same_recipe_identity() -> None:
     gateway = PreparedReplayGateway(GatewayConfig())
     add_default_source_runs(gateway)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -65,7 +65,7 @@ def test_parse_recipe_builds_immutable_typed_recipe() -> None:
     assert recipe.contract.contract_version == "v0"
     assert recipe.analysis.metric_names == ("accuracy", "latency_p95")
     assert len(recipe.analysis.finding_policy_bindings or ()) == 1
-    binding = (recipe.analysis.finding_policy_bindings or ())[0]
+    binding = (recipe.analysis.finding_policy_bindings or ())[0]  # pyright: ignore[reportGeneralTypeIssues]
     assert binding.finding_policy_id == "relative-regression"
     assert binding.parameters == {
         "labels": ("quality", "regression"),

--- a/tests/test_recipe_compiler.py
+++ b/tests/test_recipe_compiler.py
@@ -217,7 +217,7 @@ def test_compile_recipe_zero_configuration_expands_system_defaults() -> None:
         },
     }
     assert compiled.contract.contract_id == SYSTEM_DEFAULT_CONTRACT_ID
-    assert compiled.contract.version == "v0"
+    assert compiled.contract.contract_version == "v0"
     assert len(compiled.finding_policy_bindings) == 1
     binding = compiled.finding_policy_bindings[0]
     assert binding.finding_policy_id == SYSTEM_COMPATIBILITY_FINDING_POLICY_ID

--- a/tests/test_result_contract.py
+++ b/tests/test_result_contract.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from mlflow_monitor.domain import ComparabilityStatus, LifecycleStatus, MonitoringRunReference
+from mlflow_monitor.domain import (
+    ComparabilityStatus,
+    DiffReferenceKind,
+    LifecycleStatus,
+    MonitoringRunReference,
+)
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
 
 
@@ -19,7 +24,7 @@ def test_monitor_run_result_success_envelope_construction() -> None:
         diff_ids=("diff-1",),
         references=(
             MonitoringRunReference(
-                kind="baseline",
+                kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id="train-run-1",
             ),
@@ -36,7 +41,7 @@ def test_monitor_run_result_success_envelope_construction() -> None:
     assert result.diff_ids == ("diff-1",)
     assert result.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-1",
         ),
@@ -77,7 +82,8 @@ def test_monitor_run_result_requires_nonempty_timeline_id(timeline_id: str | Non
         MonitorRunResult(
             monitoring_run_id="monitoring-run-2",
             subject_id="churn_model",
-            timeline_id=timeline_id,
+            # passing null for test
+            timeline_id=timeline_id,  # pyright: ignore[reportArgumentType]
             lifecycle_status=LifecycleStatus.FAILED,
             comparability_status=None,
             summary=None,
@@ -111,7 +117,7 @@ def test_monitor_run_result_to_dict_serializes_enums_and_error() -> None:
         diff_ids=("diff-2",),
         references=(
             MonitoringRunReference(
-                kind="baseline",
+                kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id="train-run-2",
             ),
@@ -131,7 +137,7 @@ def test_monitor_run_result_to_dict_serializes_enums_and_error() -> None:
     }
     assert serialized["references"] == [
         {
-            "kind": "baseline",
+            "kind": "baseline",  # This remains a string in the serialized dict
             "monitoring_run_id": None,
             "source_run_id": "train-run-2",
         }
@@ -238,7 +244,7 @@ def test_monitor_run_result_collections_are_immutable_after_construction() -> No
     summary = {"status": "ok"}
     references = [
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-1",
         )
@@ -260,7 +266,7 @@ def test_monitor_run_result_collections_are_immutable_after_construction() -> No
     summary["status"] = "mutated"
     references.append(
         MonitoringRunReference(
-            kind="lkg",
+            kind=DiffReferenceKind.LKG,
             monitoring_run_id="monitoring-run-1",
             source_run_id="train-run-lkg",
         )
@@ -271,7 +277,7 @@ def test_monitor_run_result_collections_are_immutable_after_construction() -> No
     assert result.summary == {"status": "ok"}
     assert result.references == (
         MonitoringRunReference(
-            kind="baseline",
+            kind=DiffReferenceKind.BASELINE,
             monitoring_run_id=None,
             source_run_id="train-run-1",
         ),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -12,6 +12,7 @@ from mlflow_monitor.domain import (
     Contract,
     ContractCheckReason,
     ContractCheckResult,
+    DiffReferenceKind,
     LifecycleStatus,
     MonitoringRunReference,
     Run,
@@ -381,7 +382,7 @@ def make_prepared_context(
         contract=contract,
         references=(
             MonitoringRunReference(
-                kind="baseline",
+                kind=DiffReferenceKind.BASELINE,
                 monitoring_run_id=None,
                 source_run_id=baseline_source_run_id,
             ),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -17,7 +17,12 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
     Run,
 )
-from mlflow_monitor.errors import CheckStageError, InvalidRunTransition, PrepareStageError
+from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    CheckStageError,
+    InvalidRunTransition,
+    PrepareStageError,
+)
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
     GatewayConfig,
@@ -1569,7 +1574,7 @@ def test_prepare_run_context_fails_when_competing_bootstrap_pins_different_basel
         )
 
     error = exc_info.value
-    assert error.code == "prepare_baseline_override_existing_timeline"
+    assert error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", BASELINE.source_run_id),
@@ -1791,7 +1796,7 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
         )
 
     error = exc_info.value
-    assert error.code == "prepare_baseline_override_existing_timeline"
+    assert error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-other"),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -13,6 +13,7 @@ from mlflow_monitor.domain import (
     ContractCheckReason,
     ContractCheckResult,
     LifecycleStatus,
+    MonitoringRunReference,
     Run,
 )
 from mlflow_monitor.errors import CheckStageError, InvalidRunTransition, PrepareStageError
@@ -130,6 +131,7 @@ def prepare_test_context(
         compiled_recipe=compiled_recipe,
         gateway=gateway,
         source_run_id=effective_source_run_id,
+        sequence_index=allocation.sequence_index,
         baseline_source_run_id=baseline_source_run_id,
         custom_reference_monitoring_run_id=custom_reference_monitoring_run_id,
     )
@@ -367,22 +369,23 @@ def make_prepared_context(
     baseline_source_run_id: str = "train-run-baseline",
 ) -> PreparedContext:
     """Build a prepared context aligned with the common workflow test subject."""
+    compiled_recipe = compile_recipe()
     return PreparedContext(
         monitoring_run_id="monitoring-run-1",
-        subject_id="churn_model",
-        recipe_id="default",
-        recipe_version="v0",
-        contract_id=contract.contract_id,
-        source_experiment="training/churn",
-        timeline_id="timeline-churn_model",
-        baseline_source_run_id=baseline_source_run_id,
-        previous_monitoring_run_id=None,
-        active_lkg_monitoring_run_id=None,
-        custom_reference_monitoring_run_id=None,
         source_run_id=source_run_id,
+        subject_id="churn_model",
+        timeline_id="timeline-churn_model",
+        sequence_index=0,
+        baseline_source_run_id=baseline_source_run_id,
+        effective_recipe=compiled_recipe.effective_plan,
         contract=contract,
-        required_metrics=("f1", "auc"),
-        required_artifacts=("metrics.json",),
+        references=(
+            MonitoringRunReference(
+                kind="baseline",
+                monitoring_run_id=None,
+                source_run_id=baseline_source_run_id,
+            ),
+        ),
     )
 
 
@@ -552,7 +555,7 @@ def test_execute_contract_check_returns_warn_result_for_environment_mismatch() -
     """Check should return the canonical warning result for env mismatch."""
     contract = Contract(
         contract_id="env_repro",
-        version="v0",
+        contract_version="v0",
         schema_contract_ref=None,
         feature_contract_ref=None,
         metric_contract_ref=None,


### PR DESCRIPTION
## What changed

- Persist canonical prepared context to `state/prepared_context.json` before marking a monitoring Run `PREPARED`.
- Hydrate `PREPARED` replays from that artifact instead of resolving references from the current timeline again. (This is mostly used when we need to resume the workflow.)
- Validate the artifact schema, run identities, effective plan, complete Contract value, and resolved references before resuming.

## Ticket or Issue

V0-012

## Why

A monitoring run can be interrupted after `Prepare` succeeds. Previously, replay depended on newly resolved state, so the same run could observe a different timeline or `Contract` after the `PREPARED` lifecycle marker had already been written. Persisting the complete prepared boundary makes replay deterministic and causes any unsuccessful state to fail closed.

## Review context

- Relevant public docs: [Workflow and Stages](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/ticket/v0-012-persist-prepared-context/docs/site/source/workflow.rst) and [Recipe and Compiler](https://github.com/shizheng-rlfresh/mlflow-monitor/blob/ticket/v0-012-persist-prepared-context/docs/site/source/recipe.rst)
- Required behavior: Prepare persists its canonical context before the `PREPARED` transition; replay reads that artifact without re-resolving Timeline references; missing, malformed, or inconsistent artifacts fail with `prepared_context_inconsistent`; the complete compiled Contract and effective plan must still match.
- Out of scope: baseline-claim reconciliation, closed-only reference eligibility changes, Check-stage artifact persistence, CLI Recipe loading, and lifecycle cutover beyond the existing `CHECKED` boundary.

## Impact

Interrupted monitoring runs at `PREPARED` now resume from the exact state that originally passed `Prepare`.  No other impact.

## Validation

- [x] `uv sync --locked --group doc`
- [x] `uv run --no-sync poe validate`
- [x] No developer-doc change is required
