### PR TITLE
Cleanup - Gateway consistency violation error

### DIFF
--- a/docs/site/source/errors.rst
+++ b/docs/site/source/errors.rst
@@ -1,9 +1,100 @@
 MLflow-Monitor Errors
 =====================
 
-Errors
-------
+MLflow-Monitor exceptions separate human-readable diagnostics from structured
+error data. Treat ``message`` as text for operators and users. When an exception
+provides ``code`` and ``details``, use those fields for programmatic handling
+instead of parsing the message.
 
-.. automodule:: mlflow_monitor.errors
+Gateway consistency failures own their codes, messages, and detail formatting.
+Create them through the named constructors below and pass only the semantic
+fields that describe the failure. Catch ``GatewayConsistencyViolation`` when one
+handler should cover every gateway consistency failure.
+
+For example:
+
+.. code-block:: python
+
+   from mlflow_monitor.errors import AllocationConsistencyViolation
+
+   raise AllocationConsistencyViolation.duplicate_sequence(
+       sequence_index=2,
+       first_monitoring_run_id="monitoring-run-1",
+       second_monitoring_run_id="monitoring-run-2",
+   )
+
+Gateway Errors
+--------------
+
+General Gateway Consistency Violation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: mlflow_monitor.errors.GatewayConsistencyViolation
+   :members:
+   :show-inheritance:
+
+Allocation Consistency Violation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: mlflow_monitor.errors.AllocationConsistencyViolation
+   :members:
+   :show-inheritance:
+
+Prepared-Context Consistency Violation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: mlflow_monitor.errors.PreparedContextConsistencyViolation
+   :members:
+   :show-inheritance:
+
+Gateway Namespace Violation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: mlflow_monitor.errors.GatewayNamespaceViolation
+   :members:
+   :show-inheritance:
+
+Training Run Mutation Violation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: mlflow_monitor.errors.TrainingRunMutationViolation
+   :members:
+   :show-inheritance:
+
+
+
+Workflow Errors
+---------------
+
+.. autoclass:: mlflow_monitor.errors.PrepareStageError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: mlflow_monitor.errors.CheckStageError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: mlflow_monitor.errors.TerminalRunRetryError
+   :members:
+   :show-inheritance:
+
+Recipe Errors
+-------------
+
+.. autoclass:: mlflow_monitor.errors.ContractResolutionError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: mlflow_monitor.errors.RecipeValidationIssue
+   :members:
+
+.. autoclass:: mlflow_monitor.errors.RecipeValidationError
+   :members:
+   :show-inheritance:
+
+Invariant Errors
+----------------
+
+.. autoclass:: mlflow_monitor.errors.InvariantViolation
    :members:
    :show-inheritance:

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_timeline"
 PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
@@ -10,6 +11,19 @@ MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
 MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
 TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
 MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT = "monitoring_run_json_artifact_inconsistent"
+
+
+class MonitorAllocationReason(StrEnum):
+    """Reasons for monitoring run allocation inconsistency."""
+
+    DUPLICATE_IDENTITY = "duplicate_identity"
+    DUPLICATE_SEQUENCE = "duplicate_sequence"
+    SEQUENCE_GAP = "sequence_gap"
+    INVALID_ALLOCATION = "invalid_allocation"
+    NEXT_SEQUENCE_AHEAD = "next_sequence_ahead"
+    UNKNOWN_POINTER = "unknown_pointer"
+    SOURCE_BINDING_CONFLICT = "source_binding_conflict"
+    TIMELINE_CONFLICT = "timeline_conflict"
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,14 +167,18 @@ def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsiste
 
 
 def monitoring_allocation_inconsistent(
-    *, reason: str, message: str, details: tuple[tuple[str, str | int | None], ...] = ()
+    *,
+    reason: MonitorAllocationReason | str,
+    message: str,
+    details: tuple[tuple[str, str | int | None], ...] = (),
 ) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
+    normalized_reason = MonitorAllocationReason(reason)
     return GatewayConsistencyViolation(
         code=MONITORING_ALLOCATION_INCONSISTENT,
         message=message,
         details=(
-            ("reason", reason),
+            ("reason", normalized_reason.value),
             *details,
         ),
     )

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_timeline"
-_PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
-_MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
+PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
+MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
+MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,7 +141,7 @@ class RecipeValidationError(ValueError):
 def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for inconsistent prepared context."""
     return GatewayConsistencyViolation(
-        code=_PREPARED_CONTEXT_INCONSISTENT,
+        code=PREPARED_CONTEXT_INCONSISTENT,
         message="Persisted prepared context is missing, malformed, or inconsistent.",
         details=(
             ("reason", reason),
@@ -154,10 +155,21 @@ def monitoring_allocation_inconsistent(
 ) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
     return GatewayConsistencyViolation(
-        code=_MONITORING_ALLOCATION_INCONSISTENT,
+        code=MONITORING_ALLOCATION_INCONSISTENT,
         message=message,
         details=(
             ("reason", reason),
             *details,
         ),
+    )
+
+
+def monitoring_run_upsert_field_override(
+    message: str, details: tuple[tuple[str, str | int | None], ...] = ()
+) -> GatewayConsistencyViolation:
+    """Create a GatewayConsistencyViolation for monitoring run upsert field override."""
+    return GatewayConsistencyViolation(
+        code=MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
+        message=message,
+        details=(*details,),
     )

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -5,12 +5,21 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_timeline"
-PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
-MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
-MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
-TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
-MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT = "monitoring_run_json_artifact_inconsistent"
+from mlflow_monitor.domain import DiffReferenceKind
+
+PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
+
+
+class GatewayConsistencyCode(StrEnum):
+    """Code for gateway consistency violations."""
+
+    PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
+    MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
+    MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
+    TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
+    MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT = "monitoring_run_json_artifact_inconsistent"
+    MONITORING_RUN_SUBJECT_INCONSISTENT = "monitoring_run_subject_inconsistent"
+    MONITORING_REFERENCE_INCONSISTENT = "monitoring_reference_inconsistent"
 
 
 class MonitorAllocationReason(StrEnum):
@@ -157,7 +166,7 @@ class RecipeValidationError(ValueError):
 def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for inconsistent prepared context."""
     return GatewayConsistencyViolation(
-        code=PREPARED_CONTEXT_INCONSISTENT,
+        code=GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT,
         message="Persisted prepared context is missing, malformed, or inconsistent.",
         details=(
             ("reason", reason),
@@ -175,7 +184,7 @@ def monitoring_allocation_inconsistent(
     """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
     normalized_reason = MonitorAllocationReason(reason)
     return GatewayConsistencyViolation(
-        code=MONITORING_ALLOCATION_INCONSISTENT,
+        code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT,
         message=message,
         details=(
             ("reason", normalized_reason.value),
@@ -189,7 +198,7 @@ def monitoring_run_upsert_field_override(
 ) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for monitoring run upsert field override."""
     return GatewayConsistencyViolation(
-        code=MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
+        code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
         message=message,
         details=(*details,),
     )
@@ -198,7 +207,7 @@ def monitoring_run_upsert_field_override(
 def timeline_state_not_found_for_subject_id(*, subject_id: str) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for missing timeline state for a subject ID."""
     return GatewayConsistencyViolation(
-        code=TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
+        code=GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
         message=f"Timeline state not found for subject_id={subject_id!r}.",
         details=(("subject_id", subject_id),),
     )
@@ -209,13 +218,47 @@ def monitoring_run_json_artifact_inconsistent(
 ) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for inconsistent monitoring run JSON artifact."""
     return GatewayConsistencyViolation(
-        code=MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT,
+        code=GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT,
         message=(
-            f"Monitoring run JSON artifact is inconsistent for run_id={monitoring_run_id!r} "
+            f"Monitoring run JSON artifact is inconsistent for "
+            f"monitoring_run_id={monitoring_run_id!r} "
             f"at path={path!r}."
         ),
         details=(
             ("monitoring_run_id", monitoring_run_id),
             ("path", path),
+        ),
+    )
+
+
+def monitoring_run_subject_inconsistent(
+    *, subject_id: str, monitoring_run_id: str
+) -> GatewayConsistencyViolation:
+    """Create a GatewayConsistencyViolation for a monitoring run not indexed on the subject ID."""
+    return GatewayConsistencyViolation(
+        code=GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT,
+        message=(
+            f"monitoring_run_id={monitoring_run_id!r} is not indexed on subject_id={subject_id!r}."
+        ),
+        details=(
+            ("subject_id", subject_id),
+            ("monitoring_run_id", monitoring_run_id),
+        ),
+    )
+
+
+def monitoring_reference_inconsistent(
+    *, kind: DiffReferenceKind, monitoring_run_id: str
+) -> GatewayConsistencyViolation:
+    """Create a GatewayConsistencyViolation for an inconsistent monitoring reference."""
+    return GatewayConsistencyViolation(
+        code=GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT,
+        message=(
+            f"Monitoring reference of kind={kind.value!r} is inconsistent for "
+            f"monitoring_run_id={monitoring_run_id!r}."
+        ),
+        details=(
+            ("kind", kind.value),
+            ("monitoring_run_id", monitoring_run_id),
         ),
     )

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -8,6 +8,7 @@ PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existi
 PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
 MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
 MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
+TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
 
 
 @dataclass(frozen=True, slots=True)
@@ -172,4 +173,13 @@ def monitoring_run_upsert_field_override(
         code=MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
         message=message,
         details=(*details,),
+    )
+
+
+def timeline_state_not_found_for_subject_id(*, subject_id: str) -> GatewayConsistencyViolation:
+    """Create a GatewayConsistencyViolation for missing timeline state for a subject ID."""
+    return GatewayConsistencyViolation(
+        code=TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
+        message=f"Timeline state not found for subject_id={subject_id!r}.",
+        details=(("subject_id", subject_id),),
     )

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_timeline"
+_PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,3 +128,15 @@ class RecipeValidationError(ValueError):
     def __str__(self) -> str:
         """Return a deterministic joined message for all validation issues."""
         return "; ".join(issue.message for issue in self.issues)
+
+
+def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsistencyViolation:
+    """Helper function to create a GatewayConsistencyViolation for inconsistent prepared context."""
+    return GatewayConsistencyViolation(
+        code=_PREPARED_CONTEXT_INCONSISTENT,
+        message="Persisted prepared context is missing, malformed, or inconsistent.",
+        details=(
+            ("reason", reason),
+            ("field", field),
+        ),
+    )

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_timeline"
 _PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
+_MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,13 +131,33 @@ class RecipeValidationError(ValueError):
         return "; ".join(issue.message for issue in self.issues)
 
 
+# error factories
+
+
+# GatewayConsistencyViolation error factories
+
+
 def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsistencyViolation:
-    """Helper function to create a GatewayConsistencyViolation for inconsistent prepared context."""
+    """Create a GatewayConsistencyViolation for inconsistent prepared context."""
     return GatewayConsistencyViolation(
         code=_PREPARED_CONTEXT_INCONSISTENT,
         message="Persisted prepared context is missing, malformed, or inconsistent.",
         details=(
             ("reason", reason),
             ("field", field),
+        ),
+    )
+
+
+def monitoring_allocation_inconsistent(
+    *, reason: str, message: str, details: tuple[tuple[str, str | int | None], ...] = ()
+) -> GatewayConsistencyViolation:
+    """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
+    return GatewayConsistencyViolation(
+        code=_MONITORING_ALLOCATION_INCONSISTENT,
+        message=message,
+        details=(
+            ("reason", reason),
+            *details,
         ),
     )

--- a/src/mlflow_monitor/errors.py
+++ b/src/mlflow_monitor/errors.py
@@ -9,6 +9,7 @@ PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
 MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
 MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
 TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
+MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT = "monitoring_run_json_artifact_inconsistent"
 
 
 @dataclass(frozen=True, slots=True)
@@ -182,4 +183,21 @@ def timeline_state_not_found_for_subject_id(*, subject_id: str) -> GatewayConsis
         code=TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
         message=f"Timeline state not found for subject_id={subject_id!r}.",
         details=(("subject_id", subject_id),),
+    )
+
+
+def monitoring_run_json_artifact_inconsistent(
+    *, monitoring_run_id: str, path: str
+) -> GatewayConsistencyViolation:
+    """Create a GatewayConsistencyViolation for inconsistent monitoring run JSON artifact."""
+    return GatewayConsistencyViolation(
+        code=MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT,
+        message=(
+            f"Monitoring run JSON artifact is inconsistent for run_id={monitoring_run_id!r} "
+            f"at path={path!r}."
+        ),
+        details=(
+            ("monitoring_run_id", monitoring_run_id),
+            ("path", path),
+        ),
     )

--- a/src/mlflow_monitor/errors/__init__.py
+++ b/src/mlflow_monitor/errors/__init__.py
@@ -14,6 +14,7 @@ from .recipe import (
     RecipeValidationIssue,
 )
 from .workflow import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     PrepareStageError,
     TerminalRunRetryError,
@@ -32,4 +33,5 @@ __all__ = [
     "TrainingRunMutationViolation",
     "AllocationConsistencyViolation",
     "PreparedContextConsistencyViolation",
+    "PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE",
 ]

--- a/src/mlflow_monitor/errors/__init__.py
+++ b/src/mlflow_monitor/errors/__init__.py
@@ -1,8 +1,10 @@
 """Custom exception types for MLflow-Monitor v0."""
 
 from .gateway import (
+    AllocationConsistencyViolation,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
+    PreparedContextConsistencyViolation,
     TrainingRunMutationViolation,
 )
 from .invariant import InvariantViolation
@@ -28,4 +30,6 @@ __all__ = [
     "RecipeValidationIssue",
     "TerminalRunRetryError",
     "TrainingRunMutationViolation",
+    "AllocationConsistencyViolation",
+    "PreparedContextConsistencyViolation",
 ]

--- a/src/mlflow_monitor/errors/__init__.py
+++ b/src/mlflow_monitor/errors/__init__.py
@@ -1,0 +1,31 @@
+"""Custom exception types for MLflow-Monitor v0."""
+
+from .gateway import (
+    GatewayConsistencyViolation,
+    GatewayNamespaceViolation,
+    TrainingRunMutationViolation,
+)
+from .invariant import InvariantViolation
+from .recipe import (
+    ContractResolutionError,
+    RecipeValidationError,
+    RecipeValidationIssue,
+)
+from .workflow import (
+    CheckStageError,
+    PrepareStageError,
+    TerminalRunRetryError,
+)
+
+__all__ = [
+    "CheckStageError",
+    "ContractResolutionError",
+    "GatewayConsistencyViolation",
+    "GatewayNamespaceViolation",
+    "InvariantViolation",
+    "PrepareStageError",
+    "RecipeValidationError",
+    "RecipeValidationIssue",
+    "TerminalRunRetryError",
+    "TrainingRunMutationViolation",
+]

--- a/src/mlflow_monitor/errors/__init__.py
+++ b/src/mlflow_monitor/errors/__init__.py
@@ -14,7 +14,7 @@ from .recipe import (
     RecipeValidationIssue,
 )
 from .workflow import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     PrepareStageError,
     TerminalRunRetryError,
@@ -33,5 +33,5 @@ __all__ = [
     "TrainingRunMutationViolation",
     "AllocationConsistencyViolation",
     "PreparedContextConsistencyViolation",
-    "PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE",
+    "PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE",
 ]

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -1,39 +1,9 @@
-"""Custom exceptions types and factory functions for Gateway errors.
-
-Three main types of gateway errors:
-1. `GatewayNamespaceViolation`: a gateway operation violates namespace constraints.
-2. `TrainingRunMutationViolation`: an attempt to mutate source training run data.
-3. `GatewayConsistencyViolation`: a gateway operation violates consistency constraints.
-
-For GatewayConsistencyViolation,
-there are several specific error codes (i.e., subtypes) defined in the `GatewayConsistencyCode`:
-- "prepared_context_inconsistent": the prepared context is inconsistent with the expected state.
-- "monitoring_allocation_inconsistent": the monitoring run allocation is inconsistent with the expected state.
-- "monitoring_run_upsert_field_override": an upsert operation on a monitoring run violates field constraints.
-- "timeline_state_not_found_for_subject_id": the timeline state for a given subject ID is not found.
-- "monitoring_run_json_artifact_inconsistent": the JSON artifact of a monitoring run is inconsistent with the expected state.
-- "monitoring_run_subject_inconsistent": the subject of a monitoring run is inconsistent with the expected state.
-- "monitoring_reference_inconsistent": a monitoring reference is inconsistent with the expected state.
-
-For "monitoring_allocation_inconsistent",
-there are several specific reasons defined in the `MonitoringAllocationInconsistentReason`:
-- "duplicate_identity": multiple monitoring runs claim the same allocation identity.
-- "duplicate_sequence": multiple monitoring runs claim the sequence index.
-- "sequence_gap": there is a gap in the sequence of monitoring runs.
-- "invalid_allocation": the allocation of a monitoring run is invalid.
-- "next_sequence_ahead": the next sequence index is ahead of the expected value.
-- "unknown_pointer": the pointer to a monitoring run is unknown.
-- "unknown_tag": the tag associated with a monitoring run is unknown.
-- "source_binding_conflict": there is a conflict in the source binding of a monitoring run.
-- "timeline_conflict": there is a conflict in the timeline of monitoring runs.
-
-"""  # noqa: E501
+"""Gateway exception types and factory-owned consistency messages."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from types import MappingProxyType
 
 from mlflow_monitor.domain import DiffReferenceKind
 
@@ -76,7 +46,7 @@ class GatewayConsistencyCode(StrEnum):
 
 
 class MonitoringAllocationInconsistentReason(StrEnum):
-    """Reasons for monitoring run allocation inconsistent error code."""
+    """Reasons for monitoring run allocation inconsistent reason code."""
 
     DUPLICATE_IDENTITY = "duplicate_identity"
     DUPLICATE_SEQUENCE = "duplicate_sequence"
@@ -87,40 +57,6 @@ class MonitoringAllocationInconsistentReason(StrEnum):
     UNKNOWN_TAG = "unknown_tag"
     SOURCE_BINDING_CONFLICT = "source_binding_conflict"
     TIMELINE_CONFLICT = "timeline_conflict"
-
-
-MONITORING_ALLOCATION_REASON_MESSAGE = MappingProxyType(
-    {
-        MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY: (
-            "Multiple monitoring runs claim the same allocation identity.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE: (
-            "Multiple monitoring runs claim the sequence index.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.SEQUENCE_GAP: (
-            "Monitoring allocation sequences must be contiguous from zero.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.INVALID_ALLOCATION: (
-            "Monitoring run allocation is invalid.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD: (
-            "Monitoring run allocation's next sequence index is "
-            "ahead of the durable allocation state.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.UNKNOWN_POINTER: (
-            "Monitoring run ID points to an unknown allocation.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.UNKNOWN_TAG: (
-            "Experiment tag points to an unknown allocation.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT: (
-            "Source binding conflict detected.{context_message}"
-        ),
-        MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT: (
-            "Timeline conflict detected.{context_message}"
-        ),
-    }
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,56 +71,43 @@ class GatewayConsistencyViolation(ValueError):
         """Return the error message when the exception is converted to a string."""
         return self.message
 
-    # monitoring allocation inconsistent error factory
-    @classmethod
-    def monitoring_allocation_inconsistent(
-        cls,
-        *,
-        reason: MonitoringAllocationInconsistentReason | str,
-        details: tuple[tuple[str, str | int | None], ...] = (),
-        context_message: str | None = None,
-    ) -> GatewayConsistencyViolation:
-        """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
-        normalized_reason = MonitoringAllocationInconsistentReason(reason)
-
-        message = MONITORING_ALLOCATION_REASON_MESSAGE[normalized_reason].format(
-            context_message=f" {context_message}" if context_message else ""
-        )
-
-        return cls(
-            code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT,
-            message=message,
-            details=(
-                ("reason", normalized_reason.value),
-                *details,
-            ),
-        )
-
-    # prepared context inconsistent error factory
-    @classmethod
-    def prepared_context_inconsistent(
-        cls, *, reason: str, field: str
-    ) -> GatewayConsistencyViolation:
-        """Create a GatewayConsistencyViolation for inconsistent prepared context."""
-        return cls(
-            code=GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT,
-            message="Persisted prepared context is missing, malformed, or inconsistent.",
-            details=(
-                ("reason", reason),
-                ("field", field),
-            ),
-        )
-
     # monitoring run upsert field override error factory
     @classmethod
     def monitoring_run_upsert_field_override(
-        cls, *, message: str, details: tuple[tuple[str, str | int | None], ...] = ()
+        cls,
+        *,
+        fields: tuple[tuple[str, str | int | None], ...] = (),
     ) -> GatewayConsistencyViolation:
-        """Create a GatewayConsistencyViolation for monitoring run upsert field override."""
+        """Create a violation for one immutable Monitoring Run field override."""
+        field = [f for f, _ in fields]
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
-            message=message,
-            details=(*details,),
+            code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
+            message=f"Attempted to override immutable Monitoring Run field {field!r}.",
+            details=fields,
+        )
+
+    @classmethod
+    def monitoring_run_upsert_source_binding_conflict(
+        cls,
+        *,
+        monitoring_run_id: str,
+        source_run_id: str | None,
+        persisted_source_run_id: str | None,
+    ) -> GatewayConsistencyViolation:
+        """Create a violation for a Monitoring Run bound to another source run."""
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
+            message=(
+                "Monitoring Run source binding conflicts with durable state for "
+                f"monitoring_run_id={monitoring_run_id!r}; "
+                f"source_run_id={source_run_id!r} does not match "
+                f"persisted_source_run_id={persisted_source_run_id!r}."
+            ),
+            details=(
+                ("monitoring_run_id", monitoring_run_id),
+                ("source_run_id", source_run_id),
+                ("persisted_source_run_id", persisted_source_run_id),
+            ),
         )
 
     # timeline state not found for subject ID error factory
@@ -194,7 +117,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for missing timeline state for a subject ID."""
         return cls(
-            code=GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
+            code=GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID.value,
             message=f"Timeline state not found for subject_id={subject_id!r}.",
             details=(("subject_id", subject_id),),
         )
@@ -206,7 +129,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for inconsistent monitoring run JSON artifact."""
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT,
+            code=GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT.value,
             message=(
                 f"Monitoring run JSON artifact is inconsistent for "
                 f"monitoring_run_id={monitoring_run_id!r} "
@@ -225,7 +148,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for a monitoring run not indexed on the subject ID."""  # noqa: E501
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT,
+            code=GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT.value,
             message=(
                 f"monitoring_run_id={monitoring_run_id!r} is not indexed "
                 f"on subject_id={subject_id!r}."
@@ -243,7 +166,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for an inconsistent monitoring reference."""
         return cls(
-            code=GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT,
+            code=GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT.value,
             message=(
                 f"Monitoring reference of kind={kind.value!r} is inconsistent for "
                 f"monitoring_run_id={monitoring_run_id!r}."
@@ -252,4 +175,365 @@ class GatewayConsistencyViolation(ValueError):
                 ("kind", kind.value),
                 ("monitoring_run_id", monitoring_run_id),
             ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationConsistencyViolation(GatewayConsistencyViolation):
+    """Raised when durable Monitoring Run allocation state is inconsistent."""
+
+    @classmethod
+    def _create(
+        cls,
+        *,
+        reason: MonitoringAllocationInconsistentReason,
+        message: str,
+        details: tuple[tuple[str, str | int | None], ...],
+    ) -> AllocationConsistencyViolation:
+        """Create a violation with its stable code and normalized reason."""
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT.value,
+            message=message,
+            details=(("reason", reason.value), *details),
+        )
+
+    @classmethod
+    def duplicate_identity(
+        cls,
+        *,
+        first_monitoring_run_id: str,
+        second_monitoring_run_id: str,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for two Monitoring Runs with the same identity."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY,
+            message="Multiple Monitoring Runs claim the same allocation identity.",
+            details=(
+                ("first_monitoring_run_id", first_monitoring_run_id),
+                ("second_monitoring_run_id", second_monitoring_run_id),
+            ),
+        )
+
+    @classmethod
+    def duplicate_sequence(
+        cls,
+        *,
+        sequence_index: int,
+        first_monitoring_run_id: str,
+        second_monitoring_run_id: str,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for two Monitoring Runs with the same sequence index."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE,
+            message=f"Multiple Monitoring Runs claim sequence_index={sequence_index}.",
+            details=(
+                ("sequence_index", sequence_index),
+                ("first_monitoring_run_id", first_monitoring_run_id),
+                ("second_monitoring_run_id", second_monitoring_run_id),
+            ),
+        )
+
+    @classmethod
+    def sequence_gap(
+        cls,
+        *,
+        expected_sequence_index: int,
+        actual_sequence_index: int,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for a non-contiguous allocation sequence."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.SEQUENCE_GAP,
+            message=(
+                "Monitoring allocation sequence is not contiguous; "
+                f"expected sequence_index={expected_sequence_index}, "
+                f"got {actual_sequence_index}."
+            ),
+            details=(
+                ("expected_sequence_index", expected_sequence_index),
+                ("actual_sequence_index", actual_sequence_index),
+            ),
+        )
+
+    @classmethod
+    def missing_durable_tags(
+        cls,
+        *,
+        monitoring_run_id: str | None,
+        missing_tags: tuple[str, ...],
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for an allocation missing required durable tags."""
+        rendered_missing_tags = ", ".join(missing_tags)
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+            message=(
+                f"Monitoring Run {monitoring_run_id!r} is missing durable "
+                f"allocation tags: {rendered_missing_tags}."
+            ),
+            details=(
+                ("monitoring_run_id", monitoring_run_id),
+                ("missing_tags", rendered_missing_tags),
+            ),
+        )
+
+    @classmethod
+    def non_integer_sequence(
+        cls,
+        *,
+        monitoring_run_id: str,
+        raw_sequence_index: str,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for a non-integer allocation sequence index."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+            message=(
+                f"Monitoring Run {monitoring_run_id!r} has a non-integer "
+                f"sequence index: {raw_sequence_index!r}."
+            ),
+            details=(
+                ("monitoring_run_id", monitoring_run_id),
+                ("raw_sequence_index", raw_sequence_index),
+            ),
+        )
+
+    @classmethod
+    def negative_sequence(
+        cls,
+        *,
+        monitoring_run_id: str,
+        sequence_index: int,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for a negative allocation sequence index."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+            message=(
+                f"Monitoring Run {monitoring_run_id!r} has a negative "
+                f"sequence_index={sequence_index}."
+            ),
+            details=(
+                ("monitoring_run_id", monitoring_run_id),
+                ("sequence_index", sequence_index),
+            ),
+        )
+
+    @classmethod
+    def next_sequence_ahead(
+        cls,
+        *,
+        persisted_next_sequence_index: int,
+        durable_next_sequence_index: int,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for a persisted next sequence ahead of durable state."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD,
+            message=(
+                "Monitoring allocation next sequence index is ahead of durable state; "
+                f"persisted sequence_index={persisted_next_sequence_index}, "
+                f"durable sequence_index={durable_next_sequence_index}."
+            ),
+            details=(
+                ("persisted_next_sequence_index", persisted_next_sequence_index),
+                ("durable_next_sequence_index", durable_next_sequence_index),
+            ),
+        )
+
+    @classmethod
+    def unknown_pointer(cls, *, monitoring_run_id: str) -> AllocationConsistencyViolation:
+        """Create a violation for a pointer to an unknown allocation."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.UNKNOWN_POINTER,
+            message=(
+                "Monitoring pointer references an unknown allocation for "
+                f"monitoring_run_id={monitoring_run_id!r}."
+            ),
+            details=(("monitoring_run_id", monitoring_run_id),),
+        )
+
+    @classmethod
+    def unknown_tag(
+        cls,
+        *,
+        tag: str,
+        monitoring_run_id: str,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for an experiment tag pointing to an unknown allocation."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.UNKNOWN_TAG,
+            message=f"Experiment tag {tag!r} references an unknown allocation.",
+            details=(
+                ("tag", tag),
+                ("monitoring_run_id", monitoring_run_id),
+            ),
+        )
+
+    @classmethod
+    def source_binding_conflict(
+        cls,
+        *,
+        tag: str,
+        monitoring_run_id: str,
+        source_run_id: str,
+        persisted_source_run_id: str,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for an allocation bound to a different source run."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT,
+            message=(
+                f"Experiment tag {tag!r} points to monitoring_run_id={monitoring_run_id!r} "
+                f"allocated for source_run_id={persisted_source_run_id!r}, "
+                f"not source_run_id={source_run_id!r}."
+            ),
+            details=(
+                ("tag", tag),
+                ("monitoring_run_id", monitoring_run_id),
+                ("source_run_id", source_run_id),
+                ("persisted_source_run_id", persisted_source_run_id),
+            ),
+        )
+
+    @classmethod
+    def timeline_conflict(
+        cls,
+        *,
+        sequence_index: int,
+        indexed_monitoring_run_id: str,
+        durable_monitoring_run_id: str | None,
+    ) -> AllocationConsistencyViolation:
+        """Create a violation for a timeline slot that conflicts with durable state."""
+        return cls._create(
+            reason=MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT,
+            message=(
+                f"Experiment timeline slot sequence_index={sequence_index} does not match "
+                "its durable Monitoring Run allocation."
+            ),
+            details=(
+                ("sequence_index", sequence_index),
+                ("indexed_monitoring_run_id", indexed_monitoring_run_id),
+                ("durable_monitoring_run_id", durable_monitoring_run_id),
+            ),
+        )
+
+
+class PreparedContextInconsistentReason(StrEnum):
+    """Reasons for prepared context inconsistent reason code."""
+
+    MISSING_ARTIFACT = "missing_artifact"
+    UNSUPPORTED_ARTIFACT_SCHEMA_VERSION = "unsupported_artifact_schema_version"
+    ALLOCATION_IDENTITY_MISMATCH = "allocation_identity_mismatch"
+    INVALID_FIELD_TYPE = "invalid_field_type"
+    INVALID_FIELDS = "invalid_fields"
+    EFFECTIVE_RECIPE_MISMATCH = "effective_recipe_mismatch"
+    CONTRACT_MISMATCH = "contract_mismatch"
+    INVALID_REFERENCE = "invalid_reference"
+    BASELINE_REFERENCE_MISMATCH = "baseline_reference_mismatch"
+    NONCANONICAL_REFERENCES = "noncanonical_references"
+    BROKEN_ARTIFACT = "broken_artifact"
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
+    """Raised when durable Monitoring Run allocation state is inconsistent."""
+
+    @classmethod
+    def _create(
+        cls,
+        *,
+        reason: PreparedContextInconsistentReason,
+        details: tuple[tuple[str, str | int | None], ...],
+    ) -> PreparedContextConsistencyViolation:
+        """Create a violation with its stable code and normalized reason."""
+        return cls(
+            code=GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT.value,
+            message="Persisted prepared context is missing, malformed, or inconsistent.",
+            details=(("reason", reason.value), *details),
+        )
+
+    # prepared context inconsistent error factory
+    @classmethod
+    def missing_artifact(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for missing artifact."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.MISSING_ARTIFACT,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def broken_artifact(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for broken artifact."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.BROKEN_ARTIFACT,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def unsupported_artifact_schema_version(
+        cls, *, field: str
+    ) -> PreparedContextConsistencyViolation:
+        """Create a violation for unsupported artifact schema version."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.UNSUPPORTED_ARTIFACT_SCHEMA_VERSION,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def allocation_identity_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for allocation identity mismatch."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.ALLOCATION_IDENTITY_MISMATCH,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def invalid_field_type(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for invalid field type."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.INVALID_FIELD_TYPE,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def invalid_fields(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for invalid fields."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.INVALID_FIELDS,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def effective_recipe_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for effective recipe mismatch."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.EFFECTIVE_RECIPE_MISMATCH,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def contract_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for contract mismatch."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.CONTRACT_MISMATCH,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def invalid_reference(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for invalid reference."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.INVALID_REFERENCE,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def baseline_reference_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for baseline reference mismatch."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.BASELINE_REFERENCE_MISMATCH,
+            details=(("field", field),),
+        )
+
+    @classmethod
+    def noncanonical_references(cls, *, field: str) -> PreparedContextConsistencyViolation:
+        """Create a violation for noncanonical references."""
+        return cls._create(
+            reason=PreparedContextInconsistentReason.NONCANONICAL_REFERENCES,
+            details=(("field", field),),
         )

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -1,5 +1,7 @@
 """Custom exceptions types and factory functions for Gateway errors."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import StrEnum
 from types import MappingProxyType
@@ -19,19 +21,6 @@ class GatewayNamespaceViolation(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
-class GatewayConsistencyViolation(ValueError):
-    """Raised when a gateway operation violates consistency constraints."""
-
-    code: str
-    message: str
-    details: tuple[tuple[str, str | int | None], ...] = ()
-
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
-
-
-@dataclass(frozen=True, slots=True)
 class TrainingRunMutationViolation(ValueError):
     """Raised when code attempts to mutate source training run data."""
 
@@ -42,10 +31,9 @@ class TrainingRunMutationViolation(ValueError):
         return self.message
 
 
-# error factories
-
-
 # GatewayConsistencyViolation error factories
+
+
 class GatewayConsistencyCode(StrEnum):
     """Code for gateway consistency violations."""
 
@@ -106,107 +94,133 @@ MONITORING_ALLOCATION_REASON_MESSAGE = MappingProxyType(
 )
 
 
-def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for inconsistent prepared context."""
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT,
-        message="Persisted prepared context is missing, malformed, or inconsistent.",
-        details=(
-            ("reason", reason),
-            ("field", field),
-        ),
-    )
+@dataclass(frozen=True, slots=True)
+class GatewayConsistencyViolation(ValueError):
+    """Raised when a gateway operation violates consistency constraints."""
 
+    code: str
+    message: str
+    details: tuple[tuple[str, str | int | None], ...] = ()
 
-def monitoring_allocation_inconsistent(
-    *,
-    reason: MonitoringAllocationInconsistentReason | str,
-    details: tuple[tuple[str, str | int | None], ...] = (),
-    context_message: str | None = None,
-) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
-    normalized_reason = MonitoringAllocationInconsistentReason(reason)
+    def __str__(self) -> str:
+        """Return the error message when the exception is converted to a string."""
+        return self.message
 
-    message = MONITORING_ALLOCATION_REASON_MESSAGE[normalized_reason].format(
-        context_message=f" {context_message}" if context_message else ""
-    )
+    # monitoring allocation inconsistent error factory
+    @classmethod
+    def monitoring_allocation_inconsistent(
+        cls,
+        *,
+        reason: MonitoringAllocationInconsistentReason | str,
+        details: tuple[tuple[str, str | int | None], ...] = (),
+        context_message: str | None = None,
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
+        normalized_reason = MonitoringAllocationInconsistentReason(reason)
 
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT,
-        message=message,
-        details=(
-            ("reason", normalized_reason.value),
-            *details,
-        ),
-    )
+        message = MONITORING_ALLOCATION_REASON_MESSAGE[normalized_reason].format(
+            context_message=f" {context_message}" if context_message else ""
+        )
 
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT,
+            message=message,
+            details=(
+                ("reason", normalized_reason.value),
+                *details,
+            ),
+        )
 
-def monitoring_run_upsert_field_override(
-    message: str, details: tuple[tuple[str, str | int | None], ...] = ()
-) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for monitoring run upsert field override."""
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
-        message=message,
-        details=(*details,),
-    )
+    # prepared context inconsistent error factory
+    @classmethod
+    def prepared_context_inconsistent(
+        cls, *, reason: str, field: str
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for inconsistent prepared context."""
+        return cls(
+            code=GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT,
+            message="Persisted prepared context is missing, malformed, or inconsistent.",
+            details=(
+                ("reason", reason),
+                ("field", field),
+            ),
+        )
 
+    # monitoring run upsert field override error factory
+    @classmethod
+    def monitoring_run_upsert_field_override(
+        cls, *, message: str, details: tuple[tuple[str, str | int | None], ...] = ()
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for monitoring run upsert field override."""
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
+            message=message,
+            details=(*details,),
+        )
 
-def timeline_state_not_found_for_subject_id(*, subject_id: str) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for missing timeline state for a subject ID."""
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
-        message=f"Timeline state not found for subject_id={subject_id!r}.",
-        details=(("subject_id", subject_id),),
-    )
+    # timeline state not found for subject ID error factory
+    @classmethod
+    def timeline_state_not_found_for_subject_id(
+        cls, *, subject_id: str
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for missing timeline state for a subject ID."""
+        return cls(
+            code=GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID,
+            message=f"Timeline state not found for subject_id={subject_id!r}.",
+            details=(("subject_id", subject_id),),
+        )
 
+    # monitoring run JSON artifact inconsistent error factory
+    @classmethod
+    def monitoring_run_json_artifact_inconsistent(
+        cls, *, monitoring_run_id: str, path: str
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for inconsistent monitoring run JSON artifact."""
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT,
+            message=(
+                f"Monitoring run JSON artifact is inconsistent for "
+                f"monitoring_run_id={monitoring_run_id!r} "
+                f"at path={path!r}."
+            ),
+            details=(
+                ("monitoring_run_id", monitoring_run_id),
+                ("path", path),
+            ),
+        )
 
-def monitoring_run_json_artifact_inconsistent(
-    *, monitoring_run_id: str, path: str
-) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for inconsistent monitoring run JSON artifact."""
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT,
-        message=(
-            f"Monitoring run JSON artifact is inconsistent for "
-            f"monitoring_run_id={monitoring_run_id!r} "
-            f"at path={path!r}."
-        ),
-        details=(
-            ("monitoring_run_id", monitoring_run_id),
-            ("path", path),
-        ),
-    )
+    # monitoring run subject inconsistent error factory
+    @classmethod
+    def monitoring_run_subject_inconsistent(
+        cls, *, subject_id: str, monitoring_run_id: str
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for a monitoring run not indexed on the subject ID."""  # noqa: E501
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT,
+            message=(
+                f"monitoring_run_id={monitoring_run_id!r} is not indexed "
+                f"on subject_id={subject_id!r}."
+            ),
+            details=(
+                ("subject_id", subject_id),
+                ("monitoring_run_id", monitoring_run_id),
+            ),
+        )
 
-
-def monitoring_run_subject_inconsistent(
-    *, subject_id: str, monitoring_run_id: str
-) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for a monitoring run not indexed on the subject ID."""
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT,
-        message=(
-            f"monitoring_run_id={monitoring_run_id!r} is not indexed on subject_id={subject_id!r}."
-        ),
-        details=(
-            ("subject_id", subject_id),
-            ("monitoring_run_id", monitoring_run_id),
-        ),
-    )
-
-
-def monitoring_reference_inconsistent(
-    *, kind: DiffReferenceKind, monitoring_run_id: str
-) -> GatewayConsistencyViolation:
-    """Create a GatewayConsistencyViolation for an inconsistent monitoring reference."""
-    return GatewayConsistencyViolation(
-        code=GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT,
-        message=(
-            f"Monitoring reference of kind={kind.value!r} is inconsistent for "
-            f"monitoring_run_id={monitoring_run_id!r}."
-        ),
-        details=(
-            ("kind", kind.value),
-            ("monitoring_run_id", monitoring_run_id),
-        ),
-    )
+    # monitoring reference inconsistent error factory
+    @classmethod
+    def monitoring_reference_inconsistent(
+        cls, *, kind: DiffReferenceKind, monitoring_run_id: str
+    ) -> GatewayConsistencyViolation:
+        """Create a GatewayConsistencyViolation for an inconsistent monitoring reference."""
+        return cls(
+            code=GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT,
+            message=(
+                f"Monitoring reference of kind={kind.value!r} is inconsistent for "
+                f"monitoring_run_id={monitoring_run_id!r}."
+            ),
+            details=(
+                ("kind", kind.value),
+                ("monitoring_run_id", monitoring_run_id),
+            ),
+        )

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -28,7 +28,7 @@ class TrainingRunMutationViolation(ValueError):
 
     def __init__(self, source_run_id: str, updates: Mapping[str, str]) -> None:
         """Initialize the violation with the source run ID and attempted updates."""
-        rendered_field = _render_message_fields(tuple(updates.items()))
+        rendered_field = _render_message_fields(updates)
         self.message = (
             "Training runs are read-only in MLflow-Monitor; "
             f"Attempted to mutate Source Training Run {source_run_id!r}; "
@@ -551,6 +551,10 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
         )
 
 
-def _render_message_fields(fields: tuple[tuple[str, str | int | None], ...]) -> str:
+def _render_message_fields(
+    fields: tuple[tuple[str, str | int | None], ...] | Mapping[str, str],
+) -> str:
     """Render message fields for error messages."""
+    if isinstance(fields, Mapping):
+        return ", ".join(sorted(fields))
     return ", ".join(f"{name}={value!r}" for name, value in fields)

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -29,11 +29,12 @@ class TrainingRunMutationViolation(ValueError):
     def __init__(self, source_run_id: str, updates: Mapping[str, str]) -> None:
         """Initialize the violation with the source run ID and attempted updates."""
         update_fields = ", ".join(sorted(updates))
-        super().__init__(
+        self.message = (
             "Training runs are read-only in MLflow-Monitor; "
             f"Attempted to mutate Source Training Run {source_run_id!r}; "
             f"update fields: {update_fields}."
         )
+        super().__init__()
 
 
 # GatewayConsistencyViolation error factories

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -19,15 +20,20 @@ class GatewayNamespaceViolation(ValueError):
         return self.message
 
 
-@dataclass(frozen=True, slots=True)
 class TrainingRunMutationViolation(ValueError):
-    """Raised when code attempts to mutate source training run data."""
+    """Raised when code attempts to mutate Source Training Run data."""
 
-    message: str
+    code = "training_run_mutation_violation"
+    reason = "attempted_mutation"
 
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
+    def __init__(self, source_run_id: str, updates: Mapping[str, str]) -> None:
+        """Initialize the violation with the source run ID and attempted updates."""
+        update_fields = ", ".join(sorted(updates))
+        super().__init__(
+            "Training runs are read-only in MLflow-Monitor; "
+            f"Attempted to mutate Source Training Run {source_run_id!r}; "
+            f"update fields: {update_fields}."
+        )
 
 
 # GatewayConsistencyViolation error factories

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -28,11 +28,11 @@ class TrainingRunMutationViolation(ValueError):
 
     def __init__(self, source_run_id: str, updates: Mapping[str, str]) -> None:
         """Initialize the violation with the source run ID and attempted updates."""
-        update_fields = ", ".join(sorted(updates))
+        rendered_field = _render_message_fields(tuple(updates.items()))
         self.message = (
             "Training runs are read-only in MLflow-Monitor; "
             f"Attempted to mutate Source Training Run {source_run_id!r}; "
-            f"update fields: {update_fields}."
+            f"update fields: {rendered_field}."
         )
         super().__init__(self.message)
 
@@ -86,10 +86,15 @@ class GatewayConsistencyViolation(ValueError):
         fields: tuple[tuple[str, str | int | None], ...] = (),
     ) -> GatewayConsistencyViolation:
         """Create a violation for one immutable Monitoring Run field override."""
-        field = [f for f, _ in fields]
+        if fields:
+            rendered_field = _render_message_fields(fields)
+            message = f"Attempted to override immutable Monitoring Run field {rendered_field}."
+        else:
+            message = "Attempted to override immutable Monitoring Run field."
+
         return cls(
             code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
-            message=f"Attempted to override immutable Monitoring Run field {field!r}.",
+            message=message,
             details=fields,
         )
 
@@ -544,3 +549,8 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
             reason=PreparedContextInconsistentReason.NONCANONICAL_REFERENCES,
             details=(("field", field),),
         )
+
+
+def _render_message_fields(fields: tuple[tuple[str, str | int | None], ...]) -> str:
+    """Render message fields for error messages."""
+    return ", ".join(f"{name}={value!r}" for name, value in fields)

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -443,7 +443,7 @@ class _PreparedContextInconsistentReason(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
-    """Raised when durable Monitoring Run allocation state is inconsistent."""
+    """Raised when persisted prepared context is missing or inconsistent."""
 
     @classmethod
     def _create(

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -1,4 +1,33 @@
-"""Custom exceptions types and factory functions for Gateway errors."""
+"""Custom exceptions types and factory functions for Gateway errors.
+
+Three main types of gateway errors:
+1. `GatewayNamespaceViolation`: a gateway operation violates namespace constraints.
+2. `TrainingRunMutationViolation`: an attempt to mutate source training run data.
+3. `GatewayConsistencyViolation`: a gateway operation violates consistency constraints.
+
+For GatewayConsistencyViolation,
+there are several specific error codes (i.e., subtypes) defined in the `GatewayConsistencyCode`:
+- "prepared_context_inconsistent": the prepared context is inconsistent with the expected state.
+- "monitoring_allocation_inconsistent": the monitoring run allocation is inconsistent with the expected state.
+- "monitoring_run_upsert_field_override": an upsert operation on a monitoring run violates field constraints.
+- "timeline_state_not_found_for_subject_id": the timeline state for a given subject ID is not found.
+- "monitoring_run_json_artifact_inconsistent": the JSON artifact of a monitoring run is inconsistent with the expected state.
+- "monitoring_run_subject_inconsistent": the subject of a monitoring run is inconsistent with the expected state.
+- "monitoring_reference_inconsistent": a monitoring reference is inconsistent with the expected state.
+
+For "monitoring_allocation_inconsistent",
+there are several specific reasons defined in the `MonitoringAllocationInconsistentReason`:
+- "duplicate_identity": multiple monitoring runs claim the same allocation identity.
+- "duplicate_sequence": multiple monitoring runs claim the sequence index.
+- "sequence_gap": there is a gap in the sequence of monitoring runs.
+- "invalid_allocation": the allocation of a monitoring run is invalid.
+- "next_sequence_ahead": the next sequence index is ahead of the expected value.
+- "unknown_pointer": the pointer to a monitoring run is unknown.
+- "unknown_tag": the tag associated with a monitoring run is unknown.
+- "source_binding_conflict": there is a conflict in the source binding of a monitoring run.
+- "timeline_conflict": there is a conflict in the timeline of monitoring runs.
+
+"""  # noqa: E501
 
 from __future__ import annotations
 

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -40,7 +40,7 @@ class TrainingRunMutationViolation(ValueError):
 # GatewayConsistencyViolation error factories
 
 
-class GatewayConsistencyCode(StrEnum):
+class _GatewayConsistencyCode(StrEnum):
     """Code for gateway consistency violations."""
 
     PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
@@ -52,7 +52,7 @@ class GatewayConsistencyCode(StrEnum):
     MONITORING_REFERENCE_INCONSISTENT = "monitoring_reference_inconsistent"
 
 
-class MonitoringAllocationInconsistentReason(StrEnum):
+class _AllocationInconsistentReason(StrEnum):
     """Reasons for monitoring run allocation inconsistent reason code."""
 
     DUPLICATE_IDENTITY = "duplicate_identity"
@@ -93,7 +93,7 @@ class GatewayConsistencyViolation(ValueError):
             message = "Attempted to override immutable Monitoring Run field."
 
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
+            code=_GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
             message=message,
             details=fields,
         )
@@ -108,7 +108,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a violation for a Monitoring Run bound to another source run."""
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
+            code=_GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE.value,
             message=(
                 "Monitoring Run source binding conflicts with durable state for "
                 f"monitoring_run_id={monitoring_run_id!r}; "
@@ -129,7 +129,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for missing timeline state for a subject ID."""
         return cls(
-            code=GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID.value,
+            code=_GatewayConsistencyCode.TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID.value,
             message=f"Timeline state not found for subject_id={subject_id!r}.",
             details=(("subject_id", subject_id),),
         )
@@ -141,7 +141,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for inconsistent monitoring run JSON artifact."""
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT.value,
+            code=_GatewayConsistencyCode.MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT.value,
             message=(
                 f"Monitoring run JSON artifact is inconsistent for "
                 f"monitoring_run_id={monitoring_run_id!r} "
@@ -160,7 +160,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for a monitoring run not indexed on the subject ID."""  # noqa: E501
         return cls(
-            code=GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT.value,
+            code=_GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT.value,
             message=(
                 f"monitoring_run_id={monitoring_run_id!r} is not indexed "
                 f"on subject_id={subject_id!r}."
@@ -178,7 +178,7 @@ class GatewayConsistencyViolation(ValueError):
     ) -> GatewayConsistencyViolation:
         """Create a GatewayConsistencyViolation for an inconsistent monitoring reference."""
         return cls(
-            code=GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT.value,
+            code=_GatewayConsistencyCode.MONITORING_REFERENCE_INCONSISTENT.value,
             message=(
                 f"Monitoring reference of kind={kind.value!r} is inconsistent for "
                 f"monitoring_run_id={monitoring_run_id!r}."
@@ -198,13 +198,13 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     def _create(
         cls,
         *,
-        reason: MonitoringAllocationInconsistentReason,
+        reason: _AllocationInconsistentReason,
         message: str,
         details: tuple[tuple[str, str | int | None], ...],
     ) -> AllocationConsistencyViolation:
         """Create a violation with its stable code and normalized reason."""
         return cls(
-            code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT.value,
+            code=_GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT.value,
             message=message,
             details=(("reason", reason.value), *details),
         )
@@ -218,7 +218,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for two Monitoring Runs with the same identity."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY,
+            reason=_AllocationInconsistentReason.DUPLICATE_IDENTITY,
             message="Multiple Monitoring Runs claim the same allocation identity.",
             details=(
                 ("first_monitoring_run_id", first_monitoring_run_id),
@@ -236,7 +236,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for two Monitoring Runs with the same sequence index."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE,
+            reason=_AllocationInconsistentReason.DUPLICATE_SEQUENCE,
             message=f"Multiple Monitoring Runs claim sequence_index={sequence_index}.",
             details=(
                 ("sequence_index", sequence_index),
@@ -254,7 +254,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for a non-contiguous allocation sequence."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.SEQUENCE_GAP,
+            reason=_AllocationInconsistentReason.SEQUENCE_GAP,
             message=(
                 "Monitoring allocation sequence is not contiguous; "
                 f"expected sequence_index={expected_sequence_index}, "
@@ -276,7 +276,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
         """Create a violation for an allocation missing required durable tags."""
         rendered_missing_tags = ", ".join(missing_tags)
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+            reason=_AllocationInconsistentReason.INVALID_ALLOCATION,
             message=(
                 f"Monitoring Run {monitoring_run_id!r} is missing durable "
                 f"allocation tags: {rendered_missing_tags}."
@@ -296,7 +296,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for a non-integer allocation sequence index."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+            reason=_AllocationInconsistentReason.INVALID_ALLOCATION,
             message=(
                 f"Monitoring Run {monitoring_run_id!r} has a non-integer "
                 f"sequence index: {raw_sequence_index!r}."
@@ -316,7 +316,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for a negative allocation sequence index."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+            reason=_AllocationInconsistentReason.INVALID_ALLOCATION,
             message=(
                 f"Monitoring Run {monitoring_run_id!r} has a negative "
                 f"sequence_index={sequence_index}."
@@ -336,7 +336,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for a persisted next sequence ahead of durable state."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD,
+            reason=_AllocationInconsistentReason.NEXT_SEQUENCE_AHEAD,
             message=(
                 "Monitoring allocation next sequence index is ahead of durable state; "
                 f"persisted sequence_index={persisted_next_sequence_index}, "
@@ -352,7 +352,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     def unknown_pointer(cls, *, monitoring_run_id: str) -> AllocationConsistencyViolation:
         """Create a violation for a pointer to an unknown allocation."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.UNKNOWN_POINTER,
+            reason=_AllocationInconsistentReason.UNKNOWN_POINTER,
             message=(
                 "Monitoring pointer references an unknown allocation for "
                 f"monitoring_run_id={monitoring_run_id!r}."
@@ -369,7 +369,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for an experiment tag pointing to an unknown allocation."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.UNKNOWN_TAG,
+            reason=_AllocationInconsistentReason.UNKNOWN_TAG,
             message=f"Experiment tag {tag!r} references an unknown allocation.",
             details=(
                 ("tag", tag),
@@ -388,7 +388,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for an allocation bound to a different source run."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT,
+            reason=_AllocationInconsistentReason.SOURCE_BINDING_CONFLICT,
             message=(
                 f"Experiment tag {tag!r} points to monitoring_run_id={monitoring_run_id!r} "
                 f"allocated for source_run_id={persisted_source_run_id!r}, "
@@ -412,7 +412,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
     ) -> AllocationConsistencyViolation:
         """Create a violation for a timeline slot that conflicts with durable state."""
         return cls._create(
-            reason=MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT,
+            reason=_AllocationInconsistentReason.TIMELINE_CONFLICT,
             message=(
                 f"Experiment timeline slot sequence_index={sequence_index} does not match "
                 "its durable Monitoring Run allocation."
@@ -425,7 +425,7 @@ class AllocationConsistencyViolation(GatewayConsistencyViolation):
         )
 
 
-class PreparedContextInconsistentReason(StrEnum):
+class _PreparedContextInconsistentReason(StrEnum):
     """Reasons for prepared context inconsistent reason code."""
 
     MISSING_ARTIFACT = "missing_artifact"
@@ -449,12 +449,12 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def _create(
         cls,
         *,
-        reason: PreparedContextInconsistentReason,
+        reason: _PreparedContextInconsistentReason,
         details: tuple[tuple[str, str | int | None], ...],
     ) -> PreparedContextConsistencyViolation:
         """Create a violation with its stable code and normalized reason."""
         return cls(
-            code=GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT.value,
+            code=_GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT.value,
             message="Persisted prepared context is missing, malformed, or inconsistent.",
             details=(("reason", reason.value), *details),
         )
@@ -464,7 +464,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def missing_artifact(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for missing artifact."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.MISSING_ARTIFACT,
+            reason=_PreparedContextInconsistentReason.MISSING_ARTIFACT,
             details=(("field", field),),
         )
 
@@ -472,7 +472,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def broken_artifact(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for broken artifact."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.BROKEN_ARTIFACT,
+            reason=_PreparedContextInconsistentReason.BROKEN_ARTIFACT,
             details=(("field", field),),
         )
 
@@ -482,7 +482,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     ) -> PreparedContextConsistencyViolation:
         """Create a violation for unsupported artifact schema version."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.UNSUPPORTED_ARTIFACT_SCHEMA_VERSION,
+            reason=_PreparedContextInconsistentReason.UNSUPPORTED_ARTIFACT_SCHEMA_VERSION,
             details=(("field", field),),
         )
 
@@ -490,7 +490,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def allocation_identity_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for allocation identity mismatch."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.ALLOCATION_IDENTITY_MISMATCH,
+            reason=_PreparedContextInconsistentReason.ALLOCATION_IDENTITY_MISMATCH,
             details=(("field", field),),
         )
 
@@ -498,7 +498,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def invalid_field_type(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for invalid field type."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.INVALID_FIELD_TYPE,
+            reason=_PreparedContextInconsistentReason.INVALID_FIELD_TYPE,
             details=(("field", field),),
         )
 
@@ -506,7 +506,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def invalid_fields(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for invalid fields."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.INVALID_FIELDS,
+            reason=_PreparedContextInconsistentReason.INVALID_FIELDS,
             details=(("field", field),),
         )
 
@@ -514,7 +514,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def effective_recipe_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for effective recipe mismatch."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.EFFECTIVE_RECIPE_MISMATCH,
+            reason=_PreparedContextInconsistentReason.EFFECTIVE_RECIPE_MISMATCH,
             details=(("field", field),),
         )
 
@@ -522,7 +522,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def contract_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for contract mismatch."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.CONTRACT_MISMATCH,
+            reason=_PreparedContextInconsistentReason.CONTRACT_MISMATCH,
             details=(("field", field),),
         )
 
@@ -530,7 +530,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def invalid_reference(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for invalid reference."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.INVALID_REFERENCE,
+            reason=_PreparedContextInconsistentReason.INVALID_REFERENCE,
             details=(("field", field),),
         )
 
@@ -538,7 +538,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def baseline_reference_mismatch(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for baseline reference mismatch."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.BASELINE_REFERENCE_MISMATCH,
+            reason=_PreparedContextInconsistentReason.BASELINE_REFERENCE_MISMATCH,
             details=(("field", field),),
         )
 
@@ -546,7 +546,7 @@ class PreparedContextConsistencyViolation(GatewayConsistencyViolation):
     def noncanonical_references(cls, *, field: str) -> PreparedContextConsistencyViolation:
         """Create a violation for noncanonical references."""
         return cls._create(
-            reason=PreparedContextInconsistentReason.NONCANONICAL_REFERENCES,
+            reason=_PreparedContextInconsistentReason.NONCANONICAL_REFERENCES,
             details=(("field", field),),
         )
 

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -1,52 +1,10 @@
-"""Custom exception types for MLflow-Monitor v0."""
-
-from __future__ import annotations
+"""Custom exceptions types and factory functions for Gateway errors."""
 
 from dataclasses import dataclass
 from enum import StrEnum
+from types import MappingProxyType
 
 from mlflow_monitor.domain import DiffReferenceKind
-
-PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
-
-
-class GatewayConsistencyCode(StrEnum):
-    """Code for gateway consistency violations."""
-
-    PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
-    MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
-    MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
-    TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
-    MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT = "monitoring_run_json_artifact_inconsistent"
-    MONITORING_RUN_SUBJECT_INCONSISTENT = "monitoring_run_subject_inconsistent"
-    MONITORING_REFERENCE_INCONSISTENT = "monitoring_reference_inconsistent"
-
-
-class MonitorAllocationReason(StrEnum):
-    """Reasons for monitoring run allocation inconsistency."""
-
-    DUPLICATE_IDENTITY = "duplicate_identity"
-    DUPLICATE_SEQUENCE = "duplicate_sequence"
-    SEQUENCE_GAP = "sequence_gap"
-    INVALID_ALLOCATION = "invalid_allocation"
-    NEXT_SEQUENCE_AHEAD = "next_sequence_ahead"
-    UNKNOWN_POINTER = "unknown_pointer"
-    SOURCE_BINDING_CONFLICT = "source_binding_conflict"
-    TIMELINE_CONFLICT = "timeline_conflict"
-
-
-@dataclass(frozen=True, slots=True)
-class InvariantViolation(ValueError):
-    """Raised when a domain invariant is violated."""
-
-    code: str
-    message: str
-    entity: str
-    field: str | None = None
-
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,83 +42,68 @@ class TrainingRunMutationViolation(ValueError):
         return self.message
 
 
-@dataclass(frozen=True, slots=True)
-class PrepareStageError(ValueError):
-    """Raised when prepare-stage workflow resolution fails deterministically."""
-
-    code: str
-    message: str
-    details: tuple[tuple[str, str | None], ...] = ()
-
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
-
-
-@dataclass(frozen=True, slots=True)
-class CheckStageError(ValueError):
-    """Raised when check-stage workflow evaluation fails deterministically."""
-
-    code: str
-    message: str
-    details: tuple[tuple[str, str | None], ...] = ()
-
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
-
-
-@dataclass(frozen=True, slots=True)
-class ContractResolutionError(ValueError):
-    """Raised when recipe-selected contract binding cannot be resolved."""
-
-    code: str
-    message: str
-    details: tuple[tuple[str, str | None], ...] = ()
-
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
-
-
-@dataclass(frozen=True, slots=True)
-class TerminalRunRetryError(ValueError):
-    """Raised when a duplicate request targets a terminal failed monitoring run."""
-
-    code: str
-    message: str
-    details: tuple[tuple[str, str | int | None], ...] = ()
-
-    def __str__(self) -> str:
-        """Return the error message when the exception is converted to a string."""
-        return self.message
-
-
-@dataclass(frozen=True, slots=True)
-class RecipeValidationIssue:
-    """One machine-readable issue discovered during recipe validation."""
-
-    code: str
-    section: str
-    message: str
-    field: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class RecipeValidationError(ValueError):
-    """Raised when one or more recipe validation checks fail."""
-
-    issues: tuple[RecipeValidationIssue, ...]
-
-    def __str__(self) -> str:
-        """Return a deterministic joined message for all validation issues."""
-        return "; ".join(issue.message for issue in self.issues)
-
-
 # error factories
 
 
 # GatewayConsistencyViolation error factories
+class GatewayConsistencyCode(StrEnum):
+    """Code for gateway consistency violations."""
+
+    PREPARED_CONTEXT_INCONSISTENT = "prepared_context_inconsistent"
+    MONITORING_ALLOCATION_INCONSISTENT = "monitoring_allocation_inconsistent"
+    MONITORING_RUN_UPSERT_FIELD_OVERRIDE = "monitoring_run_upsert_field_override"
+    TIMELINE_STATE_NOT_FOUND_FOR_SUBJECT_ID = "timeline_state_not_found_for_subject_id"
+    MONITORING_RUN_JSON_ARTIFACT_INCONSISTENT = "monitoring_run_json_artifact_inconsistent"
+    MONITORING_RUN_SUBJECT_INCONSISTENT = "monitoring_run_subject_inconsistent"
+    MONITORING_REFERENCE_INCONSISTENT = "monitoring_reference_inconsistent"
+
+
+class MonitoringAllocationInconsistentReason(StrEnum):
+    """Reasons for monitoring run allocation inconsistent error code."""
+
+    DUPLICATE_IDENTITY = "duplicate_identity"
+    DUPLICATE_SEQUENCE = "duplicate_sequence"
+    SEQUENCE_GAP = "sequence_gap"
+    INVALID_ALLOCATION = "invalid_allocation"
+    NEXT_SEQUENCE_AHEAD = "next_sequence_ahead"
+    UNKNOWN_POINTER = "unknown_pointer"
+    UNKNOWN_TAG = "unknown_tag"
+    SOURCE_BINDING_CONFLICT = "source_binding_conflict"
+    TIMELINE_CONFLICT = "timeline_conflict"
+
+
+MONITORING_ALLOCATION_REASON_MESSAGE = MappingProxyType(
+    {
+        MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY: (
+            "Multiple monitoring runs claim the same allocation identity.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE: (
+            "Multiple monitoring runs claim the sequence index.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.SEQUENCE_GAP: (
+            "Monitoring allocation sequences must be contiguous from zero.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.INVALID_ALLOCATION: (
+            "Monitoring run allocation is invalid.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD: (
+            "Monitoring run allocation's next sequence index is "
+            "ahead of the durable allocation state.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.UNKNOWN_POINTER: (
+            "Monitoring run ID points to an unknown allocation.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.UNKNOWN_TAG: (
+            "Experiment tag points to an unknown allocation.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT: (
+            "Source binding conflict detected.{context_message}"
+        ),
+        MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT: (
+            "Timeline conflict detected.{context_message}"
+        ),
+    }
+)
 
 
 def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsistencyViolation:
@@ -177,12 +120,17 @@ def prepared_context_inconsistent(*, reason: str, field: str) -> GatewayConsiste
 
 def monitoring_allocation_inconsistent(
     *,
-    reason: MonitorAllocationReason | str,
-    message: str,
+    reason: MonitoringAllocationInconsistentReason | str,
     details: tuple[tuple[str, str | int | None], ...] = (),
+    context_message: str | None = None,
 ) -> GatewayConsistencyViolation:
     """Create a GatewayConsistencyViolation for inconsistent monitoring allocation."""
-    normalized_reason = MonitorAllocationReason(reason)
+    normalized_reason = MonitoringAllocationInconsistentReason(reason)
+
+    message = MONITORING_ALLOCATION_REASON_MESSAGE[normalized_reason].format(
+        context_message=f" {context_message}" if context_message else ""
+    )
+
     return GatewayConsistencyViolation(
         code=GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT,
         message=message,

--- a/src/mlflow_monitor/errors/gateway.py
+++ b/src/mlflow_monitor/errors/gateway.py
@@ -34,7 +34,7 @@ class TrainingRunMutationViolation(ValueError):
             f"Attempted to mutate Source Training Run {source_run_id!r}; "
             f"update fields: {update_fields}."
         )
-        super().__init__()
+        super().__init__(self.message)
 
 
 # GatewayConsistencyViolation error factories

--- a/src/mlflow_monitor/errors/invariant.py
+++ b/src/mlflow_monitor/errors/invariant.py
@@ -1,0 +1,17 @@
+"""Custom exception types for domain invariant violations."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class InvariantViolation(ValueError):
+    """Raised when a domain invariant is violated."""
+
+    code: str
+    message: str
+    entity: str
+    field: str | None = None
+
+    def __str__(self) -> str:
+        """Return the error message when the exception is converted to a string."""
+        return self.message

--- a/src/mlflow_monitor/errors/recipe.py
+++ b/src/mlflow_monitor/errors/recipe.py
@@ -1,0 +1,37 @@
+"""Custom exception types for recipe validation errors."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ContractResolutionError(ValueError):
+    """Raised when recipe-selected contract binding cannot be resolved."""
+
+    code: str
+    message: str
+    details: tuple[tuple[str, str | None], ...] = ()
+
+    def __str__(self) -> str:
+        """Return the error message when the exception is converted to a string."""
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeValidationIssue:
+    """One machine-readable issue discovered during recipe validation."""
+
+    code: str
+    section: str
+    message: str
+    field: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeValidationError(ValueError):
+    """Raised when one or more recipe validation checks fail."""
+
+    issues: tuple[RecipeValidationIssue, ...]
+
+    def __str__(self) -> str:
+        """Return a deterministic joined message for all validation issues."""
+        return "; ".join(issue.message for issue in self.issues)

--- a/src/mlflow_monitor/errors/workflow.py
+++ b/src/mlflow_monitor/errors/workflow.py
@@ -1,0 +1,44 @@
+"""Custom exception types for workflow errors."""
+
+from dataclasses import dataclass
+
+PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
+
+
+@dataclass(frozen=True, slots=True)
+class PrepareStageError(ValueError):
+    """Raised when prepare-stage workflow resolution fails deterministically."""
+
+    code: str
+    message: str
+    details: tuple[tuple[str, str | None], ...] = ()
+
+    def __str__(self) -> str:
+        """Return the error message when the exception is converted to a string."""
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
+class CheckStageError(ValueError):
+    """Raised when check-stage workflow evaluation fails deterministically."""
+
+    code: str
+    message: str
+    details: tuple[tuple[str, str | None], ...] = ()
+
+    def __str__(self) -> str:
+        """Return the error message when the exception is converted to a string."""
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalRunRetryError(ValueError):
+    """Raised when a duplicate request targets a terminal failed monitoring run."""
+
+    code: str
+    message: str
+    details: tuple[tuple[str, str | int | None], ...] = ()
+
+    def __str__(self) -> str:
+        """Return the error message when the exception is converted to a string."""
+        return self.message

--- a/src/mlflow_monitor/errors/workflow.py
+++ b/src/mlflow_monitor/errors/workflow.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
+PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_baseline"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -781,10 +781,8 @@ class InMemoryMonitoringGateway:
             None
         """
         raise TrainingRunMutationViolation(
-            message=(
-                "Training runs are read-only in MLflow-Monitor; "
-                f"attempted mutation for source_run_id={source_run_id} with updates={dict(updates)}"
-            )
+            source_run_id=source_run_id,
+            updates=updates,
         )
 
     def build_monitoring_namespace(self, subject_id: str) -> str:

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -54,6 +54,7 @@ from mlflow_monitor.errors import (
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
+    monitoring_run_upsert_field_override,
 )
 from mlflow_monitor.result_contract import MonitorRunResult
 from mlflow_monitor.utils import canonical_json
@@ -1031,8 +1032,7 @@ class InMemoryMonitoringGateway:
             details += (("references", str(tuple(references))),)
 
         if bool(details):
-            raise GatewayConsistencyViolation(
-                code="monitoring_run_upsert_field_override",
+            raise monitoring_run_upsert_field_override(
                 message=(
                     "Attempted to upsert monitoring run with immutable field value: "
                     + ", ".join(f"{field}={value!r}" for field, value in details)
@@ -1102,8 +1102,7 @@ class InMemoryMonitoringGateway:
             if key.subject_id != subject_id or allocated_monitoring_run_id != monitoring_run_id:
                 continue
             if key.source_run_id != source_run_id:
-                raise GatewayConsistencyViolation(
-                    code="monitoring_run_upsert_field_override",
+                raise monitoring_run_upsert_field_override(
                     message=(
                         "Attempted to upsert monitoring run with immutable field value: "
                         f"source_run_id={source_run_id!r}"
@@ -1131,8 +1130,7 @@ class InMemoryMonitoringGateway:
                 or persisted_reference.source_run_id == reference.source_run_id
             ):
                 continue
-            raise GatewayConsistencyViolation(
-                code="monitoring_run_upsert_field_override",
+            raise monitoring_run_upsert_field_override(
                 message=(
                     "Monitoring run source identity is inconsistent for "
                     f"monitoring_run_id={reference.monitoring_run_id!r}."

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -53,6 +53,8 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import (
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
+)
+from mlflow_monitor.errors.gateway import (
     monitoring_run_json_artifact_inconsistent,
     monitoring_run_upsert_field_override,
     timeline_state_not_found_for_subject_id,

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -55,6 +55,7 @@ from mlflow_monitor.errors import (
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
     monitoring_run_upsert_field_override,
+    timeline_state_not_found_for_subject_id,
 )
 from mlflow_monitor.result_contract import MonitorRunResult
 from mlflow_monitor.utils import canonical_json
@@ -421,11 +422,7 @@ class InMemoryMonitoringGateway:
 
         timeline_state = self._timeline_by_subject.get(subject_id)
         if timeline_state is None:
-            raise GatewayConsistencyViolation(
-                code="timeline_state_not_found_for_subject_id",
-                message=f"Timeline state for subject_id '{subject_id}' not found.",
-                details=(("subject_id", subject_id),),
-            )
+            raise timeline_state_not_found_for_subject_id(subject_id=subject_id)
 
         # ready to bootstrap the timeline with the baseline source run id
         if timeline_state.baseline_source_run_id is None:

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -1003,35 +1003,31 @@ class InMemoryMonitoringGateway:
         Returns:
             None
         """
-        details: tuple[tuple[str, str | int | None], ...] = ()
+        fields: tuple[tuple[str, str | int | None], ...] = ()
 
         if monitoring_run.source_run_id != source_run_id:
-            details += (("source_run_id", source_run_id),)
+            fields += (("source_run_id", source_run_id),)
 
         if monitoring_run.sequence_index != sequence_index:
-            details += (("sequence_index", sequence_index),)
+            fields += (("sequence_index", sequence_index),)
 
         if (
             monitoring_run.contract_check_result is not None
             and contract_check_result is not None
             and monitoring_run.contract_check_result != contract_check_result
         ):
-            details += (("contract_check_result", str(contract_check_result)),)
+            fields += (("contract_check_result", str(contract_check_result)),)
 
         if (
             monitoring_run.references
             and references is not None
             and monitoring_run.references != tuple(references)
         ):
-            details += (("references", str(tuple(references))),)
+            fields += (("references", str(tuple(references))),)
 
-        if bool(details):
+        if bool(fields):
             raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-                message=(
-                    "Attempted to upsert monitoring run with immutable field value: "
-                    + ", ".join(f"{field}={value!r}" for field, value in details)
-                ),
-                details=details,
+                fields=fields,
             )
 
         return
@@ -1097,11 +1093,7 @@ class InMemoryMonitoringGateway:
                 continue
             if key.source_run_id != source_run_id:
                 raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-                    message=(
-                        "Attempted to upsert monitoring run with immutable field value: "
-                        f"source_run_id={source_run_id!r}"
-                    ),
-                    details=(("source_run_id", source_run_id),),
+                    fields=(("source_run_id", source_run_id),),
                 )
             return
 
@@ -1125,11 +1117,7 @@ class InMemoryMonitoringGateway:
             ):
                 continue
             raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-                message=(
-                    "Monitoring run source identity is inconsistent for "
-                    f"monitoring_run_id={reference.monitoring_run_id!r}."
-                ),
-                details=(
+                fields=(
                     ("monitoring_run_id", reference.monitoring_run_id),
                     ("source_run_id", reference.source_run_id),
                     ("persisted_source_run_id", persisted_reference.source_run_id),

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -51,9 +51,9 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
+    monitoring_run_json_artifact_inconsistent,
     monitoring_run_upsert_field_override,
     timeline_state_not_found_for_subject_id,
 )
@@ -915,12 +915,9 @@ class InMemoryMonitoringGateway:
         if existing_artifact_encoded == encoded:
             return
 
-        raise GatewayConsistencyViolation(
-            code="monitoring_run_json_artifact_inconsistent",
-            message=(
-                "Existing monitoring run JSON artifact is inconsistent with the requested data."
-            ),
-            details=(("monitoring_run_id", monitoring_run_id), ("path", path)),
+        raise monitoring_run_json_artifact_inconsistent(
+            monitoring_run_id=monitoring_run_id,
+            path=path,
         )
 
     def _encode_monitoring_run_json_artifact(

--- a/src/mlflow_monitor/gateway.py
+++ b/src/mlflow_monitor/gateway.py
@@ -51,13 +51,9 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
+    GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
-)
-from mlflow_monitor.errors.gateway import (
-    monitoring_run_json_artifact_inconsistent,
-    monitoring_run_upsert_field_override,
-    timeline_state_not_found_for_subject_id,
 )
 from mlflow_monitor.result_contract import MonitorRunResult
 from mlflow_monitor.utils import canonical_json
@@ -424,7 +420,9 @@ class InMemoryMonitoringGateway:
 
         timeline_state = self._timeline_by_subject.get(subject_id)
         if timeline_state is None:
-            raise timeline_state_not_found_for_subject_id(subject_id=subject_id)
+            raise GatewayConsistencyViolation.timeline_state_not_found_for_subject_id(
+                subject_id=subject_id
+            )
 
         # ready to bootstrap the timeline with the baseline source run id
         if timeline_state.baseline_source_run_id is None:
@@ -917,7 +915,7 @@ class InMemoryMonitoringGateway:
         if existing_artifact_encoded == encoded:
             return
 
-        raise monitoring_run_json_artifact_inconsistent(
+        raise GatewayConsistencyViolation.monitoring_run_json_artifact_inconsistent(
             monitoring_run_id=monitoring_run_id,
             path=path,
         )
@@ -1028,7 +1026,7 @@ class InMemoryMonitoringGateway:
             details += (("references", str(tuple(references))),)
 
         if bool(details):
-            raise monitoring_run_upsert_field_override(
+            raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
                 message=(
                     "Attempted to upsert monitoring run with immutable field value: "
                     + ", ".join(f"{field}={value!r}" for field, value in details)
@@ -1098,7 +1096,7 @@ class InMemoryMonitoringGateway:
             if key.subject_id != subject_id or allocated_monitoring_run_id != monitoring_run_id:
                 continue
             if key.source_run_id != source_run_id:
-                raise monitoring_run_upsert_field_override(
+                raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
                     message=(
                         "Attempted to upsert monitoring run with immutable field value: "
                         f"source_run_id={source_run_id!r}"
@@ -1126,7 +1124,7 @@ class InMemoryMonitoringGateway:
                 or persisted_reference.source_run_id == reference.source_run_id
             ):
                 continue
-            raise monitoring_run_upsert_field_override(
+            raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
                 message=(
                     "Monitoring run source identity is inconsistent for "
                     f"monitoring_run_id={reference.monitoring_run_id!r}."

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -661,10 +661,8 @@ class MLflowMonitoringGateway:
             TrainingRunMutationViolation: Always. Training runs are read-only.
         """
         raise TrainingRunMutationViolation(
-            message=(
-                "Training runs are read-only in MLflow-Monitor; "
-                f"attempted mutation for source_run_id={source_run_id} with updates={dict(updates)}"
-            )
+            source_run_id=source_run_id,
+            updates=updates,
         )
 
     def finalize_monitoring_run_result(

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -44,12 +44,10 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
+    AllocationConsistencyViolation,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
-)
-from mlflow_monitor.errors.gateway import (
-    MonitoringAllocationInconsistentReason,
 )
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -829,25 +827,16 @@ class MLflowMonitoringGateway:
         for allocation in allocations:
             existing_key_allocation = allocations_by_key.get(allocation.key)
             if existing_key_allocation is not None:
-                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                    reason=MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY,
-                    details=(
-                        ("first_monitoring_run_id", existing_key_allocation.monitoring_run_id),
-                        ("second_monitoring_run_id", allocation.monitoring_run_id),
-                    ),
+                raise AllocationConsistencyViolation.duplicate_identity(
+                    first_monitoring_run_id=existing_key_allocation.monitoring_run_id,
+                    second_monitoring_run_id=allocation.monitoring_run_id,
                 )
             existing_sequence_allocation = allocations_by_sequence.get(allocation.sequence_index)
             if existing_sequence_allocation is not None:
-                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                    reason=MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE,
-                    details=(
-                        ("sequence_index", allocation.sequence_index),
-                        (
-                            "first_monitoring_run_id",
-                            existing_sequence_allocation.monitoring_run_id,
-                        ),
-                        ("second_monitoring_run_id", allocation.monitoring_run_id),
-                    ),
+                raise AllocationConsistencyViolation.duplicate_sequence(
+                    sequence_index=allocation.sequence_index,
+                    first_monitoring_run_id=existing_sequence_allocation.monitoring_run_id,
+                    second_monitoring_run_id=allocation.monitoring_run_id,
                 )
             allocations_by_key[allocation.key] = allocation
             allocations_by_sequence[allocation.sequence_index] = allocation
@@ -858,12 +847,9 @@ class MLflowMonitoringGateway:
         )
         for expected_sequence, allocation in enumerate(ordered_allocations):
             if allocation.sequence_index != expected_sequence:
-                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                    reason=MonitoringAllocationInconsistentReason.SEQUENCE_GAP,
-                    details=(
-                        ("expected_sequence_index", expected_sequence),
-                        ("actual_sequence_index", allocation.sequence_index),
-                    ),
+                raise AllocationConsistencyViolation.sequence_gap(
+                    expected_sequence_index=expected_sequence,
+                    actual_sequence_index=allocation.sequence_index,
                 )
 
         next_sequence_index = len(ordered_allocations)
@@ -888,7 +874,7 @@ class MLflowMonitoringGateway:
         recipe_id = snapshot.tags.get(_RECIPE_ID_TAG)
         recipe_version = snapshot.tags.get(_RECIPE_VERSION_TAG)
         raw_sequence_index = snapshot.tags.get(_SEQUENCE_INDEX_TAG)
-        missing_fields = tuple(
+        missing_tags = tuple(
             field
             for field, value in (
                 (_SOURCE_RUN_TAG, source_run_id),
@@ -898,14 +884,10 @@ class MLflowMonitoringGateway:
             )
             if not value
         )
-        if not snapshot.run_id or missing_fields:
-            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
-                details=(("monitoring_run_id", snapshot.run_id),),
-                context_message=(
-                    f"Monitoring run {snapshot.run_id!r} is missing durable allocation tags: "
-                    + ", ".join(missing_fields)
-                ),
+        if not snapshot.run_id or missing_tags:
+            raise AllocationConsistencyViolation.missing_durable_tags(
+                monitoring_run_id=snapshot.run_id,
+                missing_tags=missing_tags,
             )
 
         assert source_run_id is not None
@@ -916,25 +898,15 @@ class MLflowMonitoringGateway:
         try:
             sequence_index = int(raw_sequence_index)
         except (TypeError, ValueError) as exc:
-            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
-                details=(("monitoring_run_id", snapshot.run_id),),
-                context_message=(
-                    f"Monitoring run {snapshot.run_id!r} has a non-integer sequence index: "
-                    f"{raw_sequence_index!r}."
-                ),
+            raise AllocationConsistencyViolation.non_integer_sequence(
+                monitoring_run_id=snapshot.run_id,
+                raw_sequence_index=raw_sequence_index,
             ) from exc
+
         if sequence_index < 0:
-            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
-                details=(
-                    ("monitoring_run_id", snapshot.run_id),
-                    ("sequence_index", sequence_index),
-                ),
-                context_message=(
-                    f"Monitoring run {snapshot.run_id!r} has a negative sequence index: "
-                    f"{sequence_index}."
-                ),
+            raise AllocationConsistencyViolation.negative_sequence(
+                monitoring_run_id=snapshot.run_id,
+                sequence_index=sequence_index,
             )
 
         return _MonitoringRunAllocation(
@@ -963,12 +935,9 @@ class MLflowMonitoringGateway:
 
         persisted_next_sequence = self._read_next_sequence_index(experiment_tags)
         if persisted_next_sequence > next_sequence_index:
-            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                reason=MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD,
-                details=(
-                    ("persisted_next_sequence_index", persisted_next_sequence),
-                    ("durable_next_sequence_index", next_sequence_index),
-                ),
+            raise AllocationConsistencyViolation.next_sequence_ahead(
+                persisted_next_sequence_index=persisted_next_sequence,
+                durable_next_sequence_index=next_sequence_index,
             )
 
         repairs: dict[str, str] = {}
@@ -1023,20 +992,12 @@ class MLflowMonitoringGateway:
 
             allocation = allocations_by_sequence.get(sequence_index)
             if allocation is None or allocation.monitoring_run_id != monitoring_run_id:
-                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                    reason=MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT,
-                    details=(
-                        ("sequence_index", sequence_index),
-                        ("indexed_monitoring_run_id", monitoring_run_id),
-                        (
-                            "durable_monitoring_run_id",
-                            None if allocation is None else allocation.monitoring_run_id,
-                        ),
-                    ),
-                    context_message=(
-                        f"Experiment timeline slot with sequence_index={sequence_index} "
-                        "does not match its durable monitoring run allocation."
-                    ),
+                raise AllocationConsistencyViolation.timeline_conflict(
+                    sequence_index=sequence_index,
+                    indexed_monitoring_run_id=monitoring_run_id,
+                    durable_monitoring_run_id=None
+                    if allocation is None
+                    else allocation.monitoring_run_id,
                 )
 
     def _validate_allocation_pointer_tags(
@@ -1047,10 +1008,8 @@ class MLflowMonitoringGateway:
         """Validate latest and source pointers before any repair writes occur."""
         latest_run_id = experiment_tags.get(_LATEST_TAG)
         if latest_run_id and latest_run_id not in allocations_by_run_id:
-            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                reason=MonitoringAllocationInconsistentReason.UNKNOWN_POINTER,
-                details=(("monitoring_run_id", latest_run_id),),
-                context_message=f"monitoring_run_id={latest_run_id!r}.",
+            raise AllocationConsistencyViolation.unknown_pointer(
+                monitoring_run_id=latest_run_id,
             )
 
         source_prefix = "training."
@@ -1068,22 +1027,16 @@ class MLflowMonitoringGateway:
                 )
             allocation = allocations_by_run_id.get(monitoring_run_id)
             if allocation is None:
-                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                    reason=MonitoringAllocationInconsistentReason.UNKNOWN_TAG,
-                    details=(("monitoring_run_id", monitoring_run_id), ("tag", tag_key)),
-                    context_message=f"tag={tag_key!r}.",
+                raise AllocationConsistencyViolation.unknown_tag(
+                    tag=tag_key,
+                    monitoring_run_id=monitoring_run_id,
                 )
             if allocation.key.source_run_id != source_run_id:
-                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                    reason=MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT,
-                    details=(
-                        ("source_run_id", source_run_id),
-                        ("monitoring_run_id", monitoring_run_id),
-                    ),
-                    context_message=(
-                        f"Experiment tag={tag_key!r} points to a monitoring run allocated "
-                        f"for source_run_id={allocation.key.source_run_id!r}."
-                    ),
+                raise AllocationConsistencyViolation.source_binding_conflict(
+                    tag=tag_key,
+                    monitoring_run_id=monitoring_run_id,
+                    source_run_id=source_run_id,
+                    persisted_source_run_id=allocation.key.source_run_id,
                 )
 
     def _set_experiment_tags(self, experiment_id: str, tags: Mapping[str, str]) -> None:
@@ -1184,13 +1137,7 @@ class MLflowMonitoringGateway:
     ) -> GatewayConsistencyViolation:
         """Build a structured error for one contradictory monitoring/source pair."""
         raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-            message=(
-                "Attempted to upsert monitoring run with immutable field value: "
-                f"monitoring_run_id={monitoring_run_id!r}, "
-                f"source_run_id={source_run_id!r}, "
-                f"persisted_source_run_id={persisted_source_run_id!r}"
-            ),
-            details=(
+            fields=(
                 ("monitoring_run_id", monitoring_run_id),
                 ("source_run_id", source_run_id),
                 ("persisted_source_run_id", persisted_source_run_id),
@@ -1228,14 +1175,7 @@ class MLflowMonitoringGateway:
             tag.value for tag in RequiredMonitoringRunTags if not run_tags.get(tag.value)
         )
         if missing_tags:
-            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
-                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
-                details=(
-                    ("monitoring_run_id", monitoring_run_id),
-                    ("missing_tags", ",".join(missing_tags)),
-                ),
-                context_message=(
-                    f"Monitoring run {monitoring_run_id!r} is missing durable allocation tags: "
-                    + ", ".join(missing_tags)
-                ),
+            raise AllocationConsistencyViolation.missing_durable_tags(
+                monitoring_run_id=monitoring_run_id,
+                missing_tags=missing_tags,
             )

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -1134,7 +1134,7 @@ class MLflowMonitoringGateway:
         persisted_source_run_id: str | None,
     ) -> GatewayConsistencyViolation:
         """Build a structured error for one contradictory monitoring/source pair."""
-        raise GatewayConsistencyViolation.monitoring_run_upsert_source_binding_conflict(
+        return GatewayConsistencyViolation.monitoring_run_upsert_source_binding_conflict(
             monitoring_run_id=monitoring_run_id,
             source_run_id=source_run_id,
             persisted_source_run_id=persisted_source_run_id,

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -47,6 +47,7 @@ from mlflow_monitor.errors import (
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
+    monitoring_allocation_inconsistent,
 )
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -837,7 +838,7 @@ class MLflowMonitoringGateway:
         for allocation in allocations:
             existing_key_allocation = allocations_by_key.get(allocation.key)
             if existing_key_allocation is not None:
-                raise self._allocation_consistency_error(
+                raise monitoring_allocation_inconsistent(
                     reason="duplicate_identity",
                     message="Multiple monitoring runs claim the same allocation identity.",
                     details=(
@@ -847,7 +848,7 @@ class MLflowMonitoringGateway:
                 )
             existing_sequence_allocation = allocations_by_sequence.get(allocation.sequence_index)
             if existing_sequence_allocation is not None:
-                raise self._allocation_consistency_error(
+                raise monitoring_allocation_inconsistent(
                     reason="duplicate_sequence",
                     message=(
                         "Multiple monitoring runs claim sequence index "
@@ -871,7 +872,7 @@ class MLflowMonitoringGateway:
         )
         for expected_sequence, allocation in enumerate(ordered_allocations):
             if allocation.sequence_index != expected_sequence:
-                raise self._allocation_consistency_error(
+                raise monitoring_allocation_inconsistent(
                     reason="sequence_gap",
                     message=(
                         "Monitoring allocation sequences must be contiguous from zero; "
@@ -916,7 +917,7 @@ class MLflowMonitoringGateway:
             if not value
         )
         if not snapshot.run_id or missing_fields:
-            raise self._allocation_consistency_error(
+            raise monitoring_allocation_inconsistent(
                 reason="invalid_allocation",
                 message=(
                     f"Monitoring run {snapshot.run_id!r} is missing durable allocation tags: "
@@ -933,7 +934,7 @@ class MLflowMonitoringGateway:
         try:
             sequence_index = int(raw_sequence_index)
         except (TypeError, ValueError) as exc:
-            raise self._allocation_consistency_error(
+            raise monitoring_allocation_inconsistent(
                 reason="invalid_allocation",
                 message=(
                     f"Monitoring run {snapshot.run_id!r} has a non-integer sequence index: "
@@ -942,7 +943,7 @@ class MLflowMonitoringGateway:
                 details=(("monitoring_run_id", snapshot.run_id),),
             ) from exc
         if sequence_index < 0:
-            raise self._allocation_consistency_error(
+            raise monitoring_allocation_inconsistent(
                 reason="invalid_allocation",
                 message=(
                     f"Monitoring run {snapshot.run_id!r} has a negative sequence index: "
@@ -980,7 +981,7 @@ class MLflowMonitoringGateway:
 
         persisted_next_sequence = self._read_next_sequence_index(experiment_tags)
         if persisted_next_sequence > next_sequence_index:
-            raise self._allocation_consistency_error(
+            raise monitoring_allocation_inconsistent(
                 reason="next_sequence_ahead",
                 message=(
                     "monitoring.next_sequence_index is ahead of durable allocation state; "
@@ -1044,7 +1045,7 @@ class MLflowMonitoringGateway:
 
             allocation = allocations_by_sequence.get(sequence_index)
             if allocation is None or allocation.monitoring_run_id != monitoring_run_id:
-                raise self._allocation_consistency_error(
+                raise monitoring_allocation_inconsistent(
                     reason="timeline_conflict",
                     message=(
                         f"Experiment timeline slot {sequence_index} does not match its "
@@ -1068,7 +1069,7 @@ class MLflowMonitoringGateway:
         """Validate latest and source pointers before any repair writes occur."""
         latest_run_id = experiment_tags.get(_LATEST_TAG)
         if latest_run_id and latest_run_id not in allocations_by_run_id:
-            raise self._allocation_consistency_error(
+            raise monitoring_allocation_inconsistent(
                 reason="unknown_pointer",
                 message="monitoring.latest_run_id points to an unknown allocation.",
                 details=(("monitoring_run_id", latest_run_id),),
@@ -1089,13 +1090,13 @@ class MLflowMonitoringGateway:
                 )
             allocation = allocations_by_run_id.get(monitoring_run_id)
             if allocation is None:
-                raise self._allocation_consistency_error(
+                raise monitoring_allocation_inconsistent(
                     reason="unknown_pointer",
                     message=f"Experiment tag {tag_key!r} points to an unknown allocation.",
                     details=(("monitoring_run_id", monitoring_run_id),),
                 )
             if allocation.key.source_run_id != source_run_id:
-                raise self._allocation_consistency_error(
+                raise monitoring_allocation_inconsistent(
                     reason="source_binding_conflict",
                     message=(
                         f"Experiment tag {tag_key!r} points to a monitoring run allocated "
@@ -1107,19 +1108,19 @@ class MLflowMonitoringGateway:
                     ),
                 )
 
-    def _allocation_consistency_error(
-        self,
-        *,
-        reason: str,
-        message: str,
-        details: tuple[tuple[str, str | int | None], ...] = (),
-    ) -> GatewayConsistencyViolation:
-        """Build one operator-visible allocation consistency error."""
-        return GatewayConsistencyViolation(
-            code="monitoring_allocation_inconsistent",
-            message=message,
-            details=(("reason", reason), *details),
-        )
+    # def _allocation_consistency_error(
+    #     self,
+    #     *,
+    #     reason: str,
+    #     message: str,
+    #     details: tuple[tuple[str, str | int | None], ...] = (),
+    # ) -> GatewayConsistencyViolation:
+    #     """Build one operator-visible allocation consistency error."""
+    #     return GatewayConsistencyViolation(
+    #         code="monitoring_allocation_inconsistent",
+    #         message=message,
+    #         details=(("reason", reason), *details),
+    #     )
 
     def _set_experiment_tags(self, experiment_id: str, tags: Mapping[str, str]) -> None:
         """Write a batch of experiment tags via the thin MLflow adapter."""
@@ -1262,7 +1263,7 @@ class MLflowMonitoringGateway:
             tag.value for tag in RequiredMonitoringRunTags if not run_tags.get(tag.value)
         )
         if missing_tags:
-            raise self._allocation_consistency_error(
+            raise monitoring_allocation_inconsistent(
                 reason="invalid_allocation",
                 message=(
                     f"Monitoring run {monitoring_run_id!r} is missing durable allocation tags: "

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -46,6 +46,7 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import (
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
+    MonitorAllocationReason,
     TrainingRunMutationViolation,
     monitoring_allocation_inconsistent,
     monitoring_run_upsert_field_override,
@@ -837,7 +838,7 @@ class MLflowMonitoringGateway:
             existing_key_allocation = allocations_by_key.get(allocation.key)
             if existing_key_allocation is not None:
                 raise monitoring_allocation_inconsistent(
-                    reason="duplicate_identity",
+                    reason=MonitorAllocationReason.DUPLICATE_IDENTITY,
                     message="Multiple monitoring runs claim the same allocation identity.",
                     details=(
                         ("first_monitoring_run_id", existing_key_allocation.monitoring_run_id),
@@ -847,7 +848,7 @@ class MLflowMonitoringGateway:
             existing_sequence_allocation = allocations_by_sequence.get(allocation.sequence_index)
             if existing_sequence_allocation is not None:
                 raise monitoring_allocation_inconsistent(
-                    reason="duplicate_sequence",
+                    reason=MonitorAllocationReason.DUPLICATE_SEQUENCE,
                     message=(
                         "Multiple monitoring runs claim sequence index "
                         f"{allocation.sequence_index}."
@@ -871,7 +872,7 @@ class MLflowMonitoringGateway:
         for expected_sequence, allocation in enumerate(ordered_allocations):
             if allocation.sequence_index != expected_sequence:
                 raise monitoring_allocation_inconsistent(
-                    reason="sequence_gap",
+                    reason=MonitorAllocationReason.SEQUENCE_GAP,
                     message=(
                         "Monitoring allocation sequences must be contiguous from zero; "
                         f"expected {expected_sequence}, got {allocation.sequence_index}."
@@ -916,7 +917,7 @@ class MLflowMonitoringGateway:
         )
         if not snapshot.run_id or missing_fields:
             raise monitoring_allocation_inconsistent(
-                reason="invalid_allocation",
+                reason=MonitorAllocationReason.INVALID_ALLOCATION,
                 message=(
                     f"Monitoring run {snapshot.run_id!r} is missing durable allocation tags: "
                     + ", ".join(missing_fields)
@@ -933,7 +934,7 @@ class MLflowMonitoringGateway:
             sequence_index = int(raw_sequence_index)
         except (TypeError, ValueError) as exc:
             raise monitoring_allocation_inconsistent(
-                reason="invalid_allocation",
+                reason=MonitorAllocationReason.INVALID_ALLOCATION,
                 message=(
                     f"Monitoring run {snapshot.run_id!r} has a non-integer sequence index: "
                     f"{raw_sequence_index!r}."
@@ -942,7 +943,7 @@ class MLflowMonitoringGateway:
             ) from exc
         if sequence_index < 0:
             raise monitoring_allocation_inconsistent(
-                reason="invalid_allocation",
+                reason=MonitorAllocationReason.INVALID_ALLOCATION,
                 message=(
                     f"Monitoring run {snapshot.run_id!r} has a negative sequence index: "
                     f"{sequence_index}."
@@ -980,7 +981,7 @@ class MLflowMonitoringGateway:
         persisted_next_sequence = self._read_next_sequence_index(experiment_tags)
         if persisted_next_sequence > next_sequence_index:
             raise monitoring_allocation_inconsistent(
-                reason="next_sequence_ahead",
+                reason=MonitorAllocationReason.NEXT_SEQUENCE_AHEAD,
                 message=(
                     "monitoring.next_sequence_index is ahead of durable allocation state; "
                     f"got {persisted_next_sequence}, expected {next_sequence_index}."
@@ -1044,7 +1045,7 @@ class MLflowMonitoringGateway:
             allocation = allocations_by_sequence.get(sequence_index)
             if allocation is None or allocation.monitoring_run_id != monitoring_run_id:
                 raise monitoring_allocation_inconsistent(
-                    reason="timeline_conflict",
+                    reason=MonitorAllocationReason.TIMELINE_CONFLICT,
                     message=(
                         f"Experiment timeline slot {sequence_index} does not match its "
                         "durable monitoring-run allocation."
@@ -1068,7 +1069,7 @@ class MLflowMonitoringGateway:
         latest_run_id = experiment_tags.get(_LATEST_TAG)
         if latest_run_id and latest_run_id not in allocations_by_run_id:
             raise monitoring_allocation_inconsistent(
-                reason="unknown_pointer",
+                reason=MonitorAllocationReason.UNKNOWN_POINTER,
                 message="monitoring.latest_run_id points to an unknown allocation.",
                 details=(("monitoring_run_id", latest_run_id),),
             )
@@ -1089,13 +1090,13 @@ class MLflowMonitoringGateway:
             allocation = allocations_by_run_id.get(monitoring_run_id)
             if allocation is None:
                 raise monitoring_allocation_inconsistent(
-                    reason="unknown_pointer",
+                    reason=MonitorAllocationReason.UNKNOWN_POINTER,
                     message=f"Experiment tag {tag_key!r} points to an unknown allocation.",
                     details=(("monitoring_run_id", monitoring_run_id),),
                 )
             if allocation.key.source_run_id != source_run_id:
                 raise monitoring_allocation_inconsistent(
-                    reason="source_binding_conflict",
+                    reason=MonitorAllocationReason.SOURCE_BINDING_CONFLICT,
                     message=(
                         f"Experiment tag {tag_key!r} points to a monitoring run allocated "
                         f"for source {allocation.key.source_run_id!r}."
@@ -1105,20 +1106,6 @@ class MLflowMonitoringGateway:
                         ("monitoring_run_id", monitoring_run_id),
                     ),
                 )
-
-    # def _allocation_consistency_error(
-    #     self,
-    #     *,
-    #     reason: str,
-    #     message: str,
-    #     details: tuple[tuple[str, str | int | None], ...] = (),
-    # ) -> GatewayConsistencyViolation:
-    #     """Build one operator-visible allocation consistency error."""
-    #     return GatewayConsistencyViolation(
-    #         code="monitoring_allocation_inconsistent",
-    #         message=message,
-    #         details=(("reason", reason), *details),
-    #     )
 
     def _set_experiment_tags(self, experiment_id: str, tags: Mapping[str, str]) -> None:
         """Write a batch of experiment tags via the thin MLflow adapter."""
@@ -1263,7 +1250,7 @@ class MLflowMonitoringGateway:
         )
         if missing_tags:
             raise monitoring_allocation_inconsistent(
-                reason="invalid_allocation",
+                reason=MonitorAllocationReason.INVALID_ALLOCATION,
                 message=(
                     f"Monitoring run {monitoring_run_id!r} is missing durable allocation tags: "
                     + ", ".join(missing_tags)

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -50,11 +50,6 @@ from mlflow_monitor.errors import (
 )
 from mlflow_monitor.errors.gateway import (
     MonitoringAllocationInconsistentReason,
-    monitoring_allocation_inconsistent,
-    monitoring_run_json_artifact_inconsistent,
-    monitoring_run_subject_inconsistent,
-    monitoring_run_upsert_field_override,
-    timeline_state_not_found_for_subject_id,
 )
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -236,7 +231,9 @@ class MLflowMonitoringGateway:
 
         timeline_state = self.get_timeline_state(subject_id)
         if timeline_state is None:
-            raise timeline_state_not_found_for_subject_id(subject_id=subject_id)
+            raise GatewayConsistencyViolation.timeline_state_not_found_for_subject_id(
+                subject_id=subject_id
+            )
 
         if timeline_state.baseline_source_run_id is not None:
             return TimelinePinBaselineResult(
@@ -327,7 +324,7 @@ class MLflowMonitoringGateway:
         """
         self._validate_subject_id(subject_id)
         if self.resolve_timeline_monitoring_run_id(subject_id, monitoring_run_id) is None:
-            raise monitoring_run_subject_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_run_subject_inconsistent(
                 subject_id=subject_id,
                 monitoring_run_id=monitoring_run_id,
             )
@@ -785,7 +782,7 @@ class MLflowMonitoringGateway:
         if canonical_json(existing_artifact) == canonical_json(data):
             return
 
-        raise monitoring_run_json_artifact_inconsistent(
+        raise GatewayConsistencyViolation.monitoring_run_json_artifact_inconsistent(
             monitoring_run_id=monitoring_run_id,
             path=path,
         )
@@ -832,7 +829,7 @@ class MLflowMonitoringGateway:
         for allocation in allocations:
             existing_key_allocation = allocations_by_key.get(allocation.key)
             if existing_key_allocation is not None:
-                raise monitoring_allocation_inconsistent(
+                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                     reason=MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY,
                     details=(
                         ("first_monitoring_run_id", existing_key_allocation.monitoring_run_id),
@@ -841,7 +838,7 @@ class MLflowMonitoringGateway:
                 )
             existing_sequence_allocation = allocations_by_sequence.get(allocation.sequence_index)
             if existing_sequence_allocation is not None:
-                raise monitoring_allocation_inconsistent(
+                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                     reason=MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE,
                     details=(
                         ("sequence_index", allocation.sequence_index),
@@ -861,7 +858,7 @@ class MLflowMonitoringGateway:
         )
         for expected_sequence, allocation in enumerate(ordered_allocations):
             if allocation.sequence_index != expected_sequence:
-                raise monitoring_allocation_inconsistent(
+                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                     reason=MonitoringAllocationInconsistentReason.SEQUENCE_GAP,
                     details=(
                         ("expected_sequence_index", expected_sequence),
@@ -902,7 +899,7 @@ class MLflowMonitoringGateway:
             if not value
         )
         if not snapshot.run_id or missing_fields:
-            raise monitoring_allocation_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                 reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
                 details=(("monitoring_run_id", snapshot.run_id),),
                 context_message=(
@@ -919,7 +916,7 @@ class MLflowMonitoringGateway:
         try:
             sequence_index = int(raw_sequence_index)
         except (TypeError, ValueError) as exc:
-            raise monitoring_allocation_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                 reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
                 details=(("monitoring_run_id", snapshot.run_id),),
                 context_message=(
@@ -928,7 +925,7 @@ class MLflowMonitoringGateway:
                 ),
             ) from exc
         if sequence_index < 0:
-            raise monitoring_allocation_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                 reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
                 details=(
                     ("monitoring_run_id", snapshot.run_id),
@@ -966,7 +963,7 @@ class MLflowMonitoringGateway:
 
         persisted_next_sequence = self._read_next_sequence_index(experiment_tags)
         if persisted_next_sequence > next_sequence_index:
-            raise monitoring_allocation_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                 reason=MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD,
                 details=(
                     ("persisted_next_sequence_index", persisted_next_sequence),
@@ -1026,7 +1023,7 @@ class MLflowMonitoringGateway:
 
             allocation = allocations_by_sequence.get(sequence_index)
             if allocation is None or allocation.monitoring_run_id != monitoring_run_id:
-                raise monitoring_allocation_inconsistent(
+                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                     reason=MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT,
                     details=(
                         ("sequence_index", sequence_index),
@@ -1050,7 +1047,7 @@ class MLflowMonitoringGateway:
         """Validate latest and source pointers before any repair writes occur."""
         latest_run_id = experiment_tags.get(_LATEST_TAG)
         if latest_run_id and latest_run_id not in allocations_by_run_id:
-            raise monitoring_allocation_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                 reason=MonitoringAllocationInconsistentReason.UNKNOWN_POINTER,
                 details=(("monitoring_run_id", latest_run_id),),
                 context_message=f"monitoring_run_id={latest_run_id!r}.",
@@ -1071,13 +1068,13 @@ class MLflowMonitoringGateway:
                 )
             allocation = allocations_by_run_id.get(monitoring_run_id)
             if allocation is None:
-                raise monitoring_allocation_inconsistent(
+                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                     reason=MonitoringAllocationInconsistentReason.UNKNOWN_TAG,
                     details=(("monitoring_run_id", monitoring_run_id), ("tag", tag_key)),
                     context_message=f"tag={tag_key!r}.",
                 )
             if allocation.key.source_run_id != source_run_id:
-                raise monitoring_allocation_inconsistent(
+                raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                     reason=MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT,
                     details=(
                         ("source_run_id", source_run_id),
@@ -1186,7 +1183,7 @@ class MLflowMonitoringGateway:
         persisted_source_run_id: str | None,
     ) -> GatewayConsistencyViolation:
         """Build a structured error for one contradictory monitoring/source pair."""
-        raise monitoring_run_upsert_field_override(
+        raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
             message=(
                 "Attempted to upsert monitoring run with immutable field value: "
                 f"monitoring_run_id={monitoring_run_id!r}, "
@@ -1231,7 +1228,7 @@ class MLflowMonitoringGateway:
             tag.value for tag in RequiredMonitoringRunTags if not run_tags.get(tag.value)
         )
         if missing_tags:
-            raise monitoring_allocation_inconsistent(
+            raise GatewayConsistencyViolation.monitoring_allocation_inconsistent(
                 reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
                 details=(
                     ("monitoring_run_id", monitoring_run_id),

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -49,6 +49,7 @@ from mlflow_monitor.errors import (
     TrainingRunMutationViolation,
     monitoring_allocation_inconsistent,
     monitoring_run_upsert_field_override,
+    timeline_state_not_found_for_subject_id,
 )
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -230,11 +231,7 @@ class MLflowMonitoringGateway:
 
         timeline_state = self.get_timeline_state(subject_id)
         if timeline_state is None:
-            raise GatewayConsistencyViolation(
-                code="timeline_state_not_found_for_subject_id",
-                message=f"Timeline state for subject_id '{subject_id}' not found.",
-                details=(("subject_id", subject_id),),
-            )
+            raise timeline_state_not_found_for_subject_id(subject_id=subject_id)
 
         if timeline_state.baseline_source_run_id is not None:
             return TimelinePinBaselineResult(

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -1134,12 +1134,10 @@ class MLflowMonitoringGateway:
         persisted_source_run_id: str | None,
     ) -> GatewayConsistencyViolation:
         """Build a structured error for one contradictory monitoring/source pair."""
-        raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-            fields=(
-                ("monitoring_run_id", monitoring_run_id),
-                ("source_run_id", source_run_id),
-                ("persisted_source_run_id", persisted_source_run_id),
-            ),
+        raise GatewayConsistencyViolation.monitoring_run_upsert_source_binding_conflict(
+            monitoring_run_id=monitoring_run_id,
+            source_run_id=source_run_id,
+            persisted_source_run_id=persisted_source_run_id,
         )
 
     def _validate_namespace_prefix(self, prefix: str) -> None:

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -49,6 +49,8 @@ from mlflow_monitor.errors import (
     MonitorAllocationReason,
     TrainingRunMutationViolation,
     monitoring_allocation_inconsistent,
+    monitoring_run_json_artifact_inconsistent,
+    monitoring_run_subject_inconsistent,
     monitoring_run_upsert_field_override,
     timeline_state_not_found_for_subject_id,
 )
@@ -323,17 +325,11 @@ class MLflowMonitoringGateway:
         """
         self._validate_subject_id(subject_id)
         if self.resolve_timeline_monitoring_run_id(subject_id, monitoring_run_id) is None:
-            raise GatewayConsistencyViolation(
-                code="monitoring_run_subject_inconsistent",
-                message=(
-                    f"Monitoring run {monitoring_run_id!r} is not indexed on "
-                    f"subject_id={subject_id!r}."
-                ),
-                details=(
-                    ("subject_id", subject_id),
-                    ("monitoring_run_id", monitoring_run_id),
-                ),
+            raise monitoring_run_subject_inconsistent(
+                subject_id=subject_id,
+                monitoring_run_id=monitoring_run_id,
             )
+
         persisted_source_run_id = self._mlflow.get_run_tags(monitoring_run_id).get(_SOURCE_RUN_TAG)
         if persisted_source_run_id != source_run_id:
             raise self._source_identity_consistency_error(
@@ -787,12 +783,9 @@ class MLflowMonitoringGateway:
         if canonical_json(existing_artifact) == canonical_json(data):
             return
 
-        raise GatewayConsistencyViolation(
-            code="monitoring_run_json_artifact_inconsistent",
-            message=(
-                "Existing monitoring run JSON artifact is inconsistent with the requested data."
-            ),
-            details=(("monitoring_run_id", monitoring_run_id), ("path", path)),
+        raise monitoring_run_json_artifact_inconsistent(
+            monitoring_run_id=monitoring_run_id,
+            path=path,
         )
 
     def _get_or_create_experiment_id(self, subject_id: str) -> str:

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -48,6 +48,7 @@ from mlflow_monitor.errors import (
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
     monitoring_allocation_inconsistent,
+    monitoring_run_upsert_field_override,
 )
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -1219,11 +1220,12 @@ class MLflowMonitoringGateway:
         persisted_source_run_id: str | None,
     ) -> GatewayConsistencyViolation:
         """Build a structured error for one contradictory monitoring/source pair."""
-        return GatewayConsistencyViolation(
-            code="monitoring_run_upsert_field_override",
+        raise monitoring_run_upsert_field_override(
             message=(
-                "Monitoring run source identity is inconsistent for "
-                f"monitoring_run_id={monitoring_run_id!r}."
+                "Attempted to upsert monitoring run with immutable field value: "
+                f"monitoring_run_id={monitoring_run_id!r}, "
+                f"source_run_id={source_run_id!r}, "
+                f"persisted_source_run_id={persisted_source_run_id!r}"
             ),
             details=(
                 ("monitoring_run_id", monitoring_run_id),

--- a/src/mlflow_monitor/mlflow_gateway.py
+++ b/src/mlflow_monitor/mlflow_gateway.py
@@ -46,8 +46,10 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import (
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
-    MonitorAllocationReason,
     TrainingRunMutationViolation,
+)
+from mlflow_monitor.errors.gateway import (
+    MonitoringAllocationInconsistentReason,
     monitoring_allocation_inconsistent,
     monitoring_run_json_artifact_inconsistent,
     monitoring_run_subject_inconsistent,
@@ -831,8 +833,7 @@ class MLflowMonitoringGateway:
             existing_key_allocation = allocations_by_key.get(allocation.key)
             if existing_key_allocation is not None:
                 raise monitoring_allocation_inconsistent(
-                    reason=MonitorAllocationReason.DUPLICATE_IDENTITY,
-                    message="Multiple monitoring runs claim the same allocation identity.",
+                    reason=MonitoringAllocationInconsistentReason.DUPLICATE_IDENTITY,
                     details=(
                         ("first_monitoring_run_id", existing_key_allocation.monitoring_run_id),
                         ("second_monitoring_run_id", allocation.monitoring_run_id),
@@ -841,11 +842,7 @@ class MLflowMonitoringGateway:
             existing_sequence_allocation = allocations_by_sequence.get(allocation.sequence_index)
             if existing_sequence_allocation is not None:
                 raise monitoring_allocation_inconsistent(
-                    reason=MonitorAllocationReason.DUPLICATE_SEQUENCE,
-                    message=(
-                        "Multiple monitoring runs claim sequence index "
-                        f"{allocation.sequence_index}."
-                    ),
+                    reason=MonitoringAllocationInconsistentReason.DUPLICATE_SEQUENCE,
                     details=(
                         ("sequence_index", allocation.sequence_index),
                         (
@@ -865,11 +862,7 @@ class MLflowMonitoringGateway:
         for expected_sequence, allocation in enumerate(ordered_allocations):
             if allocation.sequence_index != expected_sequence:
                 raise monitoring_allocation_inconsistent(
-                    reason=MonitorAllocationReason.SEQUENCE_GAP,
-                    message=(
-                        "Monitoring allocation sequences must be contiguous from zero; "
-                        f"expected {expected_sequence}, got {allocation.sequence_index}."
-                    ),
+                    reason=MonitoringAllocationInconsistentReason.SEQUENCE_GAP,
                     details=(
                         ("expected_sequence_index", expected_sequence),
                         ("actual_sequence_index", allocation.sequence_index),
@@ -910,12 +903,12 @@ class MLflowMonitoringGateway:
         )
         if not snapshot.run_id or missing_fields:
             raise monitoring_allocation_inconsistent(
-                reason=MonitorAllocationReason.INVALID_ALLOCATION,
-                message=(
+                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+                details=(("monitoring_run_id", snapshot.run_id),),
+                context_message=(
                     f"Monitoring run {snapshot.run_id!r} is missing durable allocation tags: "
                     + ", ".join(missing_fields)
                 ),
-                details=(("monitoring_run_id", snapshot.run_id),),
             )
 
         assert source_run_id is not None
@@ -927,23 +920,23 @@ class MLflowMonitoringGateway:
             sequence_index = int(raw_sequence_index)
         except (TypeError, ValueError) as exc:
             raise monitoring_allocation_inconsistent(
-                reason=MonitorAllocationReason.INVALID_ALLOCATION,
-                message=(
+                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
+                details=(("monitoring_run_id", snapshot.run_id),),
+                context_message=(
                     f"Monitoring run {snapshot.run_id!r} has a non-integer sequence index: "
                     f"{raw_sequence_index!r}."
                 ),
-                details=(("monitoring_run_id", snapshot.run_id),),
             ) from exc
         if sequence_index < 0:
             raise monitoring_allocation_inconsistent(
-                reason=MonitorAllocationReason.INVALID_ALLOCATION,
-                message=(
-                    f"Monitoring run {snapshot.run_id!r} has a negative sequence index: "
-                    f"{sequence_index}."
-                ),
+                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
                 details=(
                     ("monitoring_run_id", snapshot.run_id),
                     ("sequence_index", sequence_index),
+                ),
+                context_message=(
+                    f"Monitoring run {snapshot.run_id!r} has a negative sequence index: "
+                    f"{sequence_index}."
                 ),
             )
 
@@ -974,11 +967,7 @@ class MLflowMonitoringGateway:
         persisted_next_sequence = self._read_next_sequence_index(experiment_tags)
         if persisted_next_sequence > next_sequence_index:
             raise monitoring_allocation_inconsistent(
-                reason=MonitorAllocationReason.NEXT_SEQUENCE_AHEAD,
-                message=(
-                    "monitoring.next_sequence_index is ahead of durable allocation state; "
-                    f"got {persisted_next_sequence}, expected {next_sequence_index}."
-                ),
+                reason=MonitoringAllocationInconsistentReason.NEXT_SEQUENCE_AHEAD,
                 details=(
                     ("persisted_next_sequence_index", persisted_next_sequence),
                     ("durable_next_sequence_index", next_sequence_index),
@@ -1038,11 +1027,7 @@ class MLflowMonitoringGateway:
             allocation = allocations_by_sequence.get(sequence_index)
             if allocation is None or allocation.monitoring_run_id != monitoring_run_id:
                 raise monitoring_allocation_inconsistent(
-                    reason=MonitorAllocationReason.TIMELINE_CONFLICT,
-                    message=(
-                        f"Experiment timeline slot {sequence_index} does not match its "
-                        "durable monitoring-run allocation."
-                    ),
+                    reason=MonitoringAllocationInconsistentReason.TIMELINE_CONFLICT,
                     details=(
                         ("sequence_index", sequence_index),
                         ("indexed_monitoring_run_id", monitoring_run_id),
@@ -1050,6 +1035,10 @@ class MLflowMonitoringGateway:
                             "durable_monitoring_run_id",
                             None if allocation is None else allocation.monitoring_run_id,
                         ),
+                    ),
+                    context_message=(
+                        f"Experiment timeline slot with sequence_index={sequence_index} "
+                        "does not match its durable monitoring run allocation."
                     ),
                 )
 
@@ -1062,9 +1051,9 @@ class MLflowMonitoringGateway:
         latest_run_id = experiment_tags.get(_LATEST_TAG)
         if latest_run_id and latest_run_id not in allocations_by_run_id:
             raise monitoring_allocation_inconsistent(
-                reason=MonitorAllocationReason.UNKNOWN_POINTER,
-                message="monitoring.latest_run_id points to an unknown allocation.",
+                reason=MonitoringAllocationInconsistentReason.UNKNOWN_POINTER,
                 details=(("monitoring_run_id", latest_run_id),),
+                context_message=f"monitoring_run_id={latest_run_id!r}.",
             )
 
         source_prefix = "training."
@@ -1083,20 +1072,20 @@ class MLflowMonitoringGateway:
             allocation = allocations_by_run_id.get(monitoring_run_id)
             if allocation is None:
                 raise monitoring_allocation_inconsistent(
-                    reason=MonitorAllocationReason.UNKNOWN_POINTER,
-                    message=f"Experiment tag {tag_key!r} points to an unknown allocation.",
-                    details=(("monitoring_run_id", monitoring_run_id),),
+                    reason=MonitoringAllocationInconsistentReason.UNKNOWN_TAG,
+                    details=(("monitoring_run_id", monitoring_run_id), ("tag", tag_key)),
+                    context_message=f"tag={tag_key!r}.",
                 )
             if allocation.key.source_run_id != source_run_id:
                 raise monitoring_allocation_inconsistent(
-                    reason=MonitorAllocationReason.SOURCE_BINDING_CONFLICT,
-                    message=(
-                        f"Experiment tag {tag_key!r} points to a monitoring run allocated "
-                        f"for source {allocation.key.source_run_id!r}."
-                    ),
+                    reason=MonitoringAllocationInconsistentReason.SOURCE_BINDING_CONFLICT,
                     details=(
                         ("source_run_id", source_run_id),
                         ("monitoring_run_id", monitoring_run_id),
+                    ),
+                    context_message=(
+                        f"Experiment tag={tag_key!r} points to a monitoring run allocated "
+                        f"for source_run_id={allocation.key.source_run_id!r}."
                     ),
                 )
 
@@ -1243,13 +1232,13 @@ class MLflowMonitoringGateway:
         )
         if missing_tags:
             raise monitoring_allocation_inconsistent(
-                reason=MonitorAllocationReason.INVALID_ALLOCATION,
-                message=(
-                    f"Monitoring run {monitoring_run_id!r} is missing durable allocation tags: "
-                    + ", ".join(missing_tags)
-                ),
+                reason=MonitoringAllocationInconsistentReason.INVALID_ALLOCATION,
                 details=(
                     ("monitoring_run_id", monitoring_run_id),
                     ("missing_tags", ",".join(missing_tags)),
+                ),
+                context_message=(
+                    f"Monitoring run {monitoring_run_id!r} is missing durable allocation tags: "
+                    + ", ".join(missing_tags)
                 ),
             )

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -16,6 +16,7 @@ from mlflow_monitor.errors import (
     GatewayNamespaceViolation,
     PrepareStageError,
     TerminalRunRetryError,
+    prepared_context_inconsistent,
 )
 from mlflow_monitor.gateway import (
     IdempotencyKey,
@@ -249,13 +250,8 @@ def _run_prepare_monitoring_run_slice(
         except (GatewayConsistencyViolation, GatewayNamespaceViolation):
             raise
         except ValueError as exc:
-            raise GatewayConsistencyViolation(
-                code="prepared_context_inconsistent",
-                message="Persisted prepared context is missing, broken, or inconsistent.",
-                details=(
-                    ("reason", "broken_artifact"),
-                    ("field", "prepared_context"),
-                ),
+            raise prepared_context_inconsistent(
+                reason="broken_artifact", field="prepared_context"
             ) from exc
 
         prepared_context = hydrate_prepared_context(

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -10,15 +10,13 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
 )
 from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     PreparedContextConsistencyViolation,
     PrepareStageError,
     TerminalRunRetryError,
-)
-from mlflow_monitor.errors.workflow import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
 )
 from mlflow_monitor.gateway import (
     IdempotencyKey,

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -10,13 +10,17 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     PrepareStageError,
     TerminalRunRetryError,
+)
+from mlflow_monitor.errors.gateway import (
     prepared_context_inconsistent,
+)
+from mlflow_monitor.errors.workflow import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
 )
 from mlflow_monitor.gateway import (
     IdempotencyKey,

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -13,6 +13,7 @@ from mlflow_monitor.errors import (
     CheckStageError,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
+    PreparedContextConsistencyViolation,
     PrepareStageError,
     TerminalRunRetryError,
 )
@@ -251,8 +252,8 @@ def _run_prepare_monitoring_run_slice(
         except (GatewayConsistencyViolation, GatewayNamespaceViolation):
             raise
         except ValueError as exc:
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="broken_artifact", field="prepared_context"
+            raise PreparedContextConsistencyViolation.broken_artifact(
+                field="prepared_context"
             ) from exc
 
         prepared_context = hydrate_prepared_context(

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -16,9 +16,6 @@ from mlflow_monitor.errors import (
     PrepareStageError,
     TerminalRunRetryError,
 )
-from mlflow_monitor.errors.gateway import (
-    prepared_context_inconsistent,
-)
 from mlflow_monitor.errors.workflow import (
     PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
 )
@@ -254,7 +251,7 @@ def _run_prepare_monitoring_run_slice(
         except (GatewayConsistencyViolation, GatewayNamespaceViolation):
             raise
         except ValueError as exc:
-            raise prepared_context_inconsistent(
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
                 reason="broken_artifact", field="prepared_context"
             ) from exc
 

--- a/src/mlflow_monitor/orchestration.py
+++ b/src/mlflow_monitor/orchestration.py
@@ -10,7 +10,7 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
@@ -596,7 +596,7 @@ def _validate_rerun_baseline_input(
         return None
 
     return PrepareStageError(
-        code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+        code=PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
         message=(
             f"Provided baseline_source_run_id={supplied_baseline_source_run_id!r} "
             f"with resolved baseline_source_run_id={resolved!r} does not match "
@@ -641,7 +641,7 @@ def _validate_checked_monitoring_run_rerun_inputs(
         return None
 
     return PrepareStageError(
-        code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+        code=PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
         message=(
             f"Provided baseline_source_run_id={baseline_source_run_id!r} "
             f"with resolved_baseline_source_run_id={resolved_baseline_source_run_id!r} "

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -28,7 +28,7 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     GatewayConsistencyViolation,
     InvariantViolation,
@@ -554,7 +554,7 @@ def prepare_run_context(
             _resolved_baseline = baseline_resolution_result.baseline_source_run_id
             _existing_baseline = timeline_state.baseline_source_run_id
             raise PrepareStageError(
-                code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+                code=PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
                 message=(
                     f"Provided baseline_source_run_id={_provided_baseline!r} "
                     f"with resolved_baseline_source_run_id={_resolved_baseline!r} "
@@ -837,7 +837,7 @@ def _resolve_baseline_for_prepare(
 
         if resolved_baseline != pinned_baseline:
             raise PrepareStageError(
-                code=PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+                code=PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
                 message=(
                     f"Provided baseline_source_run_id={baseline_source_run_id!r} "
                     f"with resolved baseline_source_run_id={resolved_baseline!r} does not match "

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -28,13 +28,15 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     InvariantViolation,
     PrepareStageError,
+)
+from mlflow_monitor.errors.gateway import (
     monitoring_reference_inconsistent,
     prepared_context_inconsistent,
 )
+from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
 from mlflow_monitor.invariant import validate_contract_check_result
 from mlflow_monitor.recipe_compiler import CompiledRecipe, EffectiveRecipePlan

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -31,6 +31,7 @@ from mlflow_monitor.errors import (
     CheckStageError,
     GatewayConsistencyViolation,
     InvariantViolation,
+    PreparedContextConsistencyViolation,
     PrepareStageError,
 )
 from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
@@ -233,14 +234,12 @@ def hydrate_prepared_context(
             the current allocation or compiled Recipe.
     """
     if raw is None:
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="missing_artifact",
+        raise PreparedContextConsistencyViolation.missing_artifact(
             field="prepared_context",
         )
     _require_exact_prepared_fields(raw, _PREPARED_CONTEXT_FIELDS, section="prepared_context")
     if raw.get("artifact_schema_version") != _PREPARED_CONTEXT_ARTIFACT_SCHEMA_VERSION:
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="unsupported_artifact_schema_version",
+        raise PreparedContextConsistencyViolation.unsupported_artifact_schema_version(
             field="artifact_schema_version",
         )
 
@@ -258,8 +257,7 @@ def hydrate_prepared_context(
         else:
             valid_type = isinstance(actual, str) and bool(actual.strip())
         if not valid_type or actual != expected:
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="allocation_identity_mismatch",
+            raise PreparedContextConsistencyViolation.allocation_identity_mismatch(
                 field=field,
             )
 
@@ -267,8 +265,7 @@ def hydrate_prepared_context(
 
     effective_recipe = raw.get("effective_recipe")
     if not isinstance(effective_recipe, Mapping):
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalid_field_type",
+        raise PreparedContextConsistencyViolation.invalid_field_type(
             field="effective_recipe",
         )
 
@@ -276,21 +273,18 @@ def hydrate_prepared_context(
         persisted = canonical_json(dict(effective_recipe))
         expected = canonical_json(compiled_recipe.effective_plan.to_dict())
     except (TypeError, ValueError) as exc:
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalide_field_type",
+        raise PreparedContextConsistencyViolation.invalid_field_type(
             field="effective_recipe",
         ) from exc
 
     if persisted != expected:
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="effective_recipe_mismatch",
+        raise PreparedContextConsistencyViolation.effective_recipe_mismatch(
             field="effective_recipe",
         )
 
     contract = _hydrate_prepared_contract(raw.get("contract"))
     if contract != compiled_recipe.contract:
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="contract_mismatch",
+        raise PreparedContextConsistencyViolation.contract_mismatch(
             field="contract",
         )
 
@@ -314,8 +308,8 @@ def hydrate_prepared_context(
 def _hydrate_prepared_contract(raw: object) -> Contract:
     """Hydrate the complete Contract frozen in prepared state."""
     if not isinstance(raw, Mapping):
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalid_field_type", field="contract"
+        raise PreparedContextConsistencyViolation.invalid_field_type(
+            field="contract",
         )
     _require_exact_prepared_fields(raw, _PREPARED_CONTRACT_FIELDS, section="contract")
     return Contract(
@@ -339,34 +333,28 @@ def _hydrate_prepared_references(
 ) -> tuple[MonitoringRunReference, ...]:
     """Hydrate canonical resolved Monitoring Run references."""
     if not isinstance(raw, list):
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalid_field_type", field="references"
+        raise PreparedContextConsistencyViolation.invalid_field_type(
+            field="references",
         )
 
     references: list[MonitoringRunReference] = []
     for index, item in enumerate(raw):
         field = f"references[{index}]"
         if not isinstance(item, Mapping):
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="invalid_field_type", field=field
-            )
+            raise PreparedContextConsistencyViolation.invalid_field_type(field=field)
         _require_exact_prepared_fields(item, _PREPARED_REFERENCE_FIELDS, section=field)
         kind = item.get("kind")
         monitoring_run_id = item.get("monitoring_run_id")
         source_run_id = item.get("source_run_id")
         if not isinstance(kind, str):
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="invalid_field_type", field=f"{field}.kind"
-            )
+            raise PreparedContextConsistencyViolation.invalid_field_type(field=f"{field}.kind")
         if monitoring_run_id is not None and not isinstance(monitoring_run_id, str):
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="invalid_field_type",
-                field=f"{field}.monitoring_run_id",
+            raise PreparedContextConsistencyViolation.invalid_field_type(
+                field=f"{field}.monitoring_run_id"
             )
         if not isinstance(source_run_id, str):
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="invalid_field_type",
-                field=f"{field}.source_run_id",
+            raise PreparedContextConsistencyViolation.invalid_field_type(
+                field=f"{field}.source_run_id"
             )
         try:
             reference = MonitoringRunReference(
@@ -375,10 +363,7 @@ def _hydrate_prepared_references(
                 source_run_id=source_run_id,
             )
         except ValueError as exc:
-            raise GatewayConsistencyViolation.prepared_context_inconsistent(
-                reason="invalid_reference",
-                field=field,
-            ) from exc
+            raise PreparedContextConsistencyViolation.invalid_reference(field=field) from exc
         references.append(reference)
 
     if not references or references[0] != MonitoringRunReference(
@@ -386,8 +371,7 @@ def _hydrate_prepared_references(
         monitoring_run_id=None,
         source_run_id=baseline_source_run_id,
     ):
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="baseline_reference_mismatch",
+        raise PreparedContextConsistencyViolation.baseline_reference_mismatch(
             field="references",
         )
 
@@ -396,8 +380,7 @@ def _hydrate_prepared_references(
         len(reference_kinds) != len(set(reference_kinds))
         or tuple(sorted(reference_kinds, key=_REFERENCE_ORDER.__getitem__)) != reference_kinds
     ):
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="noncanonical_references",
+        raise PreparedContextConsistencyViolation.noncanonical_references(
             field="references",
         )
     return tuple(references)
@@ -411,18 +394,14 @@ def _require_exact_prepared_fields(
 ) -> None:
     """Require one prepared-artifact mapping to have exactly its canonical fields."""
     if set(raw) != expected:
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalid_fields", field=section
-        )
+        raise PreparedContextConsistencyViolation.invalid_fields(field=section)
 
 
 def _require_prepared_string(raw: Mapping[str, object], field: str) -> str:
     """Return one required nonempty string from a prepared artifact mapping."""
     value = raw.get(field)
     if not isinstance(value, str) or not value.strip():
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalid_field_type", field=field
-        )
+        raise PreparedContextConsistencyViolation.invalid_field_type(field=field)
     return value
 
 
@@ -433,9 +412,7 @@ def _require_prepared_optional_string(
     """Return one optional string from a prepared artifact mapping."""
     value = raw.get(field)
     if value is not None and not isinstance(value, str):
-        raise GatewayConsistencyViolation.prepared_context_inconsistent(
-            reason="invalid_field_type", field=field
-        )
+        raise PreparedContextConsistencyViolation.invalid_field_type(field=field)
     return value
 
 

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -33,6 +33,7 @@ from mlflow_monitor.errors import (
     GatewayConsistencyViolation,
     InvariantViolation,
     PrepareStageError,
+    prepared_context_inconsistent,
 )
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
 from mlflow_monitor.invariant import validate_contract_check_result
@@ -233,13 +234,13 @@ def hydrate_prepared_context(
             the current allocation or compiled Recipe.
     """
     if raw is None:
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="missing_artifact",
             field="prepared_context",
         )
     _require_exact_prepared_fields(raw, _PREPARED_CONTEXT_FIELDS, section="prepared_context")
     if raw.get("artifact_schema_version") != _PREPARED_CONTEXT_ARTIFACT_SCHEMA_VERSION:
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="unsupported_artifact_schema_version",
             field="artifact_schema_version",
         )
@@ -258,7 +259,7 @@ def hydrate_prepared_context(
         else:
             valid_type = isinstance(actual, str) and bool(actual.strip())
         if not valid_type or actual != expected:
-            raise _prepared_context_inconsistent(
+            raise prepared_context_inconsistent(
                 reason="allocation_identity_mismatch",
                 field=field,
             )
@@ -267,7 +268,7 @@ def hydrate_prepared_context(
 
     effective_recipe = raw.get("effective_recipe")
     if not isinstance(effective_recipe, Mapping):
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="invalid_field_type",
             field="effective_recipe",
         )
@@ -276,20 +277,20 @@ def hydrate_prepared_context(
         persisted = canonical_json(dict(effective_recipe))
         expected = canonical_json(compiled_recipe.effective_plan.to_dict())
     except (TypeError, ValueError) as exc:
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="invalide_field_type",
             field="effective_recipe",
         ) from exc
 
     if persisted != expected:
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="effective_recipe_mismatch",
             field="effective_recipe",
         )
 
     contract = _hydrate_prepared_contract(raw.get("contract"))
     if contract != compiled_recipe.contract:
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="contract_mismatch",
             field="contract",
         )
@@ -314,7 +315,7 @@ def hydrate_prepared_context(
 def _hydrate_prepared_contract(raw: object) -> Contract:
     """Hydrate the complete Contract frozen in prepared state."""
     if not isinstance(raw, Mapping):
-        raise _prepared_context_inconsistent(reason="invalid_field_type", field="contract")
+        raise prepared_context_inconsistent(reason="invalid_field_type", field="contract")
     _require_exact_prepared_fields(raw, _PREPARED_CONTRACT_FIELDS, section="contract")
     return Contract(
         contract_id=_require_prepared_string(raw, "contract_id"),
@@ -337,26 +338,26 @@ def _hydrate_prepared_references(
 ) -> tuple[MonitoringRunReference, ...]:
     """Hydrate canonical resolved Monitoring Run references."""
     if not isinstance(raw, list):
-        raise _prepared_context_inconsistent(reason="invalid_field_type", field="references")
+        raise prepared_context_inconsistent(reason="invalid_field_type", field="references")
 
     references: list[MonitoringRunReference] = []
     for index, item in enumerate(raw):
         field = f"references[{index}]"
         if not isinstance(item, Mapping):
-            raise _prepared_context_inconsistent(reason="invalid_field_type", field=field)
+            raise prepared_context_inconsistent(reason="invalid_field_type", field=field)
         _require_exact_prepared_fields(item, _PREPARED_REFERENCE_FIELDS, section=field)
         kind = item.get("kind")
         monitoring_run_id = item.get("monitoring_run_id")
         source_run_id = item.get("source_run_id")
         if not isinstance(kind, str):
-            raise _prepared_context_inconsistent(reason="invalid_field_type", field=f"{field}.kind")
+            raise prepared_context_inconsistent(reason="invalid_field_type", field=f"{field}.kind")
         if monitoring_run_id is not None and not isinstance(monitoring_run_id, str):
-            raise _prepared_context_inconsistent(
+            raise prepared_context_inconsistent(
                 reason="invalid_field_type",
                 field=f"{field}.monitoring_run_id",
             )
         if not isinstance(source_run_id, str):
-            raise _prepared_context_inconsistent(
+            raise prepared_context_inconsistent(
                 reason="invalid_field_type",
                 field=f"{field}.source_run_id",
             )
@@ -367,7 +368,7 @@ def _hydrate_prepared_references(
                 source_run_id=source_run_id,
             )
         except ValueError as exc:
-            raise _prepared_context_inconsistent(
+            raise prepared_context_inconsistent(
                 reason="invalid_reference",
                 field=field,
             ) from exc
@@ -378,7 +379,7 @@ def _hydrate_prepared_references(
         monitoring_run_id=None,
         source_run_id=baseline_source_run_id,
     ):
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="baseline_reference_mismatch",
             field="references",
         )
@@ -388,7 +389,7 @@ def _hydrate_prepared_references(
         len(reference_kinds) != len(set(reference_kinds))
         or tuple(sorted(reference_kinds, key=_REFERENCE_ORDER.__getitem__)) != reference_kinds
     ):
-        raise _prepared_context_inconsistent(
+        raise prepared_context_inconsistent(
             reason="noncanonical_references",
             field="references",
         )
@@ -403,14 +404,14 @@ def _require_exact_prepared_fields(
 ) -> None:
     """Require one prepared-artifact mapping to have exactly its canonical fields."""
     if set(raw) != expected:
-        raise _prepared_context_inconsistent(reason="invalid_fields", field=section)
+        raise prepared_context_inconsistent(reason="invalid_fields", field=section)
 
 
 def _require_prepared_string(raw: Mapping[str, object], field: str) -> str:
     """Return one required nonempty string from a prepared artifact mapping."""
     value = raw.get(field)
     if not isinstance(value, str) or not value.strip():
-        raise _prepared_context_inconsistent(reason="invalid_field_type", field=field)
+        raise prepared_context_inconsistent(reason="invalid_field_type", field=field)
     return value
 
 
@@ -421,21 +422,8 @@ def _require_prepared_optional_string(
     """Return one optional string from a prepared artifact mapping."""
     value = raw.get(field)
     if value is not None and not isinstance(value, str):
-        raise _prepared_context_inconsistent(reason="invalid_field_type", field=field)
+        raise prepared_context_inconsistent(reason="invalid_field_type", field=field)
     return value
-
-
-def _prepared_context_inconsistent(
-    *,
-    reason: str,
-    field: str,
-) -> GatewayConsistencyViolation:
-    """Build the stable failure raised for invalid persisted prepared state."""
-    return GatewayConsistencyViolation(
-        code="prepared_context_inconsistent",
-        message="Persisted prepared context is missing, malformed, or inconsistent.",
-        details=(("reason", reason), ("field", field)),
-    )
 
 
 def prepare_run_context(

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -28,13 +28,13 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     GatewayConsistencyViolation,
     InvariantViolation,
     PreparedContextConsistencyViolation,
     PrepareStageError,
 )
-from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
 from mlflow_monitor.invariant import validate_contract_check_result
 from mlflow_monitor.recipe_compiler import CompiledRecipe, EffectiveRecipePlan

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -30,9 +30,9 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import (
     PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
-    GatewayConsistencyViolation,
     InvariantViolation,
     PrepareStageError,
+    monitoring_reference_inconsistent,
     prepared_context_inconsistent,
 )
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
@@ -659,17 +659,11 @@ def _hydrate_monitoring_run_reference(
     """Freeze a complete reference pair from a resolved Monitoring Run pointer."""
     record = gateway.get_monitoring_run(subject_id, monitoring_run_id)
     if record is None:
-        raise GatewayConsistencyViolation(
-            code="monitoring_reference_inconsistent",
-            message=(
-                "Monitoring reference could not be hydrated for "
-                f"monitoring_run_id={monitoring_run_id!r}."
-            ),
-            details=(
-                ("kind", kind.value),
-                ("monitoring_run_id", monitoring_run_id),
-            ),
+        raise monitoring_reference_inconsistent(
+            kind=kind,
+            monitoring_run_id=monitoring_run_id,
         )
+
     return MonitoringRunReference(
         kind=kind,
         monitoring_run_id=record.monitoring_run_id,

--- a/src/mlflow_monitor/workflow.py
+++ b/src/mlflow_monitor/workflow.py
@@ -29,12 +29,9 @@ from mlflow_monitor.domain import (
 )
 from mlflow_monitor.errors import (
     CheckStageError,
+    GatewayConsistencyViolation,
     InvariantViolation,
     PrepareStageError,
-)
-from mlflow_monitor.errors.gateway import (
-    monitoring_reference_inconsistent,
-    prepared_context_inconsistent,
 )
 from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import MonitoringGateway, TimelineState
@@ -236,13 +233,13 @@ def hydrate_prepared_context(
             the current allocation or compiled Recipe.
     """
     if raw is None:
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="missing_artifact",
             field="prepared_context",
         )
     _require_exact_prepared_fields(raw, _PREPARED_CONTEXT_FIELDS, section="prepared_context")
     if raw.get("artifact_schema_version") != _PREPARED_CONTEXT_ARTIFACT_SCHEMA_VERSION:
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="unsupported_artifact_schema_version",
             field="artifact_schema_version",
         )
@@ -261,7 +258,7 @@ def hydrate_prepared_context(
         else:
             valid_type = isinstance(actual, str) and bool(actual.strip())
         if not valid_type or actual != expected:
-            raise prepared_context_inconsistent(
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
                 reason="allocation_identity_mismatch",
                 field=field,
             )
@@ -270,7 +267,7 @@ def hydrate_prepared_context(
 
     effective_recipe = raw.get("effective_recipe")
     if not isinstance(effective_recipe, Mapping):
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="invalid_field_type",
             field="effective_recipe",
         )
@@ -279,20 +276,20 @@ def hydrate_prepared_context(
         persisted = canonical_json(dict(effective_recipe))
         expected = canonical_json(compiled_recipe.effective_plan.to_dict())
     except (TypeError, ValueError) as exc:
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="invalide_field_type",
             field="effective_recipe",
         ) from exc
 
     if persisted != expected:
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="effective_recipe_mismatch",
             field="effective_recipe",
         )
 
     contract = _hydrate_prepared_contract(raw.get("contract"))
     if contract != compiled_recipe.contract:
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="contract_mismatch",
             field="contract",
         )
@@ -317,7 +314,9 @@ def hydrate_prepared_context(
 def _hydrate_prepared_contract(raw: object) -> Contract:
     """Hydrate the complete Contract frozen in prepared state."""
     if not isinstance(raw, Mapping):
-        raise prepared_context_inconsistent(reason="invalid_field_type", field="contract")
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
+            reason="invalid_field_type", field="contract"
+        )
     _require_exact_prepared_fields(raw, _PREPARED_CONTRACT_FIELDS, section="contract")
     return Contract(
         contract_id=_require_prepared_string(raw, "contract_id"),
@@ -340,26 +339,32 @@ def _hydrate_prepared_references(
 ) -> tuple[MonitoringRunReference, ...]:
     """Hydrate canonical resolved Monitoring Run references."""
     if not isinstance(raw, list):
-        raise prepared_context_inconsistent(reason="invalid_field_type", field="references")
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
+            reason="invalid_field_type", field="references"
+        )
 
     references: list[MonitoringRunReference] = []
     for index, item in enumerate(raw):
         field = f"references[{index}]"
         if not isinstance(item, Mapping):
-            raise prepared_context_inconsistent(reason="invalid_field_type", field=field)
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
+                reason="invalid_field_type", field=field
+            )
         _require_exact_prepared_fields(item, _PREPARED_REFERENCE_FIELDS, section=field)
         kind = item.get("kind")
         monitoring_run_id = item.get("monitoring_run_id")
         source_run_id = item.get("source_run_id")
         if not isinstance(kind, str):
-            raise prepared_context_inconsistent(reason="invalid_field_type", field=f"{field}.kind")
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
+                reason="invalid_field_type", field=f"{field}.kind"
+            )
         if monitoring_run_id is not None and not isinstance(monitoring_run_id, str):
-            raise prepared_context_inconsistent(
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
                 reason="invalid_field_type",
                 field=f"{field}.monitoring_run_id",
             )
         if not isinstance(source_run_id, str):
-            raise prepared_context_inconsistent(
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
                 reason="invalid_field_type",
                 field=f"{field}.source_run_id",
             )
@@ -370,7 +375,7 @@ def _hydrate_prepared_references(
                 source_run_id=source_run_id,
             )
         except ValueError as exc:
-            raise prepared_context_inconsistent(
+            raise GatewayConsistencyViolation.prepared_context_inconsistent(
                 reason="invalid_reference",
                 field=field,
             ) from exc
@@ -381,7 +386,7 @@ def _hydrate_prepared_references(
         monitoring_run_id=None,
         source_run_id=baseline_source_run_id,
     ):
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="baseline_reference_mismatch",
             field="references",
         )
@@ -391,7 +396,7 @@ def _hydrate_prepared_references(
         len(reference_kinds) != len(set(reference_kinds))
         or tuple(sorted(reference_kinds, key=_REFERENCE_ORDER.__getitem__)) != reference_kinds
     ):
-        raise prepared_context_inconsistent(
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
             reason="noncanonical_references",
             field="references",
         )
@@ -406,14 +411,18 @@ def _require_exact_prepared_fields(
 ) -> None:
     """Require one prepared-artifact mapping to have exactly its canonical fields."""
     if set(raw) != expected:
-        raise prepared_context_inconsistent(reason="invalid_fields", field=section)
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
+            reason="invalid_fields", field=section
+        )
 
 
 def _require_prepared_string(raw: Mapping[str, object], field: str) -> str:
     """Return one required nonempty string from a prepared artifact mapping."""
     value = raw.get(field)
     if not isinstance(value, str) or not value.strip():
-        raise prepared_context_inconsistent(reason="invalid_field_type", field=field)
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
+            reason="invalid_field_type", field=field
+        )
     return value
 
 
@@ -424,7 +433,9 @@ def _require_prepared_optional_string(
     """Return one optional string from a prepared artifact mapping."""
     value = raw.get(field)
     if value is not None and not isinstance(value, str):
-        raise prepared_context_inconsistent(reason="invalid_field_type", field=field)
+        raise GatewayConsistencyViolation.prepared_context_inconsistent(
+            reason="invalid_field_type", field=field
+        )
     return value
 
 
@@ -661,7 +672,7 @@ def _hydrate_monitoring_run_reference(
     """Freeze a complete reference pair from a resolved Monitoring Run pointer."""
     record = gateway.get_monitoring_run(subject_id, monitoring_run_id)
     if record is None:
-        raise monitoring_reference_inconsistent(
+        raise GatewayConsistencyViolation.monitoring_reference_inconsistent(
             kind=kind,
             monitoring_run_id=monitoring_run_id,
         )

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -27,7 +27,7 @@ from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.orchestration import run_orchestration
 from mlflow_monitor.result_contract import MonitorRunResult
 
-_PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
+_PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_baseline"
 
 
 class FailingFinalizeMLflowMonitoringGateway(MLflowMonitoringGateway):
@@ -977,7 +977,7 @@ def test_mlflow_gateway_baseline_immutability_rejection(
     assert second.lifecycle_status is LifecycleStatus.FAILED
     assert second.comparability_status is None
     assert second.error is not None
-    assert second.error.code == _PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert second.error.code == _PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert dict(experiment_after.tags) == experiment_tags_before
     assert experiment_after.tags["training.baseline_run_id"] == baseline_run_id
     assert monitoring_run_before.info.status == "FINISHED"

--- a/tests/integration/test_mlflow_gateway.py
+++ b/tests/integration/test_mlflow_gateway.py
@@ -22,11 +22,12 @@ from mlflow_monitor.domain import (
     LifecycleStatus,
     MonitoringRunReference,
 )
-from mlflow_monitor.errors import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.orchestration import run_orchestration
 from mlflow_monitor.result_contract import MonitorRunResult
+
+_PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
 
 
 class FailingFinalizeMLflowMonitoringGateway(MLflowMonitoringGateway):
@@ -976,7 +977,7 @@ def test_mlflow_gateway_baseline_immutability_rejection(
     assert second.lifecycle_status is LifecycleStatus.FAILED
     assert second.comparability_status is None
     assert second.error is not None
-    assert second.error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert second.error.code == _PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert dict(experiment_after.tags) == experiment_tags_before
     assert experiment_after.tags["training.baseline_run_id"] == baseline_run_id
     assert monitoring_run_before.info.status == "FINISHED"

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -12,7 +12,6 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    GatewayConsistencyCode,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
@@ -24,9 +23,7 @@ from mlflow_monitor.gateway import (
     InMemoryMonitoringGateway,
 )
 
-_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = (
-    GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE
-)
+_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = "monitoring_run_upsert_field_override"
 
 
 def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -12,7 +12,7 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
+    GatewayConsistencyCode,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
@@ -24,7 +24,9 @@ from mlflow_monitor.gateway import (
     InMemoryMonitoringGateway,
 )
 
-_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = MONITORING_RUN_UPSERT_FIELD_OVERRIDE
+_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = (
+    GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE
+)
 
 
 def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -12,6 +12,7 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
+    MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
     TrainingRunMutationViolation,
@@ -22,6 +23,8 @@ from mlflow_monitor.gateway import (
     IdempotencyKey,
     InMemoryMonitoringGateway,
 )
+
+_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = MONITORING_RUN_UPSERT_FIELD_OVERRIDE
 
 
 def test_create_or_reuse_monitoring_run_creates_then_reuses() -> None:
@@ -691,7 +694,7 @@ def test_upsert_monitoring_run_rejects_source_identity_conflict() -> None:
             sequence_index=allocation.sequence_index,
         )
 
-    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert exc_info.value.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert exc_info.value.details == (("source_run_id", "train-run-2"),)
 
 
@@ -734,7 +737,7 @@ def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
             ),
         )
 
-    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert exc_info.value.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert dict(exc_info.value.details) == {
         "monitoring_run_id": "monitoring-run-previous",
         "source_run_id": "train-run-claimed-reference",
@@ -825,7 +828,7 @@ def test_upsert_monitoring_run_rejects_changed_sequence_index() -> None:
         )
 
     error = exc.value
-    assert error.code == "monitoring_run_upsert_field_override"
+    assert error.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert error.details == (("sequence_index", 1),)
 
 
@@ -872,7 +875,7 @@ def test_upsert_monitoring_run_reports_all_immutable_field_overrides() -> None:
         )
 
     error = exc.value
-    assert error.code == "monitoring_run_upsert_field_override"
+    assert error.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert error.details == (
         ("sequence_index", 1),
         ("contract_check_result", str(replacement_result)),
@@ -922,5 +925,5 @@ def test_upsert_monitoring_run_rejects_changed_contract_check_result_after_initi
         )
 
     error = exc.value
-    assert error.code == "monitoring_run_upsert_field_override"
+    assert error.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert error.details == (("contract_check_result", str(replacement_result)),)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -220,7 +220,7 @@ def test_pin_timeline_baseline_requires_an_existing_allocation() -> None:
 
     with pytest.raises(
         GatewayConsistencyViolation,
-        match="Timeline state for subject_id 'churn_model' not found.",
+        match="Timeline state not found for subject_id='churn_model'.",
     ):
         gateway.pin_timeline_baseline("churn_model", "train-run-1")
 

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -9,7 +9,6 @@ import pytest
 
 from mlflow_monitor.domain import DiffReferenceKind, LifecycleStatus, MonitoringRunReference
 from mlflow_monitor.errors import (
-    GatewayConsistencyCode,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
 )
@@ -17,16 +16,6 @@ from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
 from mlflow_monitor.mlflow_client import MonitoringRunInfo, MonitoringRunTagSnapshot
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
-
-_MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS = (
-    GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT
-)
-_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = (
-    GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE
-)
-_MONITORING_RUN_SUBJECT_INCONSISTENT_FOR_TESTS = (
-    GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT
-)
 
 
 def _make_result(
@@ -443,7 +432,7 @@ def test_create_or_reuse_monitoring_run_repairs_stale_latest_and_source_binding(
                 "monitoring.next_sequence_index": "0",
                 "training.train-run-1.monitoring_run_id": "unknown-run",
             },
-            "unknown_pointer",
+            "unknown_tag",
             id="repairable-next-plus-unknown-pointer",
         ),
         pytest.param(
@@ -495,7 +484,7 @@ def test_create_or_reuse_monitoring_run_fails_closed_before_writes(
             )
         )
 
-    assert exc_info.value.code == _MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS
+    assert exc_info.value.code == "monitoring_allocation_inconsistent"
     assert ("reason", expected_reason) in exc_info.value.details
     stub_client.set_monitoring_experiment_tag.assert_not_called()
     stub_client.create_monitoring_run.assert_not_called()
@@ -586,7 +575,7 @@ def test_write_monitoring_run_json_artifact_rejects_missing_allocation_tag(
             path="state/prepared_context.json",
         )
 
-    assert exc_info.value.code == _MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS
+    assert exc_info.value.code == "monitoring_allocation_inconsistent"
     assert exc_info.value.details == (
         ("reason", "invalid_allocation"),
         ("monitoring_run_id", "monitoring-run-1"),
@@ -842,7 +831,7 @@ def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
             ),
         )
 
-    assert exc_info.value.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
+    assert exc_info.value.code == "monitoring_run_upsert_field_override"
     assert dict(exc_info.value.details) == {
         "monitoring_run_id": "monitoring-run-previous",
         "source_run_id": "train-run-claimed-reference",
@@ -872,7 +861,7 @@ def test_upsert_monitoring_run_rejects_conflicting_primary_pair() -> None:
             sequence_index=0,
         )
 
-    assert exc_info.value.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
+    assert exc_info.value.code == "monitoring_run_upsert_field_override"
     assert dict(exc_info.value.details) == {
         "monitoring_run_id": "monitoring-run-1",
         "source_run_id": "train-run-claimed",
@@ -902,7 +891,7 @@ def test_upsert_monitoring_run_rejects_run_outside_subject_timeline_before_run_a
             sequence_index=0,
         )
 
-    assert exc_info.value.code == _MONITORING_RUN_SUBJECT_INCONSISTENT_FOR_TESTS
+    assert exc_info.value.code == "monitoring_run_subject_inconsistent"
     assert exc_info.value.details == (
         ("subject_id", "churn_model"),
         ("monitoring_run_id", "monitoring-run-foreign"),

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -433,7 +433,7 @@ def test_create_or_reuse_monitoring_run_repairs_stale_latest_and_source_binding(
                 "training.train-run-1.monitoring_run_id": "unknown-run",
             },
             "unknown_tag",
-            id="repairable-next-plus-unknown-pointer",
+            id="repairable-next-plus-unknown-tag",
         ),
         pytest.param(
             (

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -9,7 +9,7 @@ import pytest
 
 from mlflow_monitor.domain import DiffReferenceKind, LifecycleStatus, MonitoringRunReference
 from mlflow_monitor.errors import (
-    MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
+    GatewayConsistencyCode,
     GatewayConsistencyViolation,
     GatewayNamespaceViolation,
 )
@@ -18,8 +18,15 @@ from mlflow_monitor.mlflow_client import MonitoringRunInfo, MonitoringRunTagSnap
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
 
-_MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS = "monitoring_allocation_inconsistent"
-_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = MONITORING_RUN_UPSERT_FIELD_OVERRIDE
+_MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS = (
+    GatewayConsistencyCode.MONITORING_ALLOCATION_INCONSISTENT
+)
+_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = (
+    GatewayConsistencyCode.MONITORING_RUN_UPSERT_FIELD_OVERRIDE
+)
+_MONITORING_RUN_SUBJECT_INCONSISTENT_FOR_TESTS = (
+    GatewayConsistencyCode.MONITORING_RUN_SUBJECT_INCONSISTENT
+)
 
 
 def _make_result(
@@ -895,7 +902,7 @@ def test_upsert_monitoring_run_rejects_run_outside_subject_timeline_before_run_a
             sequence_index=0,
         )
 
-    assert exc_info.value.code == "monitoring_run_subject_inconsistent"
+    assert exc_info.value.code == _MONITORING_RUN_SUBJECT_INCONSISTENT_FOR_TESTS
     assert exc_info.value.details == (
         ("subject_id", "churn_model"),
         ("monitoring_run_id", "monitoring-run-foreign"),

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -14,6 +14,8 @@ from mlflow_monitor.mlflow_client import MonitoringRunInfo, MonitoringRunTagSnap
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
 
+_MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS = "monitoring_allocation_inconsistent"
+
 
 def _make_result(
     *,
@@ -481,7 +483,7 @@ def test_create_or_reuse_monitoring_run_fails_closed_before_writes(
             )
         )
 
-    assert exc_info.value.code == "monitoring_allocation_inconsistent"
+    assert exc_info.value.code == _MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS
     assert ("reason", expected_reason) in exc_info.value.details
     stub_client.set_monitoring_experiment_tag.assert_not_called()
     stub_client.create_monitoring_run.assert_not_called()
@@ -572,7 +574,7 @@ def test_write_monitoring_run_json_artifact_rejects_missing_allocation_tag(
             path="state/prepared_context.json",
         )
 
-    assert exc_info.value.code == "monitoring_allocation_inconsistent"
+    assert exc_info.value.code == _MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS
     assert exc_info.value.details == (
         ("reason", "invalid_allocation"),
         ("monitoring_run_id", "monitoring-run-1"),

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -8,13 +8,18 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from mlflow_monitor.domain import DiffReferenceKind, LifecycleStatus, MonitoringRunReference
-from mlflow_monitor.errors import GatewayConsistencyViolation, GatewayNamespaceViolation
+from mlflow_monitor.errors import (
+    MONITORING_RUN_UPSERT_FIELD_OVERRIDE,
+    GatewayConsistencyViolation,
+    GatewayNamespaceViolation,
+)
 from mlflow_monitor.gateway import GatewayConfig, IdempotencyKey
 from mlflow_monitor.mlflow_client import MonitoringRunInfo, MonitoringRunTagSnapshot
 from mlflow_monitor.mlflow_gateway import MLflowMonitoringGateway
 from mlflow_monitor.result_contract import MonitorRunError, MonitorRunResult
 
 _MONITORING_ALLOCATION_INCONSISTENT_FOR_TESTS = "monitoring_allocation_inconsistent"
+_MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS = MONITORING_RUN_UPSERT_FIELD_OVERRIDE
 
 
 def _make_result(
@@ -830,7 +835,7 @@ def test_upsert_monitoring_run_rejects_conflicting_reference_pair() -> None:
             ),
         )
 
-    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert exc_info.value.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert dict(exc_info.value.details) == {
         "monitoring_run_id": "monitoring-run-previous",
         "source_run_id": "train-run-claimed-reference",
@@ -860,7 +865,7 @@ def test_upsert_monitoring_run_rejects_conflicting_primary_pair() -> None:
             sequence_index=0,
         )
 
-    assert exc_info.value.code == "monitoring_run_upsert_field_override"
+    assert exc_info.value.code == _MONITORING_RUN_UPSERT_FIELD_OVERRIDE_FOR_TESTS
     assert dict(exc_info.value.details) == {
         "monitoring_run_id": "monitoring-run-1",
         "source_run_id": "train-run-claimed",

--- a/tests/test_mlflow_gateway_unit.py
+++ b/tests/test_mlflow_gateway_unit.py
@@ -197,7 +197,7 @@ def test_get_timeline_state_distinguishes_no_allocation_from_allocated_uninitial
     assert gateway.get_timeline_state("churn_model") is None
     with pytest.raises(
         GatewayConsistencyViolation,
-        match="Timeline state for subject_id 'churn_model' not found.",
+        match="Timeline state not found for subject_id='churn_model'.",
     ):
         gateway.pin_timeline_baseline("churn_model", "train-run-1")
     stub_client.set_monitoring_experiment_tag.assert_not_called()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,9 +19,9 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
+    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     GatewayConsistencyViolation,
 )
-from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
     GatewayConfig,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -20,6 +20,7 @@ from mlflow_monitor.domain import (
 )
 from mlflow_monitor.errors import (
     PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    GatewayConsistencyCode,
     GatewayConsistencyViolation,
     monitoring_run_upsert_field_override,
 )
@@ -38,7 +39,7 @@ from mlflow_monitor.utils import canonical_json
 
 _PREPARED_CONTEXT_PATH = "state/prepared_context.json"
 _USE_STORED_PREPARED_CONTEXT = object()
-_PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS = "prepared_context_inconsistent"
+_PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS = GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT
 
 
 class _ReadablePreparedContextGateway(Protocol):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -183,7 +183,7 @@ class BrokenUpsertGateway(InMemoryMonitoringGateway):
     ) -> None:
         if lifecycle_status is LifecycleStatus.PREPARED:
             raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-                message="prepared upsert broke gateway consistency",
+                fields=(("lifecycle_status", lifecycle_status),)
             )
 
         super().upsert_monitoring_run(
@@ -1245,7 +1245,7 @@ def test_run_orchestration_raises_internal_gateway_errors_instead_of_normalizing
 
     with pytest.raises(
         GatewayConsistencyViolation,
-        match="prepared upsert broke gateway consistency",
+        match="Attempted to override immutable Monitoring Run field",
     ):
         run_orchestration(
             subject_id="churn_model",

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,11 +19,10 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
-    GatewayConsistencyCode,
     GatewayConsistencyViolation,
-    monitoring_run_upsert_field_override,
 )
+from mlflow_monitor.errors.gateway import monitoring_run_upsert_field_override
+from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
     GatewayConfig,
@@ -39,7 +38,7 @@ from mlflow_monitor.utils import canonical_json
 
 _PREPARED_CONTEXT_PATH = "state/prepared_context.json"
 _USE_STORED_PREPARED_CONTEXT = object()
-_PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS = GatewayConsistencyCode.PREPARED_CONTEXT_INCONSISTENT
+_PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS = "prepared_context_inconsistent"
 
 
 class _ReadablePreparedContextGateway(Protocol):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -183,7 +183,7 @@ class BrokenUpsertGateway(InMemoryMonitoringGateway):
     ) -> None:
         if lifecycle_status is LifecycleStatus.PREPARED:
             raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
-                fields=(("lifecycle_status", lifecycle_status),)
+                fields=(("lifecycle_status", lifecycle_status.value),)
             )
 
         super().upsert_monitoring_run(

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -21,6 +21,7 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import (
     PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     GatewayConsistencyViolation,
+    monitoring_run_upsert_field_override,
 )
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -182,10 +183,10 @@ class BrokenUpsertGateway(InMemoryMonitoringGateway):
         references: tuple[MonitoringRunReference, ...] | None = None,
     ) -> None:
         if lifecycle_status is LifecycleStatus.PREPARED:
-            raise GatewayConsistencyViolation(
-                code="monitoring_run_upsert_field_override",
+            raise monitoring_run_upsert_field_override(
                 message="prepared upsert broke gateway consistency",
             )
+
         super().upsert_monitoring_run(
             subject_id=subject_id,
             monitoring_run_id=monitoring_run_id,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -21,7 +21,6 @@ from mlflow_monitor.domain import (
 from mlflow_monitor.errors import (
     GatewayConsistencyViolation,
 )
-from mlflow_monitor.errors.gateway import monitoring_run_upsert_field_override
 from mlflow_monitor.errors.workflow import PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
 from mlflow_monitor.gateway import (
     CreateOrReuseMonitoringRunResult,
@@ -183,7 +182,7 @@ class BrokenUpsertGateway(InMemoryMonitoringGateway):
         references: tuple[MonitoringRunReference, ...] | None = None,
     ) -> None:
         if lifecycle_status is LifecycleStatus.PREPARED:
-            raise monitoring_run_upsert_field_override(
+            raise GatewayConsistencyViolation.monitoring_run_upsert_field_override(
                 message="prepared upsert broke gateway consistency",
             )
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,7 +19,7 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
+    PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE,
     GatewayConsistencyViolation,
 )
 from mlflow_monitor.gateway import (
@@ -1490,7 +1490,7 @@ def test_run_orchestration_rejects_baseline_override_on_checked_idempotent_rerun
     assert second.comparability_status is None
     assert second.error is not None
     assert second.error.stage == "prepare"
-    assert second.error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert second.error.code == PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert stored is not None
     assert stored.lifecycle_status is LifecycleStatus.CHECKED
     assert stored.contract_check_result is not None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -37,6 +37,7 @@ from mlflow_monitor.utils import canonical_json
 
 _PREPARED_CONTEXT_PATH = "state/prepared_context.json"
 _USE_STORED_PREPARED_CONTEXT = object()
+_PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS = "prepared_context_inconsistent"
 
 
 class _ReadablePreparedContextGateway(Protocol):
@@ -702,7 +703,7 @@ def test_prepared_replay_rejects_malformed_prepared_context() -> None:
             contract_checker=DefaultContractChecker(),
         )
 
-    assert exc_info.value.code == "prepared_context_inconsistent"
+    assert exc_info.value.code == _PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS
 
 
 def test_prepared_replay_rejects_conflicting_persisted_identity() -> None:
@@ -720,7 +721,7 @@ def test_prepared_replay_rejects_conflicting_persisted_identity() -> None:
             contract_checker=DefaultContractChecker(),
         )
 
-    assert exc_info.value.code == "prepared_context_inconsistent"
+    assert exc_info.value.code == _PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS
 
 
 def test_prepared_replay_rejects_changed_contract_definition_for_same_identity() -> None:
@@ -747,7 +748,7 @@ def test_prepared_replay_rejects_changed_contract_definition_for_same_identity()
             contract_checker=DefaultContractChecker(),
         )
 
-    assert exc_info.value.code == "prepared_context_inconsistent"
+    assert exc_info.value.code == _PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS
 
 
 def test_prepared_replay_rejects_different_effective_plan_for_same_recipe_identity() -> None:
@@ -767,7 +768,7 @@ def test_prepared_replay_rejects_different_effective_plan_for_same_recipe_identi
             contract_checker=DefaultContractChecker(),
         )
 
-    assert exc_info.value.code == "prepared_context_inconsistent"
+    assert exc_info.value.code == _PREPARED_CONTEXT_INCONSISTENT_CODE_FOR_TESTS
 
 
 def test_run_orchestration_upserts_created_when_allocation_exists_without_run_record() -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -38,7 +38,7 @@ from mlflow_monitor.workflow import (
 )
 
 _CONTRACT = resolve_contract_v0(SYSTEM_DEFAULT_CONTRACT_ID)
-_PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
+_PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepare_baseline_override_existing_baseline"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1458,7 +1458,7 @@ def test_prepare_run_context_fails_when_competing_bootstrap_pins_different_basel
         )
 
     error = exc_info.value
-    assert error.code == _PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert error.code == _PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-1"),
@@ -1680,7 +1680,7 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
         )
 
     error = exc_info.value
-    assert error.code == _PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert error.code == _PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-other"),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -16,7 +16,6 @@ from mlflow_monitor.domain import (
     MonitoringRunReference,
 )
 from mlflow_monitor.errors import (
-    PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE,
     CheckStageError,
     PrepareStageError,
 )
@@ -38,7 +37,8 @@ from mlflow_monitor.workflow import (
     prepare_run_context as _prepare_run_context,
 )
 
-CONTRACT = resolve_contract_v0(SYSTEM_DEFAULT_CONTRACT_ID)
+_CONTRACT = resolve_contract_v0(SYSTEM_DEFAULT_CONTRACT_ID)
+_PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE = "prepared_baseline_override_existing_baseline"
 
 
 @dataclass(frozen=True, slots=True)
@@ -383,7 +383,7 @@ def test_prepare_run_context_succeeds_with_initialized_timeline() -> None:
     assert prepared.previous_monitoring_run_id == fixture.custom_monitoring_run_id
     assert prepared.active_lkg_monitoring_run_id == fixture.previous_monitoring_run_id
     assert prepared.custom_reference_monitoring_run_id == fixture.custom_monitoring_run_id
-    assert prepared.contract == CONTRACT
+    assert prepared.contract == _CONTRACT
     assert prepared.required_metrics == ("auc", "f1")
     assert prepared.required_artifacts == ("metrics.json",)
     assert prepared.recipe_id == "default"
@@ -511,7 +511,7 @@ def test_execute_contract_check_fails_when_baseline_evidence_is_missing() -> Non
 
     with pytest.raises(CheckStageError) as exc_info:
         execute_contract_check(
-            prepared_context=make_prepared_context(contract=CONTRACT),
+            prepared_context=make_prepared_context(contract=_CONTRACT),
             gateway=gateway,
             contract_checker=DefaultContractChecker(),
         )
@@ -536,7 +536,7 @@ def test_execute_contract_check_fails_when_current_evidence_is_missing() -> None
 
     with pytest.raises(CheckStageError) as exc_info:
         execute_contract_check(
-            prepared_context=make_prepared_context(contract=CONTRACT),
+            prepared_context=make_prepared_context(contract=_CONTRACT),
             gateway=gateway,
             contract_checker=DefaultContractChecker(),
         )
@@ -572,7 +572,7 @@ def test_execute_contract_check_propagates_checker_failures() -> None:
 
     with pytest.raises(RuntimeError, match="checker exploded"):
         execute_contract_check(
-            prepared_context=make_prepared_context(contract=CONTRACT),
+            prepared_context=make_prepared_context(contract=_CONTRACT),
             gateway=gateway,
             contract_checker=RaisingContractChecker(),
         )
@@ -606,7 +606,7 @@ def test_execute_contract_check_rejects_invalid_checker_result() -> None:
 
     with pytest.raises(CheckStageError) as exc_info:
         execute_contract_check(
-            prepared_context=make_prepared_context(contract=CONTRACT),
+            prepared_context=make_prepared_context(contract=_CONTRACT),
             gateway=gateway,
             contract_checker=InvalidResultContractChecker(),
         )
@@ -632,7 +632,7 @@ def test_execute_contract_check_rejects_duplicate_reason_codes() -> None:
 
     with pytest.raises(CheckStageError) as exc_info:
         execute_contract_check(
-            prepared_context=make_prepared_context(contract=CONTRACT),
+            prepared_context=make_prepared_context(contract=_CONTRACT),
             gateway=gateway,
             contract_checker=DuplicateReasonContractChecker(),
         )
@@ -1458,7 +1458,7 @@ def test_prepare_run_context_fails_when_competing_bootstrap_pins_different_basel
         )
 
     error = exc_info.value
-    assert error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert error.code == _PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-1"),
@@ -1680,7 +1680,7 @@ def test_prepare_run_context_fail_with_created_timeline_mismatch_baseline() -> N
         )
 
     error = exc_info.value
-    assert error.code == PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
+    assert error.code == _PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE
     assert error.details == (
         ("subject_id", "churn_model"),
         ("baseline_source_run_id", "train-run-other"),


### PR DESCRIPTION
## What changed

<!-- Summarize the concrete changes in this pull request. -->

The error types are now reorganized into focused modules `src/mlflow_monitor/errors/`, but the import path is preserved. There are now three focused error classes for previously one consolidated gateway consistency violation error. `GatewayConsistencyViolation` is reserved for general gateway errors, `PreparedContextConsistencyViolation` is for consistency violation when preparing context, and `AllocationConsistencyViolation` is for consistency violation related to monitoring run allocation. 

The three errors all have same interface, there is no more caller supplied message, and random field. Each class now is shipped with a few class methods, that can be directed used to construct the error instance.

That said, if later we find that there are more error message formats, types, reasons, etc, then we would need to think how to make errors better categorized and the balance between caller flexibility versus error/message consistency.

In addition to three gateway error, two errors, `TrainingRunMutationViolation` is now with a changed interface, while `GatewayNamespaceViolation` keeps the same interface.

Errors in `errors/workflow.py`, `errors/recipe.py`, and `errors/invariant.py` are not changed, and they are beyond the scope of this ticket. I would not open another ticket to change them before ... maybe, v0-023. But, this needs recalibration once I ship a bit more v0 ticket.

Again, this is a pure maintenance PR, without any breaking changes except that now I am using 
`PREPARE_BASELINE_OVERRIDE_EXISTING_BASELINE` instead of `PREPARED_BASELINE_OVERRIDE_EXISTING_BASELINE` (`PREPARED_...` was probably a typo)

Side note: the doc is now updated to organize the errors into categories. BUT, please ignore scanning the other parts of the doc.

## Ticket or Issue

<!-- Reference the ticket or issue that this pull request addresses.
Use one of these formats:
- GitHub issue: #123
- Public link: [ticket-id](https://url-to-ticket-or-issue)
- Internal ticket (no public URL): ticket-id

-->

None

## Why

<!-- Explain the problem, requirement, or ticket outcome this change addresses. -->

To make life easier moving forward handling errors.

## Review context

***Note: Please ensure including the context for agent reviewers. If human reviewers are requested, this could be skipped.***

<!--
Give reviewers only the context needed for this diff.
- Link only the relevant public documents under docs/site/source/.
- Summarize the required behavior in reviewable, externally safe terms.
- State important behavior that is explicitly out of scope.
- Do not link or quote the private design record.
-->

- Relevant public docs: errors.rst
- Required behavior: all gateway errors can be called without caller specifying random message. 
- Out of scope: any non gateway error.

## Impact

<!-- Describe user-facing or developer-facing behavior, compatibility, and migration impact. -->

there could be a flexibility gap later on, if we fine the interface has to expand. If that's the case, we will recalibrate.  But, for this moment, this is the best way to handle the messy errors.

## Validation

<!-- Check only commands that were run successfully (do not change the commands). Explain any omissions below. -->

- [x] `uv sync --locked --group doc`
- [x] `uv run --no-sync poe validate`
- [x] Matching `docs/site/` content is updated, or no developer-doc change is required

<!-- Validation omissions, if any: -->
